### PR TITLE
Store known nodes

### DIFF
--- a/Extractor/Deletes.cs
+++ b/Extractor/Deletes.cs
@@ -73,7 +73,7 @@ namespace Cognite.OpcUa
             if (deleted.Any())
             {
                 logger.LogInformation("Found {Del} stored nodes in {Tab} that no longer exist and will be marked as deleted", deleted.Count, tableName);
-                await stateStore.DeleteExtractionState(deleted.Cast<IExtractionState>(), tableName, token);
+                await stateStore.DeleteExtractionState(deleted.Select(d => new NodeExistsState(d.Id)), tableName, token);
             }
 
             var newStates = states.Values.Where(s => !oldStates.ContainsKey(s.Id)).ToList();
@@ -81,9 +81,8 @@ namespace Cognite.OpcUa
             if (newStates.Any())
             {
                 logger.LogInformation("Found {New} new nodes in {Tab}, adding to state store...", newStates.Count, tableName);
-                await stateStore.StoreExtractionState(newStates, tableName, token);
+                await stateStore.StoreExtractionState(newStates, tableName, s => new BaseStorableState { Id = s.Id }, token);
             }
-
 
             return deleted.Select(d => d.Id);
         }

--- a/Extractor/Deletes.cs
+++ b/Extractor/Deletes.cs
@@ -1,11 +1,9 @@
 ﻿using Cognite.Extractor.StateStorage;
 using Cognite.OpcUa.NodeSources;
 using Microsoft.Extensions.Logging;
-using Opc.Ua;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Extractor/Deletes.cs
+++ b/Extractor/Deletes.cs
@@ -1,0 +1,109 @@
+﻿using Cognite.Extractor.StateStorage;
+using Cognite.OpcUa.NodeSources;
+using Microsoft.Extensions.Logging;
+using Opc.Ua;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.OpcUa
+{
+    internal class NodeExistsState : BaseExtractionState
+    {
+        public NodeExistsState(string id) : base(id)
+        {
+        }
+    }
+
+    public class DeletedNodes
+    {
+        public IEnumerable<string> Objects { get; }
+        public IEnumerable<string> Variables { get; }
+        public IEnumerable<string> References { get; }
+        public DeletedNodes(IEnumerable<string> objects, IEnumerable<string> variables, IEnumerable<string> references)
+        {
+            Objects = objects;
+            Variables = variables;
+            References = references;
+        }
+
+        public DeletedNodes()
+        {
+            Objects = Enumerable.Empty<string>();
+            Variables = Enumerable.Empty<string>();
+            References = Enumerable.Empty<string>();
+        }
+    }
+
+    public class DeletesManager
+    {
+        private readonly IExtractionStateStore stateStore;
+        private readonly IUAClientAccess client;
+        private readonly FullConfig config;
+        private readonly ILogger logger;
+        public DeletesManager(IExtractionStateStore stateStore, IUAClientAccess client, ILogger<DeletesManager> logger, FullConfig config)
+        {
+            this.stateStore = stateStore;
+            this.client = client;
+            this.config = config;
+            this.logger = logger;
+        }
+
+        private async Task<IEnumerable<string>> GetDeletedItems(string? tableName, Dictionary<string, NodeExistsState> states, CancellationToken token)
+        {
+            // If there are no states we don't check for deletes. This means we can't ever delete the _last_ of a type, but that is likely to be
+            // an issue or a bug either way.
+            if (tableName == null || !states.Any()) return Enumerable.Empty<string>();
+
+            Dictionary<string, BaseStorableState> oldStates;
+            try
+            {
+                oldStates = (await stateStore.GetAllExtractionStates<BaseStorableState>(tableName, token)).ToDictionary(s => s.Id);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to get states from state store, assuming it is empty");
+                oldStates = new Dictionary<string, BaseStorableState>();
+            }
+            var deleted = oldStates.Where(s => !states.ContainsKey(s.Key)).Select(kvp => kvp.Value).ToList();
+
+            if (deleted.Any())
+            {
+                logger.LogInformation("Found {Del} stored nodes in {Tab} that no longer exist and will be marked as deleted", deleted.Count, tableName);
+                await stateStore.DeleteExtractionState(deleted.Cast<IExtractionState>(), tableName, token);
+            }
+
+            var newStates = states.Values.Where(s => !oldStates.ContainsKey(s.Id)).ToList();
+
+            if (newStates.Any())
+            {
+                logger.LogInformation("Found {New} new nodes in {Tab}, adding to state store...", newStates.Count, tableName);
+                await stateStore.StoreExtractionState(newStates, tableName, token);
+            }
+
+
+            return deleted.Select(d => d.Id);
+        }
+
+        public async Task<DeletedNodes> GetDiffAndStoreIds(NodeSourceResult result, CancellationToken token)
+        {
+            if (!result.CanBeUsedForDeletes) return new DeletedNodes();
+
+            var newVariables = result.DestinationVariables.Select(v => client.GetUniqueId(v.Id, v.Index)!).ToDictionary(
+                i => i, i => new NodeExistsState(i));
+            var newObjects = result.DestinationObjects.Select(o => client.GetUniqueId(o.Id)!).ToDictionary(i => i, i => new NodeExistsState(i));
+            var newReferences = result.DestinationReferences.Select(r => client.GetRelationshipId(r)!).ToDictionary(i => i, i => new NodeExistsState(i));
+
+            var res = await Task.WhenAll(
+                GetDeletedItems(config.StateStorage?.KnownObjectsStore, newObjects, token),
+                GetDeletedItems(config.StateStorage?.KnownVariablesStore, newVariables, token),
+                GetDeletedItems(config.StateStorage?.KnownReferencesStore, newReferences, token)
+            );
+
+            return new DeletedNodes(res[0], res[1], res[2]);
+        }
+    }
+}

--- a/Test/Unit/DeleteTest.cs
+++ b/Test/Unit/DeleteTest.cs
@@ -1,0 +1,245 @@
+﻿using Cognite.Extractor.StateStorage;
+using Cognite.OpcUa;
+using Cognite.OpcUa.NodeSources;
+using Cognite.OpcUa.TypeCollectors;
+using Cognite.OpcUa.Types;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Opc.Ua;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Test.Utils;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Test.Unit
+{
+    class MockStateStore : IExtractionStateStore
+    {
+        public Dictionary<string, Dictionary<string, BaseStorableState>> States { get; } = new();
+
+        public bool ThrowOnMissingTable { get; set; }
+
+        public Task DeleteExtractionState(IEnumerable<IExtractionState> extractionStates, string tableName, CancellationToken token)
+        {
+            if (!States.TryGetValue(tableName, out var state))
+            {
+                if (ThrowOnMissingTable) throw new InvalidOperationException("Table does not exist!");
+                States[tableName] = state = new Dictionary<string, BaseStorableState>();
+            }
+            foreach (var s in extractionStates)
+            {
+                state.Remove(s.Id);
+            }
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public Task<IEnumerable<T>> GetAllExtractionStates<T>(string tableName, CancellationToken token) where T : BaseStorableState
+        {
+            if (!States.TryGetValue(tableName, out var state))
+            {
+                if (ThrowOnMissingTable) throw new InvalidOperationException("Table does not exist!");
+                States[tableName] = state = new Dictionary<string, BaseStorableState>();
+            }
+            return Task.FromResult(state.Values.OfType<T>());
+        }
+
+        public Task RestoreExtractionState<T, K>(IDictionary<string, K> extractionStates, string tableName, Action<K, T> restoreStorableState, CancellationToken token)
+            where T : BaseStorableState
+            where K : IExtractionState
+        {
+            if (!States.TryGetValue(tableName, out var state))
+            {
+                if (ThrowOnMissingTable) throw new InvalidOperationException("Table does not exist!");
+                States[tableName] = state = new Dictionary<string, BaseStorableState>();
+            }
+            foreach (var kvp in extractionStates)
+            {
+                if (state.TryGetValue(kvp.Key, out var inpState))
+                {
+                    restoreStorableState(kvp.Value, (T)inpState);
+                }
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task RestoreExtractionState<K>(IDictionary<string, K> extractionStates, string tableName, bool initializeMissing, CancellationToken token) where K : BaseExtractionState
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task StoreExtractionState<T, K>(IEnumerable<K> extractionStates, string tableName, Func<K, T> buildStorableState, CancellationToken token)
+            where T : BaseStorableState
+            where K : IExtractionState
+        {
+            if (!States.TryGetValue(tableName, out var state))
+            {
+                States[tableName] = state = new Dictionary<string, BaseStorableState>();
+            }
+            foreach (var s in extractionStates)
+            {
+                state[s.Id] = buildStorableState(s);
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task StoreExtractionState<K>(IEnumerable<K> extractionStates, string tableName, CancellationToken token) where K : BaseExtractionState
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+
+    [Collection("Shared server tests")]
+    public class DeleteTest
+    {
+        private readonly StaticServerTestFixture tester;
+        public DeleteTest(ITestOutputHelper output, StaticServerTestFixture tester)
+        {
+            this.tester = tester ?? throw new ArgumentNullException(nameof(tester));
+            tester.ResetConfig();
+            tester.Init(output);
+        }
+
+        private static UANode GetObject(string id)
+        {
+            return new UANode(new NodeId(id), id, NodeId.Null, NodeClass.Object);
+        }
+
+        private static UAVariable GetVariable(string id)
+        {
+            return new UAVariable(new NodeId(id), id, NodeId.Null);
+        }
+
+        private static UAReference GetReference(string source, string target, ReferenceTypeManager manager)
+        {
+            return new UAReference(new NodeId("type"), true, new NodeId(source), new NodeId(target), false, false, false, manager);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestDeleteManagerNodes(bool throwOnMissing)
+        {
+            using var store = new MockStateStore();
+            store.ThrowOnMissingTable = throwOnMissing;
+            var manager = new DeletesManager(store, tester.Client, tester.Provider.GetRequiredService<ILogger<DeletesManager>>(), tester.Config);
+
+            var result = new NodeSourceResult(
+                Enumerable.Empty<UANode>(),
+                Enumerable.Empty<UAVariable>(),
+                new[] { GetObject("obj1"), GetObject("obj2") },
+                new[] { GetVariable("var1"), GetVariable("var2") },
+                Enumerable.Empty<UAReference>(), false);
+
+            // Cannot be used for deletes, so nothing happens.
+            var toDelete = await manager.GetDiffAndStoreIds(result, tester.Source.Token);
+            Assert.Empty(toDelete.Objects);
+            Assert.Empty(toDelete.Variables);
+            Assert.Empty(toDelete.References);
+            Assert.Empty(store.States);
+
+            result = new NodeSourceResult(
+                Enumerable.Empty<UANode>(),
+                Enumerable.Empty<UAVariable>(),
+                new[] { GetObject("obj1"), GetObject("obj2") },
+                new[] { GetVariable("var1"), GetVariable("var2") },
+                Enumerable.Empty<UAReference>(), true);
+
+            // No configured tables, and no references, so nothing happens
+            tester.Config.StateStorage.KnownObjectsStore = null;
+            tester.Config.StateStorage.KnownVariablesStore = null;
+            toDelete = await manager.GetDiffAndStoreIds(result, tester.Source.Token);
+            Assert.Empty(toDelete.Objects);
+            Assert.Empty(toDelete.Variables);
+            Assert.Empty(toDelete.References);
+            Assert.Empty(store.States);
+
+            tester.Config.StateStorage = new StateStorageConfig();
+
+            // This time there is a store and data, so we get some states, nothing reported as deleted yet.
+            toDelete = await manager.GetDiffAndStoreIds(result, tester.Source.Token);
+            Assert.Empty(toDelete.Objects);
+            Assert.Empty(toDelete.Variables);
+            Assert.Empty(toDelete.References);
+            Assert.Equal(2, store.States.Count);
+            Assert.Equal(2, store.States["known_objects"].Count);
+
+            // Remove one each of objects and variables, so we get a removed of each
+            result = new NodeSourceResult(
+                Enumerable.Empty<UANode>(),
+                Enumerable.Empty<UAVariable>(),
+                new[] { GetObject("obj2") },
+                new[] { GetVariable("var2") },
+                Enumerable.Empty<UAReference>(), true);
+
+            toDelete = await manager.GetDiffAndStoreIds(result, tester.Source.Token);
+            Assert.Single(toDelete.Objects);
+            Assert.Single(toDelete.Variables);
+            Assert.Empty(toDelete.References);
+            Assert.Equal(2, store.States.Count);
+            Assert.Single(store.States["known_objects"]);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestDeleteManagerReferences(bool throwOnMissing)
+        {
+            var refManager = new ReferenceTypeManager(tester.Config, tester.Provider.GetRequiredService<ILogger<ReferenceTypeManager>>(), tester.Client, null);
+            using var store = new MockStateStore();
+            store.ThrowOnMissingTable = throwOnMissing;
+            var manager = new DeletesManager(store, tester.Client, tester.Provider.GetRequiredService<ILogger<DeletesManager>>(), tester.Config);
+
+            var result = new NodeSourceResult(
+                Enumerable.Empty<UANode>(),
+                Enumerable.Empty<UAVariable>(),
+                new[] { GetObject("obj1"), GetObject("obj2") },
+                new[] { GetVariable("var1"), GetVariable("var2") },
+                new[] { GetReference("obj1", "obj2", refManager), GetReference("var1", "var2", refManager)}, true);
+
+            // No configured tables, and no references, so nothing happens
+            tester.Config.StateStorage.KnownObjectsStore = null;
+            tester.Config.StateStorage.KnownVariablesStore = null;
+            tester.Config.StateStorage.KnownReferencesStore = null;
+            var toDelete = await manager.GetDiffAndStoreIds(result, tester.Source.Token);
+            Assert.Empty(toDelete.Objects);
+            Assert.Empty(toDelete.Variables);
+            Assert.Empty(toDelete.References);
+            Assert.Empty(store.States);
+
+            tester.Config.StateStorage = new StateStorageConfig();
+
+            // This time there is a store and data, so we get some states, nothing reported as deleted yet.
+            toDelete = await manager.GetDiffAndStoreIds(result, tester.Source.Token);
+            Assert.Empty(toDelete.Objects);
+            Assert.Empty(toDelete.Variables);
+            Assert.Empty(toDelete.References);
+            Assert.Equal(3, store.States.Count);
+            Assert.Equal(2, store.States["known_references"].Count);
+
+            // Remove one each of objects, variables, and references, so we get a removed of each
+            result = new NodeSourceResult(
+                Enumerable.Empty<UANode>(),
+                Enumerable.Empty<UAVariable>(),
+                new[] { GetObject("obj2") },
+                new[] { GetVariable("var2") },
+                new[] { GetReference("var1", "var2", refManager) }, true);
+
+            toDelete = await manager.GetDiffAndStoreIds(result, tester.Source.Token);
+            Assert.Single(toDelete.Objects);
+            Assert.Single(toDelete.Variables);
+            Assert.Single(toDelete.References);
+            Assert.Equal(3, store.States.Count);
+            Assert.Single(store.States["known_references"]);
+        }
+    }
+}

--- a/Test/Unit/DeleteTest.cs
+++ b/Test/Unit/DeleteTest.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 using Test.Utils;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace Test.Unit
 {


### PR DESCRIPTION
System to store known nodes and identify which has been deleted. This does not yet do anything in the extractor, it is just utility code that we will use to mark deletes later.