### PR TITLE
Pass delete request to pushers

### DIFF
--- a/Extractor/Deletes.cs
+++ b/Extractor/Deletes.cs
@@ -34,6 +34,14 @@ namespace Cognite.OpcUa
             Variables = Enumerable.Empty<string>();
             References = Enumerable.Empty<string>();
         }
+
+        public DeletedNodes Merge(DeletedNodes other)
+        {
+            return new DeletedNodes(
+                Objects.Concat(other.Objects).Distinct().ToList(),
+                Variables.Concat(other.Variables).Distinct().ToList(),
+                References.Concat(other.References).Distinct().ToList());
+        }
     }
 
     public class DeletesManager

--- a/Extractor/Looper.cs
+++ b/Extractor/Looper.cs
@@ -138,12 +138,9 @@ namespace Cognite.OpcUa
                     var toInit = recovered.Select(pair => pair.pusher).Where(pusher => !pusher.Initialized);
                     foreach (var pusher in toInit)
                     {
-                        var (nodes, timeseries) = ExtractorUtils.SortNodes(pusher.PendingNodes);
-                        var references = pusher.PendingReferences.ToList();
-                        pusher.PendingNodes.Clear();
-                        pusher.PendingReferences.Clear();
                         pusher.NoInit = false;
-                        tasks.Add(extractor.PushNodes(nodes, timeseries, references, pusher, true));
+                        tasks.Add(extractor.PushNodes(pusher.PendingNodes, pusher, true));
+                        pusher.PendingNodes = null;
                     }
 
                     await Task.WhenAll(tasks);

--- a/Extractor/NodeSources/NodeSourceResult.cs
+++ b/Extractor/NodeSources/NodeSourceResult.cs
@@ -15,8 +15,12 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. */
 
+using Cognite.Extractor.Common;
 using Cognite.OpcUa.Types;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Cognite.OpcUa.NodeSources
 {
@@ -47,5 +51,69 @@ namespace Cognite.OpcUa.NodeSources
         public IEnumerable<UAReference> DestinationReferences { get; }
 
         public bool CanBeUsedForDeletes { get; }
+    }
+
+    /// <summary>
+    /// Data passed to pushers
+    /// </summary>
+    public class PusherInput
+    {
+        public IEnumerable<UANode> Objects { get; }
+        public IEnumerable<UAVariable> Variables { get; }
+        public IEnumerable<UAReference> References { get; }
+        public DeletedNodes? Deletes { get; }
+
+        public PusherInput(IEnumerable<UANode> objects, IEnumerable<UAVariable> variables, IEnumerable<UAReference> references, DeletedNodes? deletes)
+        {
+            Objects = objects;
+            Variables = variables;
+            References = references;
+            Deletes = deletes;
+        }
+
+        public static async Task<PusherInput> FromNodeSourceResult(NodeSourceResult result, DeletesManager? deletesManager, CancellationToken token)
+        {
+            DeletedNodes? deleted = null;
+            if (deletesManager != null)
+            {
+                deleted = await deletesManager.GetDiffAndStoreIds(result, token);
+            }
+            return new PusherInput(result.DestinationObjects, result.DestinationVariables, result.DestinationReferences, deleted);
+        }
+
+        public PusherInput Merge(PusherInput other, FullPushResult result)
+        {
+            var objects = result.Objects ? Enumerable.Empty<UANode>() : Objects.Concat(other.Objects).DistinctBy(n => n.Id).ToList();
+            var variables = result.Variables ? Enumerable.Empty<UAVariable>() : Variables.Concat(other.Variables).DistinctBy(n => (n.Index, n.Id)).ToList();
+            var references = result.References ? Enumerable.Empty<UAReference>() : References.Concat(other.References).DistinctBy(n => (n.Source.Id, n.Target.Id, n.Type.Id)).ToList();
+
+            if (result.Variables && !result.Ranges)
+            {
+                variables = Variables.Concat(other.Variables.Where(v => v.ReadHistory)).DistinctBy(n => (n.Index, n.Id)).ToList();
+            }
+
+            var deleted = result.Deletes ? null : Deletes?.Merge(other.Deletes!);
+
+            return new PusherInput(objects, variables, references, deleted);
+        }
+    }
+
+    /// <summary>
+    /// Class containing a summary of the result of pushing to a destination.
+    /// </summary>
+    public class FullPushResult
+    {
+        public bool Objects { get; set; }
+        public bool Variables { get; set; }
+        public bool References { get; set; }
+        public bool Deletes { get; set; }
+        public bool Ranges { get; set; }
+
+        public void Apply(PushResult result)
+        {
+            Objects = result.Objects;
+            Variables = result.Variables;
+            References = result.References;
+        }
     }
 }

--- a/Extractor/Pushers/CDFPusher.cs
+++ b/Extractor/Pushers/CDFPusher.cs
@@ -50,8 +50,8 @@ namespace Cognite.OpcUa.Pushers
         public bool Initialized { get; set; }
         public bool NoInit { get; set; }
 
-        public List<UANode> PendingNodes { get; } = new List<UANode>();
-        public List<UAReference> PendingReferences { get; } = new List<UAReference>();
+        public PusherInput? PendingNodes { get; set; }
+
         public UAExtractor Extractor { get; set; } = null!;
         public IPusherConfig BaseConfig { get; }
 

--- a/Extractor/Pushers/IPusher.cs
+++ b/Extractor/Pushers/IPusher.cs
@@ -16,6 +16,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. */
 
 using Cognite.OpcUa.History;
+using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.Types;
 using System;
 using System.Collections.Generic;
@@ -48,11 +49,19 @@ namespace Cognite.OpcUa
         /// <summary>
         /// Nodes not yet pushed due to pusher failure, should be cleared to free up memory after a successfull push.
         /// </summary>
-        List<UANode> PendingNodes { get; }
-        /// <summary>
-        /// References not yet pushed due to pusher failure.
-        /// </summary>
-        List<UAReference> PendingReferences { get; }
+        PusherInput? PendingNodes { get; set; }
+
+        public void AddPendingNodes(PusherInput pending, FullPushResult result)
+        {
+            if (PendingNodes is null)
+            {
+                PendingNodes = pending;
+            }
+            else
+            {
+                PendingNodes = PendingNodes.Merge(pending, result);
+            }
+        }
 
         /// <summary>
         /// Push nodes, emptying the queue
@@ -114,6 +123,17 @@ namespace Cognite.OpcUa
         Task<bool?> PushDataPoints(IEnumerable<UADataPoint> points, CancellationToken token)
         {
             return Task.FromResult((bool?)true);
+        }
+
+        /// <summary>
+        /// Mark the given nodes as deleted in destinations.
+        /// </summary>
+        /// <param name="deletes"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<bool> ExecuteDeletes(DeletedNodes deletes, CancellationToken token)
+        {
+            return Task.FromResult(true);
         }
 
         /// <summary>

--- a/Extractor/Pushers/IPusher.cs
+++ b/Extractor/Pushers/IPusher.cs
@@ -51,15 +51,17 @@ namespace Cognite.OpcUa
         /// </summary>
         PusherInput? PendingNodes { get; set; }
 
-        public void AddPendingNodes(PusherInput pending, FullPushResult result)
+
+        void AddPendingNodes(PusherInput pending, FullPushResult result)
         {
+            var filtered = pending.Filter(result);
             if (PendingNodes is null)
             {
-                PendingNodes = pending;
+                PendingNodes = filtered;
             }
             else
             {
-                PendingNodes = PendingNodes.Merge(pending, result);
+                PendingNodes = PendingNodes.Merge(filtered);
             }
         }
 

--- a/Extractor/Pushers/InfluxPusher.cs
+++ b/Extractor/Pushers/InfluxPusher.cs
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
 using AdysTech.InfluxDB.Client.Net;
 using Cognite.Extractor.Common;
 using Cognite.OpcUa.History;
+using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.Types;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
@@ -43,8 +44,7 @@ namespace Cognite.OpcUa
         public bool EventsFailing { get; set; }
         public bool Initialized { get; set; }
         public bool NoInit { get; set; }
-        public List<UANode> PendingNodes { get; } = new List<UANode>();
-        public List<UAReference> PendingReferences { get; } = new List<UAReference>();
+        public PusherInput? PendingNodes { get; set; }
 
         private readonly DateTime minTs = DateTime.Parse("1677-09-21T00:12:43.145224194Z");
         private readonly DateTime maxTs = DateTime.Parse("2262-04-11T23:47:16.854775806Z");

--- a/Extractor/Pushers/MqttPusher.cs
+++ b/Extractor/Pushers/MqttPusher.cs
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
 using Cognite.Extensions;
 using Cognite.Extractor.Common;
 using Cognite.Extractor.StateStorage;
+using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.Types;
 using CogniteSdk;
 using Com.Cognite.V1.Timeseries.Proto;
@@ -45,8 +46,7 @@ namespace Cognite.OpcUa.Pushers
         public bool EventsFailing { get; set; }
         public bool Initialized { get; set; }
         public bool NoInit { get; set; }
-        public List<UANode> PendingNodes { get; } = new List<UANode>();
-        public List<UAReference> PendingReferences { get; } = new List<UAReference>();
+        public PusherInput? PendingNodes { get; set; }
         public UAExtractor Extractor { get; set; } = null!;
         public IPusherConfig BaseConfig => config;
         private readonly MqttPusherConfig config;

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -855,9 +855,15 @@ namespace Cognite.OpcUa
         /// <param name="pusher">Destination to push to</param>
         /// <param name="initial">True if this counts as initialization of the pusher</param>
         public async Task PushNodes(
-            PusherInput input,
+            PusherInput? input,
             IPusher pusher, bool initial)
         {
+            if (input == null)
+            {
+                log.LogWarning("No input given to pusher {Name}, not initializing", pusher.GetType());
+                return;
+            }
+
             var result = new FullPushResult();
             if (pusher.NoInit)
             {
@@ -866,7 +872,7 @@ namespace Cognite.OpcUa
                 return;
             }
 
-            log.LogInformation("Executing pushes on pusher {Type}", pushers.GetType());
+            log.LogInformation("Executing pushes on pusher {Type}", pusher.GetType());
 
             if (input.Objects.Any() || input.Variables.Any() || input.References.Any())
             {

--- a/Server/NodeManager.cs
+++ b/Server/NodeManager.cs
@@ -328,6 +328,19 @@ namespace Server
             prop.Delete(SystemContext);
         }
 
+        public void RemoveNode(NodeId id)
+        {
+            log.LogDebug("Remove node with ID {Id}", id);
+
+            var node = PredefinedNodes[id];
+            var refsToRemove = new List<LocalReference>();
+            RemovePredefinedNode(SystemContext, node, refsToRemove);
+            if (refsToRemove.Any())
+            {
+                Server.NodeManager.RemoveReferences(refsToRemove);
+            }
+        }
+
         public void ReContextualize(NodeId id, NodeId oldParentId, NodeId newParentId, NodeId referenceType)
         {
             log.LogDebug("Move node {Id} from {Old} to {New} with reference type {Ref}",

--- a/Server/TestServer.cs
+++ b/Server/TestServer.cs
@@ -256,6 +256,10 @@ namespace Server
         {
             custom.RemoveProperty(parentId, name);
         }
+        public void RemoveNode(NodeId id)
+        {
+            custom.RemoveNode(id);
+        }
         public void MutateNode(NodeId id, Action<NodeState> mutation)
         {
             if (mutation == null) throw new ArgumentNullException(nameof(mutation));

--- a/Test/Integration/NodeExtractionTests.cs
+++ b/Test/Integration/NodeExtractionTests.cs
@@ -736,8 +736,9 @@ namespace Test.Integration
 
             Assert.Empty(pusher.PushedNodes);
             Assert.Empty(pusher.PushedVariables);
-            Assert.Equal(22, pusher.PendingNodes.Count);
-            Assert.Equal(32, pusher.PendingReferences.Count);
+            Assert.Equal(6, pusher.PendingNodes.Objects.Count());
+            Assert.Equal(16, pusher.PendingNodes.Variables.Count());
+            Assert.Equal(32, pusher.PendingNodes.References.Count());
 
             Assert.False(pusher.Initialized);
 
@@ -788,12 +789,13 @@ namespace Test.Integration
             {
                 Assert.Empty(pusher.PushedNodes);
                 Assert.Empty(pusher.PushedVariables);
-                Assert.Equal(22, pusher.PendingNodes.Count);
+                Assert.Equal(6, pusher.PendingNodes.Objects.Count());
+                Assert.Equal(16, pusher.PendingNodes.Variables.Count());
             }
             if (failReferences)
             {
                 Assert.Empty(pusher.PushedReferences);
-                Assert.Equal(32, pusher.PendingReferences.Count);
+                Assert.Equal(32, pusher.PendingNodes.References.Count());
             }
 
 

--- a/Test/Unit/LooperTest.cs
+++ b/Test/Unit/LooperTest.cs
@@ -1,6 +1,7 @@
 ﻿using Cognite.Extractor.Testing;
 using Cognite.OpcUa;
 using Cognite.OpcUa.History;
+using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.Types;
 using Opc.Ua;
 using System;
@@ -271,16 +272,6 @@ namespace Test.Unit
             Assert.Equal(100, evts3.Count);
 
             // Add some missing nodes to each of the pushers, and verify that they are pushed on recovery
-
-            var nodes = new List<UANode>
-            {
-                new UANode(new NodeId("missing1"), "missing1", new NodeId("test"), NodeClass.Object),
-                new UAVariable(new NodeId("missing2"), "missing2", new NodeId("test"))
-            };
-
-            pusher1.PendingNodes.AddRange(nodes);
-            pusher2.PendingNodes.Add(nodes.First());
-
             var refManager = extractor.ReferenceTypeManager;
 
             var reference = new UAReference(
@@ -292,8 +283,21 @@ namespace Test.Unit
                 false,
                 refManager);
 
-            pusher1.PendingReferences.Add(reference);
-            pusher2.PendingReferences.Add(reference);
+            var objects = new[] { new UANode(new NodeId("missing1"), "missing1", new NodeId("test"), NodeClass.Object) };
+            var variables = new[] { new UAVariable(new NodeId("missing2"), "missing2", new NodeId("test")) };
+
+            var input = new PusherInput(
+                objects,
+                variables,
+                new[] { reference }, null);
+
+            var input2 = new PusherInput(
+                objects,
+                Enumerable.Empty<UAVariable>(),
+                new[] { reference }, null);
+
+            (pusher1 as IPusher).AddPendingNodes(input, new FullPushResult());
+            (pusher2 as IPusher).AddPendingNodes(input2, new FullPushResult());
 
             extractor.Streamer.Enqueue(dps);
             extractor.Streamer.Enqueue(evts);
@@ -320,10 +324,8 @@ namespace Test.Unit
             Assert.True(pusher1.Initialized);
             Assert.True(pusher2.Initialized);
 
-            Assert.Empty(pusher1.PendingNodes);
-            Assert.Empty(pusher1.PendingReferences);
-            Assert.Empty(pusher2.PendingNodes);
-            Assert.Empty(pusher2.PendingReferences);
+            Assert.Null(pusher1.PendingNodes);
+            Assert.Null(pusher2.PendingNodes);
         }
     }
 }

--- a/Test/Utils/DummyPusher.cs
+++ b/Test/Utils/DummyPusher.cs
@@ -1,6 +1,7 @@
 ﻿using Cognite.Extractor.Common;
 using Cognite.OpcUa;
 using Cognite.OpcUa.History;
+using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.Types;
 using Opc.Ua;
 using System;
@@ -55,9 +56,7 @@ namespace Test.Utils
         public HashSet<UAReference> PushedReferences { get; }
             = new HashSet<UAReference>();
 
-        public List<UANode> PendingNodes { get; } = new List<UANode>();
-
-        public List<UAReference> PendingReferences { get; } = new List<UAReference>();
+        public PusherInput PendingNodes { get; set; }
 
         public DummyPusher(DummyPusherConfig config)
         {

--- a/Test/Utils/DummyPusher.cs
+++ b/Test/Utils/DummyPusher.cs
@@ -231,6 +231,7 @@ namespace Test.Utils
         public Task<bool> ExecuteDeletes(DeletedNodes deletes, CancellationToken token)
         {
             LastDeleteReq = deletes;
+
             return Task.FromResult(DeleteResult);
         }
 

--- a/Test/Utils/DummyPusher.cs
+++ b/Test/Utils/DummyPusher.cs
@@ -32,6 +32,7 @@ namespace Test.Utils
         public bool? PushDataPointResult { get; set; } = true;
         public bool? PushEventResult { get; set; } = true;
         public bool PushReferenceResult { get; set; } = true;
+        public bool DeleteResult { get; set; } = true;
         public ManualResetEvent OnReset { get; } = new ManualResetEvent(false);
 
         private readonly object dpLock = new object();
@@ -48,6 +49,7 @@ namespace Test.Utils
 
         public UAExtractor Extractor { get; set; }
 
+        public DeletedNodes LastDeleteReq { get; set; }
 
         public Dictionary<NodeId, UANode> PushedNodes { get; }
             = new Dictionary<NodeId, UANode>();
@@ -224,6 +226,12 @@ namespace Test.Utils
             }
 
             return Task.FromResult(PushDataPointResult);
+        }
+
+        public Task<bool> ExecuteDeletes(DeletedNodes deletes, CancellationToken token)
+        {
+            LastDeleteReq = deletes;
+            return Task.FromResult(DeleteResult);
         }
 
         public void Reset()


### PR DESCRIPTION
This ended up being somewhat more complicated than expected. The PushNodes methods in UAExtractor were not really that well suited to get a list of nodes to delete as well, and required a small rewrite. The system for caching nodes that failed during the initial push also required a little work. The result is (IMO) a lot cleaner, and makes a lot more sense.

Beyond that we now have an ExecuteDeletes method on IPusher, which can be implemented for CDFPusher to handle deletes.