### PR TITLE
Better handling of certificate files in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ WORKDIR /extractor
 
 ENV OPCUA_CONFIG_DIR="/config"
 ENV OPCUA_CERTIFICATE_DIR="/certificates"
+ENV OPCUA_OWN_CERTIFICATE_DIR="/certificates/pki/own"
+ENV OPCUA_CERTIFICATE_SUBJECT="CN=Opcua-extractor, C=NO, S=Oslo, O=Cognite, DC=docker.opcua"
 
 ENTRYPOINT ["dotnet", "/extractor/OpcuaExtractor.dll"]

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -188,12 +188,25 @@ namespace Cognite.OpcUa
                 throw new ExtractorFailureException("Failed to load OPC-UA xml configuration file", exc);
             }
 
+            string ownCertificateDir = Environment.GetEnvironmentVariable("OPCUA_OWN_CERTIFICATE_DIR");
             string certificateDir = Environment.GetEnvironmentVariable("OPCUA_CERTIFICATE_DIR");
+            string certificateSubject = Environment.GetEnvironmentVariable("OPCUA_CERTIFICATE_SUBJECT");
             if (!string.IsNullOrEmpty(certificateDir))
             {
                 AppConfig.SecurityConfiguration.TrustedIssuerCertificates.StorePath = $"{certificateDir}/pki/issuer";
                 AppConfig.SecurityConfiguration.TrustedPeerCertificates.StorePath = $"{certificateDir}/pki/trusted";
                 AppConfig.SecurityConfiguration.RejectedCertificateStore.StorePath = $"{certificateDir}/pki/rejected";
+            }
+
+            if (!string.IsNullOrEmpty(ownCertificateDir))
+            {
+                AppConfig.SecurityConfiguration.ApplicationCertificate.StoreType = "Directory";
+                AppConfig.SecurityConfiguration.ApplicationCertificate.StorePath = $"{ownCertificateDir}";
+            }
+
+            if (!string.IsNullOrEmpty(certificateSubject))
+            {
+                AppConfig.SecurityConfiguration.ApplicationCertificate.SubjectName = certificateSubject;
             }
 
             bool validAppCert = await application.CheckApplicationInstanceCertificate(false, 0, Config.Source.CertificateExpiry);

--- a/manifest.yml
+++ b/manifest.yml
@@ -55,6 +55,11 @@ extractor:
   image: opc-ua.png
 
 versions:
+  "2.9.2":
+    description: Improve configuration of certificates in docker containers
+    changelog:
+      changed:
+        - "Docker containers now use a local certificate directory for application certificates by default, they also use a static signature not dependent on the host machine."
   "2.9.1":
     description: Actual fix to missing `cognite` section bug.
     changelog:


### PR DESCRIPTION
I'd like to find a better way to handle these kinds of special configs in docker, and in general overrides for the default xml config.