### PR TITLE
Redo ua trace

### DIFF
--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -92,7 +92,7 @@ namespace Server
         public string LogLevel { get; set; }
         [CommandLineOption("Path to log files, this enables logging to file")]
         public string LogFile { get; set; }
-        [CommandLineOption("Write OPC-UA SDK trace to log at debug level")]
+        [CommandLineOption("Write OPC-UA SDK trace to log.")]
         public bool LogTrace { get; set; }
     }
 


### PR DESCRIPTION
The SDK now allows writing traces directly to an ILogger, which greatly simplifies the code.

We would have probably done this slightly differently if this was supported from the beginning, but it is not worth breaking backwards compatibility of the config file to clean it up.