### PR TITLE
Fix retries

### DIFF
--- a/Extractor/Config.cs
+++ b/Extractor/Config.cs
@@ -229,7 +229,8 @@ namespace Cognite.OpcUa
             StatusCodes.BadServerHalted,
             StatusCodes.BadServerNotConnected,
             StatusCodes.BadTimeout,
-            StatusCodes.BadSecureChannelClosed
+            StatusCodes.BadSecureChannelClosed,
+            StatusCodes.BadNoCommunication
         };
 
         private HashSet<uint>? finalRetryStatusCodes;

--- a/Extractor/ExtractorUtils.cs
+++ b/Extractor/ExtractorUtils.cs
@@ -179,6 +179,10 @@ namespace Cognite.OpcUa
             {
                 return HandleServiceResult(log, serviceEx, op);
             }
+            else if (ex is SilentServiceException silentEx)
+            {
+                return silentEx;
+            }
             else
             {
                 log.LogError(ex, "Unexpected error of type {Type} in operation {Op}", ex.GetType(), op);

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -283,6 +283,12 @@ namespace Cognite.OpcUa
                     return Config.Source.Retries.FinalRetryStatusCodes.Contains(silentExc.InnerServiceException.StatusCode);
                 }
             }
+            else if (ex is AggregateException aex)
+            {
+                // Only retry aggregate exceptions if all inner exceptions should be retried...
+                var flat = aex.Flatten();
+                return aex.InnerExceptions.All(e => ShouldRetryException(e));
+            }
             return false;
         }
 

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -285,9 +285,9 @@ namespace Cognite.OpcUa
             }
             else if (ex is AggregateException aex)
             {
-                // Only retry aggregate exceptions if all inner exceptions should be retried...
+                // Only retry aggregate exceptions if one of the inner exceptions should be retried...
                 var flat = aex.Flatten();
-                return aex.InnerExceptions.All(e => ShouldRetryException(e));
+                return aex.InnerExceptions.Any(e => ShouldRetryException(e));
             }
             return false;
         }

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -100,6 +100,10 @@ namespace Server
 
         [CommandLineOption("Set server redundancy support. One of None, Cold, Warm, Hot, Transparent, HotAndMirrored")]
         public string RedundancySupport { get; set; }
+
+        [CommandLineOption("Server issue: This is the denominator for a probability that an arbitrary browse operation will fail " +
+            "I.e. 5 means that 1/5 browse ops will fail with BadNoCommunication")]
+        public int RandomBrowseFail { get; set; }
     }
 
 
@@ -143,6 +147,7 @@ namespace Server
             server.Server.Issues.MaxSubscriptions = opt.MaxSubscriptions;
             server.Server.Issues.MaxHistoryNodes = opt.MaxHistoryNodes;
             server.Server.Issues.RemainingBrowseCount = opt.RemainingBrowseCount;
+            server.Server.Issues.BrowseFailDenom = opt.RandomBrowseFail;
 
             if (opt.RedundancySupport != null)
             {

--- a/manifest.yml
+++ b/manifest.yml
@@ -60,6 +60,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.10.2":
+    description: Fix to retries on some operations
+    changelog:
+      fixed:
+        - "Fix retries not working on certain operations"
   "2.10.1":
     description: Fixes internal performance issue
     changelog:


### PR DESCRIPTION
The issue was that when silenced exceptions were given to HandleServiceResult, they were treated as unknown exceptions. We would rather just return them back.

This also contains a bit of server code to make testing this easier, though it's not something I would like to include in tests.

It also adds `BadNoCommunication` as a default status code.