### PR TITLE
[DOG-363] Redundancy support

### DIFF
--- a/Extractor/Config.cs
+++ b/Extractor/Config.cs
@@ -48,6 +48,10 @@ namespace Cognite.OpcUa
         [Required]
         public string? EndpointUrl { get; set; }
         /// <summary>
+        /// Alternate endpoint URLs, used for redundancy if the server supports it.
+        /// </summary>
+        public IEnumerable<string>? AltEndpointUrls { get; set; }
+        /// <summary>
         /// True to auto accept untrusted certificates.
         /// If this is false, server certificates must be trusted by manually moving them to the "trusted" certificates folder.
         /// </summary>

--- a/Extractor/SessionManager.cs
+++ b/Extractor/SessionManager.cs
@@ -188,7 +188,7 @@ namespace Cognite.OpcUa
                 }
 
 
-                return await Session.Create(
+                var session = await Session.Create(
                     appConfig,
                     connection,
                     endpoint,
@@ -198,6 +198,8 @@ namespace Cognite.OpcUa
                     0,
                     identity,
                     null);
+                EndpointUrl = config.EndpointUrl;
+                return session;
             }
             catch (Exception ex)
             {
@@ -229,7 +231,7 @@ namespace Cognite.OpcUa
                 identity.DisplayName);
             try
             {
-                return await Session.Create(
+                var session = await Session.Create(
                     appConfig,
                     endpoint,
                     false,
@@ -238,6 +240,8 @@ namespace Cognite.OpcUa
                     identity,
                     null
                 );
+                EndpointUrl = endpointUrl;
+                return session;
             }
             catch (Exception ex)
             {

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -230,14 +230,15 @@ namespace Cognite.OpcUa
             if (sessionManager == null)
             {
                 sessionManager = new SessionManager(Config.Source, this, AppConfig!, log, liveToken, timeout);
-            } else
+            }
+            else
             {
                 sessionManager.Timeout = timeout;
             }
 
             await sessionManager.Connect();
             Started = true;
-            log.LogInformation("Successfully connected to server at {EndpointURL}", Config.Source.EndpointUrl);
+            log.LogInformation("Successfully connected to server at {EndpointURL}", sessionManager.EndpointUrl);
         }
 
         public void TriggerOnServerDisconnect()

--- a/Server/NodeManager.cs
+++ b/Server/NodeManager.cs
@@ -343,6 +343,21 @@ namespace Server
             state.AddReference(referenceType, true, newParentId);
         }
 
+        public void SetServerRedundancyStatus(byte serviceLevel, RedundancySupport support)
+        {
+            log.LogInformation("Set server redundancy statues: Level: {Level}, Support: {Support}", serviceLevel, support);
+            lock (Server.DiagnosticsNodeManager.Lock)
+            {
+                ServerObjectState serverObject = (ServerObjectState)Server.DiagnosticsNodeManager.FindPredefinedNode(
+                    ObjectIds.Server,
+                    typeof(ServerObjectState));
+
+                // update server capabilities.
+                serverObject.ServiceLevel.Value = serviceLevel;
+                serverObject.ServerRedundancy.RedundancySupport.Value = support;
+            }
+        }
+
         public void SetEventConfig(bool auditing, bool server, bool serverAuditing)
         {
             log.LogInformation("Set server event options. Auditing: {Auditing}, Server emitting events: {Server}", auditing, server);

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -94,6 +94,12 @@ namespace Server
         public string LogFile { get; set; }
         [CommandLineOption("Write OPC-UA SDK trace to log.")]
         public bool LogTrace { get; set; }
+
+        [CommandLineOption("Manually set server service level, 0-255")]
+        public byte ServiceLevel { get; set; } = 255;
+
+        [CommandLineOption("Set server redundancy support. One of None, Cold, Warm, Hot, Transparent, HotAndMirrored")]
+        public string RedundancySupport { get; set; }
     }
 
 
@@ -137,6 +143,11 @@ namespace Server
             server.Server.Issues.MaxSubscriptions = opt.MaxSubscriptions;
             server.Server.Issues.MaxHistoryNodes = opt.MaxHistoryNodes;
             server.Server.Issues.RemainingBrowseCount = opt.RemainingBrowseCount;
+
+            if (opt.RedundancySupport != null)
+            {
+                server.SetServerRedundancyStatus(opt.ServiceLevel, Enum.Parse<Opc.Ua.RedundancySupport>(opt.RedundancySupport));
+            }
 
             int idx = 0;
 

--- a/Server/ServerController.cs
+++ b/Server/ServerController.cs
@@ -340,5 +340,10 @@ namespace Server
             UpdateNode(Ids.Custom.EnumVar3, idx % 2 == 0
                 ? new[] { 123, 123, 321, 123 } : new[] { 123, 123, 123, 321 });
         }
+
+        public void SetServerRedundancyStatus(byte serviceLevel, RedundancySupport support)
+        {
+            Server.SetServerRedundancyStatus(serviceLevel, support);
+        }
     }
 }

--- a/Server/ServerController.cs
+++ b/Server/ServerController.cs
@@ -93,6 +93,7 @@ namespace Server
         }
         public void Stop()
         {
+            log.LogInformation("Closing server");
             Server.Stop();
             running = false;
         }

--- a/Server/TestServer.cs
+++ b/Server/TestServer.cs
@@ -211,6 +211,11 @@ namespace Server
         {
             custom.SetEventConfig(auditing, server, serverAuditing);
         }
+
+        public void SetServerRedundancyStatus(byte serviceLevel, RedundancySupport support)
+        {
+            custom.SetServerRedundancyStatus(serviceLevel, support);
+        }
         public void PopulateEventHistory<T>(NodeId eventId,
             NodeId emitter,
             NodeId source,

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -277,6 +277,44 @@ namespace Test.Unit
             }
         }
 
+        [Fact]
+        public async Task TestRedundancy()
+        {
+            await tester.Client.Close(tester.Source.Token);
+            tester.Server.SetServerRedundancyStatus(230, RedundancySupport.Hot);
+            var altServer = new ServerController(new[] {
+                PredefinedSetup.Base
+            }, tester.Provider, 62300)
+            {
+                ConfigRoot = "Server.Test.UaClient"
+            };
+            await altServer.Start();
+            altServer.SetServerRedundancyStatus(240, RedundancySupport.Hot);
+            tester.Config.Source.AltEndpointUrls = new[]
+            {
+                "opc.tcp://localhost:62300"
+            };
+            tester.Config.Source.ForceRestart = true;
+
+            try
+            {
+                await tester.Client.Run(tester.Source.Token, 0);
+                var sm = tester.Client.GetType().GetField("sessionManager", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                    .GetValue(tester.Client) as SessionManager;
+                Assert.Equal("opc.tcp://localhost:62300", sm.EndpointUrl);
+
+                altServer.Stop();
+                altServer.Dispose();
+                await TestUtils.WaitForCondition(() => sm.EndpointUrl == tester.Config.Source.EndpointUrl, 20, "Expected session to reconnect to original server");
+            }
+            finally
+            {
+                tester.Config.Source.AltEndpointUrls = null;
+                tester.Config.Source.ForceRestart = false;
+                await tester.Client.Run(tester.Source.Token, 0);
+            }
+        }
+
         #endregion
 
         #region browse

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -282,6 +282,7 @@ namespace Test.Unit
         {
             await tester.Client.Close(tester.Source.Token);
             tester.Server.SetServerRedundancyStatus(230, RedundancySupport.Hot);
+            tester.Config.Source.KeepAliveInterval = 1000;
             var altServer = new ServerController(new[] {
                 PredefinedSetup.Base
             }, tester.Provider, 62300)
@@ -311,6 +312,7 @@ namespace Test.Unit
             {
                 tester.Config.Source.AltEndpointUrls = null;
                 tester.Config.Source.ForceRestart = false;
+                tester.Config.Source.KeepAliveInterval = 10000;
                 await tester.Client.Run(tester.Source.Token, 0);
             }
         }

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -12,6 +12,14 @@ version: 1
 source:
     # The URL of the OPC-UA server to connect to
     endpoint-url: "opc.tcp://localhost:4840"
+    # A list of URLs to connect to if the endpoint-url fails.
+    # These are connected to in order, and the one with the highest ServiceLevel is selected.
+    # See the OPC-UA standard part 4 6.6.2, this is for non-transparent redundancy.
+    # When using this, setting force-restart: true is recommended, as otherwise the extractor will only try to
+    # reconnect to the same server on failure.
+    alt-endpoint-urls:
+    # - opc.tcp://some-other-server:1234
+    # - opc.tcp://some-third-server:4321
     # Auto accept connections from unknown servers.
     # There is not yet a feature to accept new certificates, but you can manually move rejected certificates to accepted.
     # Paths are defined in opc.ua.net.extractor.Config.xml
@@ -51,7 +59,9 @@ source:
     # Note that enabling this makes the connection less secure, and that a better solution is to resolve these issues on
     # the server.
     ignore-certificate-issues: false
-    # If true, force restart the extractor on disconnect. Required for some servers
+    # If true, exit the session and reconnect on restart, this means that subscriptions will need to be recreated,
+    # which has some performance cost.
+    # Required for failover if alt-endpoint-urls is set.
     force-restart: false
     # Completely exit the extractor on failure, instead of doing an internal restart. Internal reset should re-initialize everything relevant,
     # but this can be set to do restart with some external tool instead.

--- a/manifest.yml
+++ b/manifest.yml
@@ -55,6 +55,13 @@ extractor:
   image: opc-ua.png
 
 versions:
+  "2.9.0":
+    description: Support for non-transparent server redundancy.
+    changelog:
+      added:
+        - Support for non-transparent server redundancy ref. OPC-UA standard chapter 4 6.6.2
+      changed:
+        - Improved performance of force-restart, the extractor will no-longer rebrowse automatically if force-restart is enabled. Instead use restart-on-reconnect if that is desired.
   "2.8.0":
     description: Basic support for high availability.
     changelog:

--- a/manifest.yml
+++ b/manifest.yml
@@ -60,6 +60,9 @@ versions:
     changelog:
       added:
         - Support for non-transparent server redundancy ref. OPC-UA standard chapter 4 6.6.2
+        - `extraction-pipeline: external-id` as alias for `pipeline-id` in config, to align with python extractors.
+      fixed:
+        - Bug causing extractor to fail if the `cognite` section was missing in remote config.
       changed:
         - Improved performance of force-restart, the extractor will no-longer rebrowse automatically if force-restart is enabled. Instead use restart-on-reconnect if that is desired.
   "2.8.0":


### PR DESCRIPTION
Support redundant OPC-UA servers, using non-transparent redundancy.

This adds an `alt-endpoint-urls` property containing a list of URLs. The one with the lowest read `ServiceLevel` is selected.