### PR TITLE
Pass along whether a node source result can be used for deletes

### DIFF
--- a/Extractor/Config.cs
+++ b/Extractor/Config.cs
@@ -403,6 +403,12 @@ namespace Cognite.OpcUa
         /// </summary>
         public bool MapVariableChildren { get; set; }
         /// <summary>
+        /// Configuration for enabling soft deletes.
+        /// </summary>
+        public DeletesConfig Deletes { get => deletes; set => deletes = value ?? deletes; }
+        private DeletesConfig deletes = new DeletesConfig();
+
+        /// <summary>
         /// A list of transformations to be applied to the source nodes before pushing
         /// The possible transformations are
         /// "Ignore", ignore the node. This will ignore all descendants of the node.
@@ -574,8 +580,16 @@ namespace Cognite.OpcUa
         /// True to update context, i.e. the position of the node in the node hierarchy.
         /// </summary>
         public bool Context { get; set; }
-
     }
+
+    public class DeletesConfig
+    {
+        /// <summary>
+        /// Enable deletes.
+        /// </summary>
+        public bool Enabled { get; set; }
+    }
+
     public class DataSubscriptionConfig
     {
         /// <summary>
@@ -1355,6 +1369,18 @@ namespace Cognite.OpcUa
         /// Name of the raw table or litedb store for influxdb failurebuffer event ranges.
         /// </summary>
         public string InfluxEventStore { get; set; } = "influx_event_states";
+        /// <summary>
+        /// Name of the raw table or litedb store for storing known object-type nodes, used for detecting deleted nodes.
+        /// </summary>
+        public string KnownObjectsStore { get; set; } = "known_objects";
+        /// <summary>
+        /// Name of the raw table or litedb store for storing known variable-type nodes, used for detecting deleted nodes.
+        /// </summary>
+        public string KnownVariablesStore { get; set; } = "known_variables";
+        /// <summary>
+        /// Name of the raw table or litedb store for storing known reference-type nodes, used for detecting deleted nodes.
+        /// </summary>
+        public string KnownReferencesStore { get; set; } = "known_references";
     }
     public class RawNodeFilter
     {

--- a/Extractor/NodeSources/BaseNodeSource.cs
+++ b/Extractor/NodeSources/BaseNodeSource.cs
@@ -301,7 +301,8 @@ namespace Cognite.OpcUa.NodeSources
         /// <returns>True if node should be considered for mapping, false otherwise.</returns>
         protected bool FilterObject(TypeUpdateConfig update, UANode node)
         {
-            if (update.AnyUpdate)
+            // If deletes are enabled, we are not able to filter any nodes, even if that has a real cost in terms of memory usage.
+            if (update.AnyUpdate && !Config.Extraction.Deletes.Enabled)
             {
                 var oldChecksum = Extractor.State.GetMappedNode(node.Id)?.Checksum;
                 if (oldChecksum != null)

--- a/Extractor/NodeSources/CDFNodeSource.cs
+++ b/Extractor/NodeSources/CDFNodeSource.cs
@@ -192,7 +192,8 @@ namespace Cognite.OpcUa.NodeSources
                 FinalSourceVariables,
                 FinalDestinationObjects,
                 FinalDestinationVariables,
-                FinalReferences);
+                FinalReferences,
+                false);
         }
 
         private async Task GetExtraNodeData(CancellationToken token)

--- a/Extractor/NodeSources/NodeSetSource.cs
+++ b/Extractor/NodeSources/NodeSetSource.cs
@@ -82,6 +82,7 @@ namespace Cognite.OpcUa.NodeSources
         private readonly Dictionary<NodeId, IList<IReference>> references = new Dictionary<NodeId, IList<IReference>>();
         private readonly object buildLock = new object();
         private bool built;
+        private bool isFullBrowse;
         public NodeSetSource(ILogger<NodeSetSource> log, FullConfig config, UAExtractor extractor, UAClient client)
             : base(log, config, extractor, client)
         {
@@ -361,9 +362,10 @@ namespace Cognite.OpcUa.NodeSources
         /// <summary>
         /// Construct 
         /// </summary>
-        public void BuildNodes(IEnumerable<NodeId> rootNodes)
+        public void BuildNodes(IEnumerable<NodeId> rootNodes, bool isFullBrowse)
         {
             Build();
+            this.isFullBrowse = isFullBrowse;
 
             NodeMap.Clear();
             var visitedNodes = new HashSet<NodeId>();
@@ -478,7 +480,8 @@ namespace Cognite.OpcUa.NodeSources
                 FinalSourceVariables,
                 FinalDestinationObjects,
                 FinalDestinationVariables,
-                FinalReferences);
+                FinalReferences,
+                isFullBrowse);
         }
 
         private void GetRelationshipData()

--- a/Extractor/NodeSources/NodeSourceResult.cs
+++ b/Extractor/NodeSources/NodeSourceResult.cs
@@ -30,18 +30,22 @@ namespace Cognite.OpcUa.NodeSources
             IEnumerable<UAVariable> sourceVariables,
             IEnumerable<UANode> destinationObjects,
             IEnumerable<UAVariable> destinationVariables,
-            IEnumerable<UAReference> destinationReferences)
+            IEnumerable<UAReference> destinationReferences,
+            bool canBeUsedForDeletes)
         {
             SourceObjects = sourceObjects;
             SourceVariables = sourceVariables;
             DestinationObjects = destinationObjects;
             DestinationVariables = destinationVariables;
             DestinationReferences = destinationReferences;
+            CanBeUsedForDeletes = canBeUsedForDeletes;
         }
         public IEnumerable<UANode> SourceObjects { get; }
         public IEnumerable<UAVariable> SourceVariables { get; }
         public IEnumerable<UANode> DestinationObjects { get; }
         public IEnumerable<UAVariable> DestinationVariables { get; }
         public IEnumerable<UAReference> DestinationReferences { get; }
+
+        public bool CanBeUsedForDeletes { get; }
     }
 }

--- a/Extractor/NodeSources/UANodeSource.cs
+++ b/Extractor/NodeSources/UANodeSource.cs
@@ -37,10 +37,12 @@ namespace Cognite.OpcUa.NodeSources
 
         private readonly List<(ReferenceDescription Node, NodeId ParentId)> references = new List<(ReferenceDescription, NodeId)>();
         public Action<ReferenceDescription, NodeId> Callback => HandleNode;
+        private readonly bool isFullBrowse;
 
-        public UANodeSource(ILogger<UANodeSource> log, FullConfig config, UAExtractor extractor, UAClient client)
+        public UANodeSource(ILogger<UANodeSource> log, FullConfig config, UAExtractor extractor, UAClient client, bool isFullBrowse)
             : base(log, config, extractor, client)
         {
+            this.isFullBrowse = isFullBrowse;
         }
 
         /// <summary>
@@ -120,7 +122,8 @@ namespace Cognite.OpcUa.NodeSources
                 FinalSourceVariables,
                 FinalDestinationObjects,
                 FinalDestinationVariables,
-                FinalReferences);
+                FinalReferences,
+                isFullBrowse);
         }
 
         /// <summary>

--- a/Test/Unit/NodeSourceTest.cs
+++ b/Test/Unit/NodeSourceTest.cs
@@ -53,29 +53,31 @@ namespace Test.Unit
             var source = new NodeSetSource(log, tester.Config, extractor, tester.Client);
 
             // Base, nothing enabled
-            source.BuildNodes(new[] { tester.Ids.Custom.Root });
+            source.BuildNodes(new[] { tester.Ids.Custom.Root }, true);
             var result = await source.ParseResults(tester.Source.Token);
             Assert.Equal(3, result.SourceVariables.Count());
             Assert.Equal(3, result.DestinationVariables.Count());
             Assert.Equal(3, result.DestinationObjects.Count());
             Assert.Equal(3, result.SourceObjects.Count());
             Assert.Empty(result.DestinationReferences);
+            Assert.True(result.CanBeUsedForDeletes);
 
             // Enable arrays
             extractor.State.Clear();
             tester.Config.Extraction.DataTypes.MaxArraySize = 4;
-            source.BuildNodes(new[] { tester.Ids.Custom.Root });
+            source.BuildNodes(new[] { tester.Ids.Custom.Root }, false);
             result = await source.ParseResults(tester.Source.Token);
             Assert.Equal(5, result.SourceVariables.Count());
             Assert.Equal(11, result.DestinationVariables.Count());
             Assert.Equal(5, result.DestinationObjects.Count());
             Assert.Equal(3, result.SourceObjects.Count());
             Assert.Empty(result.DestinationReferences);
+            Assert.False(result.CanBeUsedForDeletes);
 
             // Enable strings
             extractor.State.Clear();
             tester.Config.Extraction.DataTypes.AllowStringVariables = true;
-            source.BuildNodes(new[] { tester.Ids.Custom.Root });
+            source.BuildNodes(new[] { tester.Ids.Custom.Root }, true);
             result = await source.ParseResults(tester.Source.Token);
             Assert.Equal(9, result.SourceVariables.Count());
             Assert.Equal(16, result.DestinationVariables.Count());
@@ -90,7 +92,7 @@ namespace Test.Unit
                 CommonTestUtils.ToProtoNodeId(tester.Server.Ids.Custom.IgnoreType, tester.Client)
             };
             extractor.DataTypeManager.Configure();
-            source.BuildNodes(new[] { tester.Ids.Custom.Root });
+            source.BuildNodes(new[] { tester.Ids.Custom.Root }, true);
             result = await source.ParseResults(tester.Source.Token);
             Assert.Equal(8, result.SourceVariables.Count());
             Assert.Equal(15, result.DestinationVariables.Count());
@@ -101,7 +103,7 @@ namespace Test.Unit
             // Map variable children to objects
             extractor.State.Clear();
             tester.Config.Extraction.MapVariableChildren = true;
-            source.BuildNodes(new[] { tester.Ids.Custom.Root });
+            source.BuildNodes(new[] { tester.Ids.Custom.Root }, true);
             result = await source.ParseResults(tester.Source.Token);
             Assert.Equal(8, result.SourceVariables.Count());
             Assert.Equal(15, result.DestinationVariables.Count());
@@ -114,7 +116,7 @@ namespace Test.Unit
             // Enable non-hierarchical relations
             extractor.State.Clear();
             tester.Config.Extraction.Relationships.Enabled = true;
-            source.BuildNodes(new[] { tester.Ids.Custom.Root });
+            source.BuildNodes(new[] { tester.Ids.Custom.Root }, true);
             result = await source.ParseResults(tester.Source.Token);
             foreach (var rf in result.DestinationReferences)
             {
@@ -139,7 +141,7 @@ namespace Test.Unit
             // Enable forward hierarchical relations
             extractor.State.Clear();
             tester.Config.Extraction.Relationships.Hierarchical = true;
-            source.BuildNodes(new[] { tester.Ids.Custom.Root });
+            source.BuildNodes(new[] { tester.Ids.Custom.Root }, true);
             result = await source.ParseResults(tester.Source.Token);
             Assert.Equal(18, result.DestinationReferences.Count());
             Assert.Equal(14, result.DestinationReferences.Count(rel => rel.IsForward));
@@ -157,7 +159,7 @@ namespace Test.Unit
             // Enable inverse hierarchical relations
             extractor.State.Clear();
             tester.Config.Extraction.Relationships.InverseHierarchical = true;
-            source.BuildNodes(new[] { tester.Ids.Custom.Root });
+            source.BuildNodes(new[] { tester.Ids.Custom.Root }, true);
             result = await source.ParseResults(tester.Source.Token);
             Assert.Equal(28, result.DestinationReferences.Count());
             Assert.Equal(14, result.DestinationReferences.Count(rel => rel.IsForward));
@@ -173,6 +175,7 @@ namespace Test.Unit
                 Assert.Contains(result.DestinationReferences, orel => orel.Source.Id == rel.Target.Id
                     && orel.Target.Id == rel.Source.Id && orel.IsForward == !rel.IsForward);
             });
+            Assert.True(result.CanBeUsedForDeletes);
         }
 
         [Fact]
@@ -194,7 +197,7 @@ namespace Test.Unit
             tester.Config.Extraction.Relationships.InverseHierarchical = true;
             tester.Config.Extraction.Relationships.Enabled = true;
 
-            source.BuildNodes(new[] { tester.Ids.Custom.Root, ObjectIds.TypesFolder });
+            source.BuildNodes(new[] { tester.Ids.Custom.Root, ObjectIds.TypesFolder }, true);
             var result = await source.ParseResults(tester.Source.Token);
             Assert.Equal(892, result.SourceVariables.Count());
             Assert.Equal(899, result.DestinationVariables.Count());
@@ -214,6 +217,7 @@ namespace Test.Unit
                 Assert.Contains(result.DestinationReferences, orel => orel.Source.Id == rel.Target.Id
                     && orel.Target.Id == rel.Source.Id && orel.IsForward == !rel.IsForward);
             });
+            Assert.True(result.CanBeUsedForDeletes);
         }
 
 
@@ -224,7 +228,7 @@ namespace Test.Unit
             var log = tester.Provider.GetRequiredService<ILogger<NodeSetSource>>();
             var source = new NodeSetSource(log, tester.Config, extractor, tester.Client);
 
-            source.BuildNodes(new[] { ObjectIds.ObjectsFolder });
+            source.BuildNodes(new[] { ObjectIds.ObjectsFolder }, true);
 
             tester.Config.Events.AllEvents = true;
             tester.Config.Events.Enabled = true;
@@ -293,7 +297,7 @@ namespace Test.Unit
             var log = tester.Provider.GetRequiredService<ILogger<NodeSetSource>>();
             var source = new NodeSetSource(log, tester.Config, extractor, tester.Client);
 
-            source.BuildNodes(new[] { tester.Ids.Wrong.Root });
+            source.BuildNodes(new[] { tester.Ids.Wrong.Root }, true);
             var extConfig = tester.Config.Extraction;
             extConfig.DataTypes.MaxArraySize = 6;
             extConfig.DataTypes.EstimateArraySizes = true;


### PR DESCRIPTION
Also add a few config options we'll need.

This is the first small step towards deletes. We need to pass along this information so that partial browses (triggered by audit events or the like) do not make us delete everything in CDF. (though we probably won't implement hard deletes at all)

