### PR TITLE
Refactor connection logic

### DIFF
--- a/ConfigurationTool/Checks/Attributes.cs
+++ b/ConfigurationTool/Checks/Attributes.cs
@@ -47,7 +47,7 @@ namespace Cognite.OpcUa.Config
 
             if (Session == null || !Session.Connected)
             {
-                await Run(token);
+                await Run(token, 0);
                 await LimitConfigValues(token);
             }
 

--- a/ConfigurationTool/Checks/Browse.cs
+++ b/ConfigurationTool/Checks/Browse.cs
@@ -133,7 +133,7 @@ namespace Cognite.OpcUa.Config
         {
             if (Session == null || !Session.Connected)
             {
-                await Run(token);
+                await Run(token, 0);
                 await LimitConfigValues(token);
             }
 

--- a/ConfigurationTool/Checks/DataTypes.cs
+++ b/ConfigurationTool/Checks/DataTypes.cs
@@ -135,7 +135,7 @@ namespace Cognite.OpcUa.Config
         {
             if (Session == null || !Session.Connected)
             {
-                await Run(token);
+                await Run(token, 0);
                 await LimitConfigValues(token);
             }
             await PopulateDataTypes(token);

--- a/ConfigurationTool/Checks/Session.cs
+++ b/ConfigurationTool/Checks/Session.cs
@@ -72,7 +72,7 @@ namespace Cognite.OpcUa.Config
             {
                 try
                 {
-                    await Run(token);
+                    await Run(token, 0);
                     await LimitConfigValues(token);
                 }
                 catch (Exception ex)

--- a/Extractor/SessionManager.cs
+++ b/Extractor/SessionManager.cs
@@ -32,12 +32,11 @@ namespace Cognite.OpcUa
             .CreateCounter("opcua_connects", "Number of times the client has connected to and mapped the opcua server");
         private static readonly Gauge connected = Metrics
             .CreateGauge("opcua_connected", "Whether or not the client is currently connected to the opcua server");
-        public Session Session { get
+        public Session? Session { get
             {
                 readerSemaphore.Wait(liveToken);
                 var xSession = session;
                 readerSemaphore.Release();
-                if (xSession == null) throw new InvalidOperationException("Session is not initialized");
                 return xSession;
             } }
 

--- a/Extractor/SessionManager.cs
+++ b/Extractor/SessionManager.cs
@@ -25,7 +25,7 @@ namespace Cognite.OpcUa
         private Session? session;
         private CancellationToken liveToken;
         private bool disposedValue;
-        private int timeout;
+        public int Timeout { get; set; }
 
         private static readonly Counter connects = Metrics
             .CreateCounter("opcua_connects", "Number of times the client has connected to and mapped the opcua server");
@@ -40,7 +40,7 @@ namespace Cognite.OpcUa
             this.appConfig = appConfig;
             this.log = log;
             liveToken = token;
-            this.timeout = timeout;
+            this.Timeout = timeout;
         }
 
         private async Task TryWithBackoff(Func<Task> method, int maxBackoff, CancellationToken token)
@@ -61,7 +61,7 @@ namespace Cognite.OpcUa
                     iter = Math.Min(iter, maxBackoff);
                     backoff = TimeSpan.FromSeconds(Math.Pow(2, iter));
 
-                    if (timeout >= 0 && (DateTime.UtcNow - start).TotalSeconds > timeout)
+                    if (Timeout >= 0 && (DateTime.UtcNow - start).TotalSeconds > Timeout)
                     {
                         throw;
                     }

--- a/Extractor/SessionManager.cs
+++ b/Extractor/SessionManager.cs
@@ -1,0 +1,413 @@
+﻿using Microsoft.Identity.Client;
+using Opc.Ua.Client;
+using Opc.Ua;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using Prometheus;
+using Metrics = Prometheus.Metrics;
+using System.Linq;
+
+namespace Cognite.OpcUa
+{
+    public class SessionManager : IDisposable
+    {
+        private UAClientConfig config;
+        private UAClient client;
+        private ReverseConnectManager? reverseConnectManager;
+        private SessionReconnectHandler? reconnectHandler;
+        private ApplicationConfiguration appConfig;
+        private ILogger log;
+
+        private SemaphoreSlim readerSemaphore = new SemaphoreSlim(1);
+        private Session? session;
+        private CancellationToken liveToken;
+        private bool disposedValue;
+        private int timeout;
+
+        private static readonly Counter connects = Metrics
+            .CreateCounter("opcua_connects", "Number of times the client has connected to and mapped the opcua server");
+        private static readonly Gauge connected = Metrics
+            .CreateGauge("opcua_connected", "Whether or not the client is currently connected to the opcua server");
+        public Session Session { get
+            {
+                readerSemaphore.Wait(liveToken);
+                var xSession = session;
+                readerSemaphore.Release();
+                if (xSession == null) throw new InvalidOperationException("Session is not initialized");
+                return xSession;
+            } }
+
+        public SessionManager(UAClientConfig config, UAClient parent, ApplicationConfiguration appConfig, ILogger log, CancellationToken token, int timeout = -1)
+        {
+            client = parent;
+            this.config = config;
+            this.appConfig = appConfig;
+            this.log = log;
+            liveToken = token;
+            this.timeout = timeout;
+        }
+
+        private async Task TryWithBackoff(Func<Task> method, int maxBackoff, CancellationToken token)
+        {
+            int iter = 0;
+            var start = DateTime.UtcNow;
+            TimeSpan backoff;
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    await method();
+                    break;
+                }
+                catch
+                {
+                    iter++;
+                    iter = Math.Min(iter, maxBackoff);
+                    backoff = TimeSpan.FromSeconds(Math.Pow(2, iter));
+
+                    if (timeout >= 0 && (DateTime.UtcNow - start).TotalSeconds > timeout)
+                    {
+                        throw;
+                    }
+                    if (!liveToken.IsCancellationRequested)
+                        log.LogWarning("Failed to connect, retrying in {Backoff}", backoff);
+                    try { await Task.Delay(backoff, token); } catch (TaskCanceledException) { }
+                }
+            }
+        }
+
+        public async Task Connect()
+        {
+            await readerSemaphore.WaitAsync(liveToken);
+            if (session != null)
+            {
+                try
+                {
+                    session.Close();
+                } catch { }
+                session.KeepAlive -= ClientKeepAlive;
+                session.PublishError -= OnPublishError;
+                session.Dispose();
+                session = null;
+            }
+            if (reconnectHandler != null) reconnectHandler.Dispose();
+            session = null;
+
+            Func<Task> generator = async () =>
+            {
+                Session newSession;
+                if (!string.IsNullOrEmpty(config.ReverseConnectUrl))
+                {
+                    newSession = await WaitForReverseConnect();
+                }
+                else
+                {
+                    newSession = await CreateSessionDirect();
+                }
+                newSession.KeepAliveInterval = config.KeepAliveInterval;
+                newSession.KeepAlive += ClientKeepAlive;
+                newSession.PublishError += OnPublishError;
+                session = newSession;
+            };
+            try
+            {
+                await TryWithBackoff(generator, 6, liveToken);
+            }
+            finally
+            {
+                readerSemaphore.Release();
+            }
+            if (!liveToken.IsCancellationRequested)
+            {
+                log.LogInformation("Successfully connected to server");
+                connects.Inc();
+                connected.Set(1);
+            }
+        }
+
+        /// <summary>
+        /// Event triggered when a publish request fails.
+        /// </summary>
+        private void OnPublishError(Session session, PublishErrorEventArgs e)
+        {
+            string symId = StatusCode.LookupSymbolicId(e.Status.Code);
+
+            var sub = session.Subscriptions.FirstOrDefault(sub => sub.Id == e.SubscriptionId);
+
+            if (sub != null)
+            {
+                log.LogError("Unexpected error on publish: {Code}, subscription: {Name}", symId, sub.DisplayName);
+            }
+        }
+
+        private async Task<Session> WaitForReverseConnect()
+        {
+            reverseConnectManager?.Dispose();
+
+            appConfig.ClientConfiguration.ReverseConnect = new ReverseConnectClientConfiguration
+            {
+                WaitTimeout = 300000,
+                HoldTime = 30000
+            };
+
+            reverseConnectManager = new ReverseConnectManager();
+            var endpointUrl = new Uri(config.EndpointUrl);
+            var reverseUrl = new Uri(config.ReverseConnectUrl);
+            reverseConnectManager.AddEndpoint(reverseUrl);
+            reverseConnectManager.StartService(appConfig);
+
+            log.LogInformation("Waiting for reverse connection from: {EndpointURL}", config.EndpointUrl);
+            var connection = await reverseConnectManager.WaitForConnection(endpointUrl, null);
+            if (connection == null)
+            {
+                log.LogError("Reverse connect failed, no connection established");
+                throw new ExtractorFailureException("Failed to obtain reverse connection from server");
+            }
+            EndpointDescription selectedEndpoint;
+            try
+            {
+                selectedEndpoint = CoreClientUtils.SelectEndpoint(appConfig, connection, config.Secure, 30000);
+            }
+            catch (Exception ex)
+            {
+                throw ExtractorUtils.HandleServiceResult(log, ex, ExtractorUtils.SourceOp.SelectEndpoint);
+            }
+            var endpointConfiguration = EndpointConfiguration.Create(appConfig);
+            client.LogDump("Reverse connect endpoint configuration", endpointConfiguration);
+
+            var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
+            client.LogDump("Reverse connect endpoint", endpoint);
+
+            var identity = AuthenticationUtils.GetUserIdentity(config);
+            log.LogInformation("Attempt to connect to endpoint with security: {SecurityPolicyUri} using user identity {Identity}",
+                endpoint.Description.SecurityPolicyUri,
+                identity.DisplayName);
+
+            try
+            {
+                connection = await reverseConnectManager.WaitForConnection(endpointUrl, null);
+                if (connection == null)
+                {
+                    log.LogError("Reverse connect failed, no connection established");
+                    throw new ExtractorFailureException("Failed to obtain reverse connection from server");
+                }
+
+
+                return await Session.Create(
+                    appConfig,
+                    connection,
+                    endpoint,
+                    false,
+                    false,
+                    ".NET OPC-UA Extractor Client",
+                    0,
+                    identity,
+                    null);
+            }
+            catch (Exception ex)
+            {
+                throw ExtractorUtils.HandleServiceResult(log, ex, ExtractorUtils.SourceOp.CreateSession);
+            }
+        }
+
+        private async Task<Session> CreateSessionDirect()
+        {
+            log.LogInformation("Attempt to select endpoint from: {EndpointURL}", config.EndpointUrl);
+            EndpointDescription selectedEndpoint;
+            try
+            {
+                selectedEndpoint = CoreClientUtils.SelectEndpoint(config.EndpointUrl, config.Secure);
+            }
+            catch (Exception ex)
+            {
+                throw ExtractorUtils.HandleServiceResult(log, ex, ExtractorUtils.SourceOp.SelectEndpoint);
+            }
+            var endpointConfiguration = EndpointConfiguration.Create(appConfig);
+            client.LogDump("Endpoint configuration", endpointConfiguration);
+
+            var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
+            client.LogDump("Endpoint", endpoint);
+
+            var identity = AuthenticationUtils.GetUserIdentity(config);
+            log.LogInformation("Attempt to connect to endpoint with security: {SecurityPolicyUri} using user identity {Identity}",
+                endpoint.Description.SecurityPolicyUri,
+                identity.DisplayName);
+            try
+            {
+                return await Session.Create(
+                    appConfig,
+                    endpoint,
+                    false,
+                    ".NET OPC-UA Extractor Client",
+                    0,
+                    identity,
+                    null
+                );
+            }
+            catch (Exception ex)
+            {
+                throw ExtractorUtils.HandleServiceResult(log, ex, ExtractorUtils.SourceOp.CreateSession);
+            }
+        }
+
+        /// <summary>
+        /// Event triggered after a succesfull reconnect.
+        /// </summary>
+        private void ClientReconnectComplete(object sender, EventArgs eventArgs)
+        {
+            if (!ReferenceEquals(sender, reconnectHandler)) return;
+            if (reconnectHandler == null) return;
+            session = reconnectHandler.Session;
+            reconnectHandler.Dispose();
+            log.LogWarning("--- RECONNECTED ---");
+
+            // It's really important to release the semaphore before invoking the event, or we will deadlock, since event
+            // invocation is synchronous.
+            readerSemaphore.Release();
+
+            client.TriggerOnServerReconnect();
+
+            connects.Inc();
+            connected.Set(1);
+            reconnectHandler = null;
+        }
+
+        /// <summary>
+        /// Called on client keep alive, handles the case where the server has stopped responding and the connection timed out.
+        /// </summary>
+        private void ClientKeepAlive(Session sender, KeepAliveEventArgs eventArgs)
+        {
+            client.LogDump("Keep Alive", eventArgs);
+            if (eventArgs.Status == null || !ServiceResult.IsNotGood(eventArgs.Status)) return;
+            log.LogWarning("Keep alive failed: {Status}", eventArgs.Status);
+            if (reconnectHandler != null || liveToken.IsCancellationRequested) return;
+            connected.Set(0);
+
+            readerSemaphore.Wait(liveToken);
+#pragma warning disable CA1508 // Avoid dead conditional code
+            if (reconnectHandler != null) return;
+#pragma warning restore CA1508 // Avoid dead conditional code
+            log.LogWarning("--- RECONNECTING ---");
+            if (!config.ForceRestart && !liveToken.IsCancellationRequested)
+            {
+                reconnectHandler = new SessionReconnectHandler();
+                if (reverseConnectManager != null)
+                {
+                    reconnectHandler.BeginReconnect(sender, reverseConnectManager, 5000, ClientReconnectComplete);
+                }
+                else
+                {
+                    reconnectHandler.BeginReconnect(sender, 5000, ClientReconnectComplete);
+                }
+            }
+            else
+            {
+                try
+                {
+                    session?.Close();
+                }
+                catch
+                {
+                    log.LogWarning("Client failed to close");
+                }
+                finally
+                {
+                    if (session != null)
+                    {
+                        session.KeepAlive -= ClientKeepAlive;
+                        session.PublishError -= OnPublishError;
+                        session = null;
+                    }
+                    
+                    readerSemaphore.Release();
+                }
+                if (!liveToken.IsCancellationRequested)
+                {
+                    var _ =Task.Run(async () => {
+                        log.LogInformation("Attempting to reconnect to server");
+                        await Connect();
+                        if (!liveToken.IsCancellationRequested)
+                        {
+                            client.TriggerOnServerReconnect();
+                            connects.Inc();
+                            connected.Set(1);
+                        }
+                    }, liveToken);
+                }
+            }
+            client.TriggerOnServerDisconnect();
+        }
+
+        public async Task Close(CancellationToken token)
+        {
+            await readerSemaphore.WaitAsync(token);
+            reconnectHandler?.Dispose();
+            reconnectHandler = null;
+            try
+            {
+                if (session != null && !session.Disposed)
+                {
+                    var closeTask = session.CloseSessionAsync(null, true, token);
+                    var resultTask = await Task.WhenAny(Task.Delay(5000, token), closeTask);
+                    if (closeTask != resultTask)
+                    {
+                        log.LogWarning("Failed to close session, timed out");
+                    }
+                    else
+                    {
+                        log.LogInformation("Successfully closed connection to server");
+                    }
+                    session.KeepAlive -= ClientKeepAlive;
+                    session.PublishError -= OnPublishError;
+                    session.Dispose();
+                    session = null;
+                }
+            }
+            finally
+            {
+                connected.Set(0);
+                readerSemaphore.Release();
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    reverseConnectManager?.Dispose();
+                    reverseConnectManager = null;
+                    readerSemaphore?.Dispose();
+                    reconnectHandler?.Dispose();
+                    reconnectHandler = null;
+                    if (session != null)
+                    {
+                        try
+                        {
+                            session.Close();
+                        }
+                        catch { }
+                        session.KeepAlive -= ClientKeepAlive;
+                        session.PublishError -= OnPublishError;
+                    }
+                    session?.Dispose();
+                    session = null;
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -1064,6 +1064,10 @@ namespace Cognite.OpcUa
             {
                 await Session.RemoveSubscriptionAsync(subscription);
             }
+            catch
+            {
+                // A failure to delete the subscription generally means it just doesn't exist.
+            }
             finally
             {
                 subscription.Dispose();

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -45,10 +45,8 @@ namespace Cognite.OpcUa
     public class UAClient : IDisposable, IUAClientAccess
     {
         protected FullConfig Config { get; set; }
-        protected Session? Session { get; set; }
+        protected Session? Session => sessionManager?.Session;
         protected ApplicationConfiguration? AppConfig { get; set; }
-        private ReverseConnectManager? reverseConnectManager;
-        private SessionReconnectHandler? reconnectHandler;
         public DataTypeManager DataTypeManager { get; }
         public NodeTypeManager ObjectTypeManager { get; }
 
@@ -63,10 +61,6 @@ namespace Cognite.OpcUa
         public event EventHandler? OnServerDisconnect;
         public event EventHandler? OnServerReconnect;
 
-        private static readonly Counter connects = Metrics
-            .CreateCounter("opcua_connects", "Number of times the client has connected to and mapped the opcua server");
-        private static readonly Gauge connected = Metrics
-            .CreateGauge("opcua_connected", "Whether or not the client is currently connected to the opcua server");
         private static readonly Counter attributeRequests = Metrics
             .CreateCounter("opcua_attribute_requests", "Number of attributes fetched from the server");
         private static readonly Gauge numSubscriptions = Metrics
@@ -83,6 +77,8 @@ namespace Cognite.OpcUa
             .CreateCounter("opcua_browse_failures", "Number of failures on browse operations");
 
         private readonly NodeMetricsManager? metricsManager;
+
+        private SessionManager? sessionManager;
 
         private readonly ILogger<UAClient> log;
         private readonly ILogger<Tracing> traceLog;
@@ -114,10 +110,10 @@ namespace Cognite.OpcUa
         /// <summary>
         /// Entrypoint for starting the opcua Session. Must be called before any further requests can be made.
         /// </summary>
-        public async Task Run(CancellationToken token)
+        public async Task Run(CancellationToken token, int timeout = -1)
         {
             liveToken = token;
-            await StartSession();
+            await StartSession(timeout);
             await StartNodeMetrics();
         }
         /// <summary>
@@ -125,30 +121,17 @@ namespace Cognite.OpcUa
         /// </summary>
         public async Task Close(CancellationToken token)
         {
-            reconnectHandler?.Dispose();
-            reconnectHandler = null;
             try
             {
-                if (Session != null && !Session.Disposed)
+                if (sessionManager != null)
                 {
-#pragma warning disable CA1508 // Avoid dead conditional code
-                    var closeTask = Session?.CloseSessionAsync(null, true, token);
-                    var resultTask = await Task.WhenAny(Task.Delay(5000, token), closeTask);
-                    if (closeTask != resultTask)
-                    {
-                        log.LogWarning("Failed to close session, timed out");
-                    }
-                    Session?.Dispose();
-#pragma warning restore CA1508 // Avoid dead conditional code
-                    Session = null;
+                    await sessionManager.Close(token);
                 }
             }
             finally
             {
-                connected.Set(0);
                 Started = false;
             }
-
         }
 
         private void ConfigureUtilsTrace()
@@ -170,7 +153,7 @@ namespace Cognite.OpcUa
             Utils.SetLogLevel(traceLevel.Value);
         }
 
-        private void LogDump<T>(string message, T item)
+        public void LogDump<T>(string message, T item)
         {
             if (Config.Logger.UaSessionTracing) log.LogDump(message, item);
         }
@@ -231,133 +214,10 @@ namespace Cognite.OpcUa
             ConfigureUtilsTrace();
         }
 
-        private async Task CreateSessionDirect()
-        {
-            log.LogInformation("Attempt to select endpoint from: {EndpointURL}", Config.Source.EndpointUrl);
-            EndpointDescription selectedEndpoint;
-            try
-            {
-                selectedEndpoint = CoreClientUtils.SelectEndpoint(Config.Source.EndpointUrl, Config.Source.Secure);
-            }
-            catch (Exception ex)
-            {
-                throw ExtractorUtils.HandleServiceResult(log, ex, ExtractorUtils.SourceOp.SelectEndpoint);
-            }
-            var endpointConfiguration = EndpointConfiguration.Create(AppConfig);
-            LogDump("Endpoint configuration", endpointConfiguration);
-
-            var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
-            LogDump("Endpoint", endpoint);
-
-            var identity = AuthenticationUtils.GetUserIdentity(Config.Source);
-            log.LogInformation("Attempt to connect to endpoint with security: {SecurityPolicyUri} using user identity {Identity}",
-                endpoint.Description.SecurityPolicyUri,
-                identity.DisplayName);
-            try
-            {
-                if (Session?.Connected ?? false)
-                {
-                    Session.Close();
-                }
-                Session?.Dispose();
-
-
-                Session = await Session.Create(
-                    AppConfig,
-                    endpoint,
-                    false,
-                    ".NET OPC-UA Extractor Client",
-                    0,
-                    identity,
-                    null
-                );
-            }
-            catch (Exception ex)
-            {
-                throw ExtractorUtils.HandleServiceResult(log, ex, ExtractorUtils.SourceOp.CreateSession);
-            }
-        }
-        private async Task WaitForReverseConnect()
-        {
-            if (AppConfig == null) throw new InvalidOperationException("AppConfig must be initialized");
-            reverseConnectManager?.Dispose();
-
-            AppConfig.ClientConfiguration.ReverseConnect = new ReverseConnectClientConfiguration
-            {
-                WaitTimeout = 300000,
-                HoldTime = 30000
-            };
-
-            reverseConnectManager = new ReverseConnectManager();
-            var endpointUrl = new Uri(Config.Source.EndpointUrl);
-            var reverseUrl = new Uri(Config.Source.ReverseConnectUrl);
-            reverseConnectManager.AddEndpoint(reverseUrl);
-            reverseConnectManager.StartService(AppConfig);
-
-            log.LogInformation("Waiting for reverse connection from: {EndpointURL}", Config.Source.EndpointUrl);
-            var connection = await reverseConnectManager.WaitForConnection(endpointUrl, null);
-            if (connection == null)
-            {
-                log.LogError("Reverse connect failed, no connection established");
-                throw new ExtractorFailureException("Failed to obtain reverse connection from server");
-            }
-            EndpointDescription selectedEndpoint;
-            try
-            {
-                selectedEndpoint = CoreClientUtils.SelectEndpoint(AppConfig, connection, Config.Source.Secure, 30000);
-            }
-            catch (Exception ex)
-            {
-                throw ExtractorUtils.HandleServiceResult(log, ex, ExtractorUtils.SourceOp.SelectEndpoint);
-            }
-            var endpointConfiguration = EndpointConfiguration.Create(AppConfig);
-            LogDump("Reverse connect endpoint configuration", endpointConfiguration);
-
-            var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
-            LogDump("Reverse connect endpoint", endpoint);
-
-            var identity = AuthenticationUtils.GetUserIdentity(Config.Source);
-            log.LogInformation("Attempt to connect to endpoint with security: {SecurityPolicyUri} using user identity {Identity}",
-                endpoint.Description.SecurityPolicyUri,
-                identity.DisplayName);
-
-            try
-            {
-                if (Session?.Connected ?? false)
-                {
-                    Session.Close();
-                }
-                Session?.Dispose();
-
-                connection = await reverseConnectManager.WaitForConnection(endpointUrl, null);
-                if (connection == null)
-                {
-                    log.LogError("Reverse connect failed, no connection established");
-                    throw new ExtractorFailureException("Failed to obtain reverse connection from server");
-                }
-
-
-                Session = await Session.Create(
-                    AppConfig,
-                    connection,
-                    endpoint,
-                    false,
-                    false,
-                    ".NET OPC-UA Extractor Client",
-                    0,
-                    identity,
-                    null);
-            }
-            catch (Exception ex)
-            {
-                throw ExtractorUtils.HandleServiceResult(log, ex, ExtractorUtils.SourceOp.CreateSession);
-            }
-        }
-
         /// <summary>
         /// Load security configuration for the Session, then start the server.
         /// </summary>
-        private async Task StartSession()
+        private async Task StartSession(int timeout = -1)
         {
             Browser.ResetVisitedNodes();
             // A restarted Session might mean a restarted server, so all server-relevant data must be cleared.
@@ -367,93 +227,26 @@ namespace Cognite.OpcUa
 
             await LoadAppConfig();
 
-            if (!string.IsNullOrEmpty(Config.Source.ReverseConnectUrl))
+            if (sessionManager == null)
             {
-                await WaitForReverseConnect();
+                sessionManager = new SessionManager(Config.Source, this, AppConfig!, log, liveToken, timeout);
             }
-            else
-            {
-                await CreateSessionDirect();
-            }
-            if (Session == null) return;
-            Session.KeepAliveInterval = Config.Source.KeepAliveInterval;
-            Session.KeepAlive += ClientKeepAlive;
-            Session.PublishError += OnPublishError;
+
+            await sessionManager.Connect();
             Started = true;
-            connects.Inc();
-            connected.Set(1);
             log.LogInformation("Successfully connected to server at {EndpointURL}", Config.Source.EndpointUrl);
         }
 
-        /// <summary>
-        /// Event triggered when a publish request fails.
-        /// </summary>
-        private void OnPublishError(Session session, PublishErrorEventArgs e)
+        public void TriggerOnServerDisconnect()
         {
-            string symId = StatusCode.LookupSymbolicId(e.Status.Code);
-
-            var sub = session.Subscriptions.FirstOrDefault(sub => sub.Id == e.SubscriptionId);
-
-            if (sub != null)
-            {
-                log.LogError("Unexpected error on publish: {Code}, subscription: {Name}", symId, sub.DisplayName);
-            }
-        }
-
-        /// <summary>
-        /// Event triggered after a succesfull reconnect.
-        /// </summary>
-        private void ClientReconnectComplete(object sender, EventArgs eventArgs)
-        {
-            if (!ReferenceEquals(sender, reconnectHandler)) return;
-            if (reconnectHandler == null) return;
-            Session = reconnectHandler.Session;
-            reconnectHandler.Dispose();
-            log.LogWarning("--- RECONNECTED ---");
-
-            OnServerReconnect?.Invoke(this, EventArgs.Empty);
-
-            connects.Inc();
-            connected.Set(1);
-            reconnectHandler = null;
-        }
-
-        /// <summary>
-        /// Called on client keep alive, handles the case where the server has stopped responding and the connection timed out.
-        /// </summary>
-        private void ClientKeepAlive(Session sender, KeepAliveEventArgs eventArgs)
-        {
-            LogDump("Keep Alive", eventArgs);
-            if (eventArgs.Status == null || !ServiceResult.IsNotGood(eventArgs.Status)) return;
-            log.LogWarning("Keep alive failed: {Status}", eventArgs.Status);
-            if (reconnectHandler != null) return;
-            connected.Set(0);
-            log.LogWarning("--- RECONNECTING ---");
-            if (!Config.Source.ForceRestart && !liveToken.IsCancellationRequested)
-            {
-                reconnectHandler = new SessionReconnectHandler();
-                if (reverseConnectManager != null)
-                {
-                    reconnectHandler.BeginReconnect(sender, reverseConnectManager, 5000, ClientReconnectComplete);
-                }
-                else
-                {
-                    reconnectHandler.BeginReconnect(sender, 5000, ClientReconnectComplete);
-                }
-            }
-            else
-            {
-                try
-                {
-                    Session?.Close();
-                }
-                catch
-                {
-                    log.LogWarning("Client failed to close, quitting");
-                }
-            }
             OnServerDisconnect?.Invoke(this, EventArgs.Empty);
         }
+
+        public void TriggerOnServerReconnect()
+        {
+            OnServerReconnect?.Invoke(this, EventArgs.Empty);
+        }
+
         /// <summary>
         /// Called after succesful validation of a server certificate. Handles the case where the certificate is untrusted.
         /// </summary>
@@ -1068,7 +861,7 @@ namespace Cognite.OpcUa
 
         private async Task RecreateSubscription(Subscription sub, CancellationToken token)
         {
-            if (Session == null || !Session.Connected || reconnectHandler != null || token.IsCancellationRequested) return;
+            if (Session == null || !Session.Connected || token.IsCancellationRequested) return;
 
             if (!sub.PublishingStopped) return;
 
@@ -1744,18 +1537,13 @@ namespace Cognite.OpcUa
             {
                 log.LogWarning("Failed to close UAClient: {Message}", ex.Message);
             }
-            reconnectHandler?.Dispose();
-            reverseConnectManager?.Dispose();
             waiter.Dispose();
             if (AppConfig != null)
             {
                 AppConfig.CertificateValidator.CertificateValidation -= CertificateValidationHandler;
             }
-            if (Session != null)
-            {
-                Session.KeepAlive -= ClientKeepAlive;
-            }
             subscriptionSem.Dispose();
+            sessionManager?.Dispose();
         }
         #endregion
     }

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -230,6 +230,9 @@ namespace Cognite.OpcUa
             if (sessionManager == null)
             {
                 sessionManager = new SessionManager(Config.Source, this, AppConfig!, log, liveToken, timeout);
+            } else
+            {
+                sessionManager.Timeout = timeout;
             }
 
             await sessionManager.Connect();

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -230,7 +230,7 @@ namespace Cognite.OpcUa
             Init(token);
         }
 
-        private async Task RunExtractorInternal()
+        private async Task RunExtractorInternal(int startTimeout = -1)
         {
             Starting.Set(1);
 
@@ -244,7 +244,7 @@ namespace Cognite.OpcUa
                 log.LogInformation("Start UAClient");
                 try
                 {
-                    await uaClient.Run(Source.Token);
+                    await uaClient.Run(Source.Token, startTimeout);
                 }
                 catch (Exception ex)
                 {
@@ -313,9 +313,9 @@ namespace Cognite.OpcUa
         /// </summary>
         /// <param name="quitAfterMap">False to wait for cancellation</param>
         /// <returns></returns>
-        public async Task RunExtractor(bool quitAfterMap = false)
+        public async Task RunExtractor(bool quitAfterMap = false, int startTimeout = -1)
         {
-            await RunExtractorInternal();
+            await RunExtractorInternal(startTimeout);
             if (!quitAfterMap)
             {
                 Looper.Run();

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -165,10 +165,10 @@ namespace Cognite.OpcUa
         /// <param name="e">EventArgs for this event</param>
         private void UaClient_OnServerDisconnect(object sender, EventArgs e)
         {
-            if (Config.Source.ForceRestart && !Source.IsCancellationRequested)
+            /* if (Config.Source.ForceRestart && !Source.IsCancellationRequested)
             {
                 Close().Wait();
-            }
+            } */
         }
 
         /// <summary>
@@ -180,19 +180,20 @@ namespace Cognite.OpcUa
         {
             if (sender is not UAClient client || Source.IsCancellationRequested) return;
 
-            if (Config.Source.RestartOnReconnect)
+            Scheduler.ScheduleTask(null, async t =>
             {
-                client.DataTypeManager.Configure();
-                client.ClearNodeOverrides();
-                client.ClearEventFields();
-                client.Browser.ResetVisitedNodes();
-                RestartExtractor();
-            }
-            else
-            {
-                if (historyReader != null)
+                await EnsureSubscriptions();
+                if (Config.Source.RestartOnReconnect)
                 {
-                    Scheduler.ScheduleTask(null, async t =>
+                    client.DataTypeManager.Configure();
+                    client.ClearNodeOverrides();
+                    client.ClearEventFields();
+                    client.Browser.ResetVisitedNodes();
+                    await RestartExtractor();
+                }
+                else
+                {
+                    if (historyReader != null)
                     {
                         await historyReader.Terminate(Source.Token);
                         foreach (var state in State.NodeStates)
@@ -206,9 +207,9 @@ namespace Cognite.OpcUa
                         }
 
                         await RestartHistory();
-                    });
+                    }
                 }
-            }
+            });
         }
         #region Interface
 
@@ -340,22 +341,25 @@ namespace Cognite.OpcUa
         /// <summary>
         /// Initializes restart of the extractor. Waits for history, reset states, then schedule restart on the looper.
         /// </summary>
-        public void RestartExtractor()
+        public async Task RestartExtractor()
         {
             subscribed = 0;
             subscribeFlag = false;
-            historyReader?.Terminate(Source.Token, 30).Wait();
-            foreach (var state in State.NodeStates)
+            if (historyReader != null)
             {
-                state.RestartHistory();
+                await historyReader.Terminate(Source.Token, 30);
+                foreach (var state in State.NodeStates)
+                {
+                    state.RestartHistory();
+                }
+
+                foreach (var state in State.EmitterStates)
+                {
+                    state.RestartHistory();
+                }
             }
 
-            foreach (var state in State.EmitterStates)
-            {
-                state.RestartHistory();
-            }
-
-            Looper.WaitForNextPush(true).Wait();
+            await Looper.WaitForNextPush(true);
             foreach (var pusher in pushers)
             {
                 pusher.Reset();
@@ -642,6 +646,24 @@ namespace Cognite.OpcUa
             var historyTasks = Synchronize(result.SourceVariables.Where(var => !var.Changed));
             Starting.Set(0);
             return historyTasks;
+        }
+
+        private async Task EnsureSubscriptions()
+        {
+            if (Config.Subscriptions.Events)
+            {
+                var subscribeStates = State.EmitterStates.Where(state => state.ShouldSubscribe);
+
+                await uaClient.SubscribeToEvents(subscribeStates, Streamer.EventSubscriptionHandler, Source.Token);
+            }
+
+            if (Config.Subscriptions.DataPoints)
+            {
+                var subscribeStates = State.NodeStates.Where(state => state.ShouldSubscribe);
+
+                await uaClient.SubscribeToNodes(subscribeStates, Streamer.DataSubscriptionHandler, Source.Token);
+            }
+
         }
 
         /// <summary>

--- a/Test/Unit/ConfigToolTest.cs
+++ b/Test/Unit/ConfigToolTest.cs
@@ -50,7 +50,7 @@ namespace Test.Unit
 
             Explorer = new UAServerExplorer(Provider, Config, BaseConfig);
             Source = new CancellationTokenSource();
-            await Explorer.Run(Source.Token);
+            await Explorer.Run(Source.Token, 0);
         }
 
         public async Task DisposeAsync()
@@ -73,7 +73,7 @@ namespace Test.Unit
             this.tester = tester;
             tester.Init(output);
         }
-        [Fact]
+        [Fact(Timeout = 10000)]
         public async Task TestEndpointDiscovery()
         {
             // Test while connected

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -69,7 +69,7 @@ namespace Test.Unit
             await Server.Start();
             Client = new UAClient(Provider, Config);
             Source = new CancellationTokenSource();
-            await Client.Run(Source.Token, 1);
+            await Client.Run(Source.Token, 0);
         }
 
         public async Task DisposeAsync()

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -131,11 +131,14 @@ namespace Test.Unit
                 await tester.Client.Run(tester.Source.Token, 0);
             }
         }
-        [Fact]
-        public async Task TestReconnect()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestReconnect(bool forceRestart)
         {
             await tester.Client.Close(tester.Source.Token);
             tester.Config.Source.KeepAliveInterval = 1000;
+            tester.Config.Source.ForceRestart = forceRestart;
 
             bool connected = true;
 

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -69,7 +69,7 @@ namespace Test.Unit
             await Server.Start();
             Client = new UAClient(Provider, Config);
             Source = new CancellationTokenSource();
-            await Client.Run(Source.Token);
+            await Client.Run(Source.Token, 1);
         }
 
         public async Task DisposeAsync()
@@ -98,7 +98,7 @@ namespace Test.Unit
             Assert.Equal(4, tester.Client.NamespaceTable.Count);
             Assert.Equal("opc.tcp://test.localhost", tester.Client.NamespaceTable.GetString(2));
         }
-        [Fact]
+        [Fact(Timeout = 10000)]
         public async Task TestConnectionFailure()
         {
             string oldEP = tester.Config.Source.EndpointUrl;
@@ -106,14 +106,14 @@ namespace Test.Unit
             tester.Config.Source.EndpointUrl = "opc.tcp://localhost:62009";
             try
             {
-                var exc = await Assert.ThrowsAsync<SilentServiceException>(() => tester.Client.Run(tester.Source.Token));
+                var exc = await Assert.ThrowsAsync<SilentServiceException>(() => tester.Client.Run(tester.Source.Token, 0));
                 Assert.Equal(StatusCodes.BadNotConnected, exc.StatusCode);
                 Assert.Equal(ExtractorUtils.SourceOp.SelectEndpoint, exc.Operation);
             }
             finally
             {
                 tester.Config.Source.EndpointUrl = "opc.tcp://localhost:62000";
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
             }
         }
         [Fact]
@@ -123,12 +123,12 @@ namespace Test.Unit
             tester.Config.Source.ConfigRoot = "wrong";
             try
             {
-                var exc = await Assert.ThrowsAsync<ExtractorFailureException>(() => tester.Client.Run(tester.Source.Token));
+                var exc = await Assert.ThrowsAsync<ExtractorFailureException>(() => tester.Client.Run(tester.Source.Token, 0));
             }
             finally
             {
                 tester.Config.Source.ConfigRoot = "config";
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
             }
         }
         [Fact]
@@ -150,24 +150,7 @@ namespace Test.Unit
 
             try
             {
-
-                Exception exception = null;
-                for (int i = 0; i < 10; i++)
-                {
-                    await Task.Delay(1000);
-                    try
-                    {
-                        await tester.Client.Run(tester.Source.Token);
-                        exception = null;
-                        break;
-                    }
-                    catch (Exception ex)
-                    {
-                        exception = ex;
-                    }
-                }
-
-                if (exception != null) throw exception;
+                await tester.Client.Run(tester.Source.Token, 10);
                 
                 Assert.True(CommonTestUtils.TestMetricValue("opcua_connected", 1));
                 tester.Server.Stop();
@@ -186,7 +169,7 @@ namespace Test.Unit
                 await tester.Client.Close(tester.Source.Token);
                 tester.Config.Source.KeepAliveInterval = 10000;
                 tester.Config.Logger.UaSessionTracing = false;
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
             }
         }
         [Fact]
@@ -200,7 +183,7 @@ namespace Test.Unit
             try
             {
                 Environment.SetEnvironmentVariable("OPCUA_CERTIFICATE_DIR", "certificates-test");
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
                 var dir = new DirectoryInfo("./certificates-test/pki/trusted/certs/");
                 Assert.Single(dir.GetFiles());
             }
@@ -209,7 +192,7 @@ namespace Test.Unit
                 await tester.Client.Close(tester.Source.Token);
                 Environment.SetEnvironmentVariable("OPCUA_CERTIFICATE_DIR", null);
                 Directory.Delete("./certificates-test/", true);
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
             }
         }
         [Fact]
@@ -230,18 +213,18 @@ namespace Test.Unit
 
                 tester.Server.Server.SetValidator(true);
 
-                await Assert.ThrowsAsync<SilentServiceException>(async () => await tester.Client.Run(tester.Source.Token));
+                await Assert.ThrowsAsync<SilentServiceException>(async () => await tester.Client.Run(tester.Source.Token, 0));
 
                 tester.Server.Server.SetValidator(false);
 
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
             }
             finally
             {
                 tester.Server.Server.AllowAnonymous = true;
                 tester.Config.Source.X509Certificate = null;
                 tester.Server.Server.SetValidator(false);
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
             }
         }
 
@@ -256,18 +239,18 @@ namespace Test.Unit
                 tester.Config.Source.Username = "testuser";
                 tester.Config.Source.Password = "wrongpassword";
 
-                await Assert.ThrowsAsync<SilentServiceException>(async () => await tester.Client.Run(tester.Source.Token));
+                await Assert.ThrowsAsync<SilentServiceException>(async () => await tester.Client.Run(tester.Source.Token, 0));
 
                 tester.Config.Source.Password = "testpassword";
 
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
             }
             finally
             {
                 tester.Server.Server.AllowAnonymous = true;
                 tester.Config.Source.Username = null;
                 tester.Config.Source.Password = null;
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
             }
         }
         [Fact]
@@ -278,7 +261,7 @@ namespace Test.Unit
             tester.Config.Source.ReverseConnectUrl = "opc.tcp://localhost:61000";
             try
             {
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
                 Assert.True(tester.Client.Started);
                 // Just check that we are able to read, indicating an established connection
                 await tester.Client.ReadRawValues(new[] { VariableIds.Server_ServerStatus }, tester.Source.Token);
@@ -287,7 +270,7 @@ namespace Test.Unit
             {
                 tester.Server.Server.RemoveReverseConnection(new Uri("opc.tcp://localhost:61000"));
                 tester.Config.Source.ReverseConnectUrl = null;
-                await tester.Client.Run(tester.Source.Token);
+                await tester.Client.Run(tester.Source.Token, 0);
             }
         }
 

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -61,7 +61,7 @@ namespace Test.Utils
 
             Client = new UAClient(Provider, Config);
             Source = new CancellationTokenSource();
-            await Client.Run(Source.Token);
+            await Client.Run(Source.Token, 0);
         }
 
         private void ResetType(object obj, object reference)


### PR DESCRIPTION
The idea is to lower restart times and also clean up the code a bit. Instead of restarting from zero when the extractor fails to connect, we restart inside a new SessionManager class.

This PR also improves the ForceRestart option to not quit the extractor entirely, which greatly improves restart time. Some users have been hesitant to use the ForceRestart option because it is so slow, this should help them considerably.

This is also the groundwork for supporting redundant servers. For those it is nice to have some abstraction around the session, since it may represent one of several servers.