### PR TITLE
Delete in cdf

### DIFF
--- a/Extractor/Config.cs
+++ b/Extractor/Config.cs
@@ -589,6 +589,12 @@ namespace Cognite.OpcUa
         /// Enable deletes.
         /// </summary>
         public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Name of marker for indicating that a node is deleted.
+        /// Added to metadata, as a column on raw rows, or similar.
+        /// </summary>
+        public string DeleteMarker { get; set; } = "deleted";
     }
 
     public class DataSubscriptionConfig
@@ -734,6 +740,13 @@ namespace Cognite.OpcUa
         /// reporting the number changed.
         /// </summary>
         public BrowseCallbackConfig? BrowseCallback { get; set; }
+
+        /// <summary>
+        /// There is no good way to mark relationships as deleted, so they are hard-deleted.
+        /// This has to be enabled to delete relationships deleted from OPC-UA. This requires extraction.deletes to be enabled.
+        /// Alternatively, use Raw, where relationships can be marked as deleted.
+        /// </summary>
+        public bool DeleteRelationships { get; set; }
     }
     public class RawMetadataConfig
     {

--- a/Extractor/Deletes.cs
+++ b/Extractor/Deletes.cs
@@ -73,9 +73,7 @@ namespace Cognite.OpcUa
 
         private async Task<IEnumerable<string>> GetDeletedItems(string? tableName, Dictionary<string, NodeExistsState> states, CancellationToken token)
         {
-            // If there are no states we don't check for deletes. This means we can't ever delete the _last_ of a type, but that is likely to be
-            // an issue or a bug either way.
-            if (tableName == null || !states.Any()) return Enumerable.Empty<string>();
+            if (tableName == null) return Enumerable.Empty<string>();
 
             var oldStates = await GetExistingStates(tableName, token);
 

--- a/Extractor/Pushers/CDFPusher.cs
+++ b/Extractor/Pushers/CDFPusher.cs
@@ -538,7 +538,7 @@ namespace Cognite.OpcUa.Pushers
             }
             if (deletes.Variables.Any())
             {
-                tasks.Add(MarkTimeSeriesAsDeleted(deletes.Objects, token));
+                tasks.Add(MarkTimeSeriesAsDeleted(deletes.Variables, token));
             }
             if (deletes.References.Any())
             {
@@ -1223,7 +1223,7 @@ namespace Cognite.OpcUa.Pushers
             {
                 await MarkRawRowsAsDeleted(config.RawMetadata!.Database!, config.RawMetadata!.RelationshipsTable!, externalIds, token);
             }
-            else
+            else if (config.DeleteRelationships)
             {
                 var tasks = externalIds.ChunkBy(1000).Select(chunk => destination.CogniteClient.Relationships.DeleteAsync(chunk, true, token));
                 await Task.WhenAll(tasks);

--- a/Server/ServerController.cs
+++ b/Server/ServerController.cs
@@ -83,7 +83,7 @@ namespace Server
                 await app.CheckApplicationInstanceCertificate(false, 0);
                 Server = new TestServer(setups, mqttUrl, provider, logTrace);
                 await Task.Run(async () => await app.Start(Server));
-                log.LogInformation("Server started on address: {address}", address);
+                log.LogInformation("Server started on address: {Address}", address);
                 running = true;
             }
             catch (Exception e)

--- a/Test/CDFMockHandler.cs
+++ b/Test/CDFMockHandler.cs
@@ -226,6 +226,9 @@ namespace Test
                         case "/relationships":
                             res = HandleCreateRelationships(content);
                             break;
+                        case "/relationships/delete":
+                            res = HandleDeleteRelationships(content);
+                            break;
                         case "/datasets/byids":
                             res = HandleRetrieveDataSets(content);
                             break;
@@ -878,6 +881,7 @@ namespace Test
                     {
                         foreach (var field in upd.metadata.add)
                         {
+                            log.LogInformation("Add metadata: {Field}", field.Key);
                             old.metadata[field.Key] = field.Value;
                         }
                     }
@@ -957,6 +961,7 @@ namespace Test
                     {
                         foreach (var field in upd.metadata.add)
                         {
+                            log.LogInformation("Add metadata: {Field}", field.Key);
                             old.metadata[field.Key] = field.Value;
                         }
                     }
@@ -973,6 +978,21 @@ namespace Test
                 Content = new StringContent(JsonConvert.SerializeObject(result))
             };
         }
+
+        private HttpResponseMessage HandleDeleteRelationships(string content)
+        {
+            var data = JsonConvert.DeserializeObject<ItemsWithoutCursor<CogniteExternalId>>(content);
+            foreach (var id in data.Items)
+            {
+                Relationships.Remove(id.ExternalId);
+            }
+            return new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{}")
+            };
+        }
+
 
         private HttpResponseMessage HandleCallFunction(string content)
         {
@@ -1285,6 +1305,7 @@ namespace Test
         public string targetType { get; set; }
         public long createdTime { get; set; }
         public long lastUpdatedTime { get; set; }
+        public bool deleted { get; set; }
     }
     public class RelationshipsReadWrapper
     {

--- a/Test/Unit/DeleteTest.cs
+++ b/Test/Unit/DeleteTest.cs
@@ -47,7 +47,7 @@ namespace Test.Unit
             if (!States.TryGetValue(tableName, out var state))
             {
                 if (ThrowOnMissingTable) throw new InvalidOperationException("Table does not exist!");
-                States[tableName] = state = new Dictionary<string, BaseStorableState>();
+                return Task.FromResult(Enumerable.Empty<T>());
             }
             return Task.FromResult(state.Values.OfType<T>());
         }
@@ -157,6 +157,7 @@ namespace Test.Unit
             // No configured tables, and no references, so nothing happens
             tester.Config.StateStorage.KnownObjectsStore = null;
             tester.Config.StateStorage.KnownVariablesStore = null;
+            tester.Config.StateStorage.KnownReferencesStore = null;
             toDelete = await manager.GetDiffAndStoreIds(result, tester.Source.Token);
             Assert.Empty(toDelete.Objects);
             Assert.Empty(toDelete.Variables);

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,6 +3,7 @@ storage: none
 
 nuget Cognite.ExtractorUtils
 nuget Cognite.Extractor.Testing
+nuget CogniteSdk 3.7.0
 nuget Microsoft.CSharp
 nuget coverlet.msbuild
 nuget Microsoft.NET.Test.Sdk
@@ -11,7 +12,7 @@ nuget xunit.runner.visualstudio
 nuget OPCFoundation.NetStandard.Opc.Ua.Client
 nuget OPCFoundation.NetStandard.Opc.Ua.Configuration
 nuget OPCFoundation.NetStandard.Opc.Ua.Server
-nuget OPCFoundation.NetStandard.Opc.Ua.PubSub 1.4.371.50-beta
+nuget OPCFoundation.NetStandard.Opc.Ua.PubSub 1.4.371.60-beta
 nuget AdysTech.InfluxDB.Client.Net.Core
 nuget Microsoft.Windows.Compatibility
 nuget Microsoft.Extensions.Hosting.WindowsServices

--- a/paket.lock
+++ b/paket.lock
@@ -57,18 +57,18 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 6.0.1) - restriction: >= netstandard2.0
       StackExchange.Redis (>= 2.6.48) - restriction: >= netstandard2.0
       System.CommandLine (>= 2.0.0-beta4.22272.1) - restriction: >= netstandard2.0
-    CogniteSdk (3.6) - restriction: >= netstandard2.0
-      CogniteSdk.Types (>= 3.6) - restriction: >= netstandard2.0
+    CogniteSdk (3.7)
+      CogniteSdk.Types (>= 3.7) - restriction: >= netstandard2.0
       Oryx (>= 5.0.2) - restriction: >= netstandard2.0
-      Oryx.Cognite (>= 3.6) - restriction: >= netstandard2.0
+      Oryx.Cognite (>= 3.7) - restriction: >= netstandard2.0
     CogniteSdk.Protobuf (1.0.3) - restriction: >= netstandard2.0
       Google.Protobuf (>= 3.19.4) - restriction: >= netstandard2.0
-    CogniteSdk.Types (3.6) - restriction: >= netstandard2.0
+    CogniteSdk.Types (3.7) - restriction: >= netstandard2.0
       System.Text.Json (>= 6.0.2) - restriction: >= netstandard2.0
     coverlet.msbuild (3.2)
     Cronos (0.7.1) - restriction: >= netstandard2.0
     FSharp.Core (7.0) - restriction: >= netstandard2.0
-    FsToolkit.ErrorHandling (4.2.1) - restriction: >= netstandard2.0
+    FsToolkit.ErrorHandling (4.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: && (>= netstandard2.0) (< netstandard2.1)
       FSharp.Core (>= 7.0) - restriction: >= netstandard2.1
     Google.Protobuf (3.21.12) - restriction: >= netstandard2.0
@@ -252,7 +252,7 @@ NUGET
       System.Xml.XmlDocument (>= 4.3) - restriction: && (< net6.0) (>= xamarinios)
       Xamarin.Android.Support.CustomTabs (>= 28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< netcoreapp2.1)
       Xamarin.AndroidX.Browser (>= 1.0) - restriction: && (>= monoandroid10.0) (< net6.0)
-    Microsoft.IdentityModel.Abstractions (6.25.1) - restriction: || (&& (>= monoandroid10.0) (< net6.0)) (&& (< monoandroid10.0) (>= monoandroid9.0) (< netcoreapp2.1)) (&& (< monoandroid9.0) (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios)) (&& (< monoandroid9.0) (>= net6.0) (< xamarinios)) (&& (< monoandroid9.0) (< net6.0) (>= netcoreapp2.1) (< xamarinios)) (&& (>= net461) (>= netstandard2.0)) (&& (< net6.0) (>= xamarinios)) (>= net6.0-android) (>= net6.0-ios) (>= net6.0-windows10.0.17763.0)
+    Microsoft.IdentityModel.Abstractions (6.26) - restriction: || (&& (>= monoandroid10.0) (< net6.0)) (&& (< monoandroid10.0) (>= monoandroid9.0) (< netcoreapp2.1)) (&& (< monoandroid9.0) (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios)) (&& (< monoandroid9.0) (>= net6.0) (< xamarinios)) (&& (< monoandroid9.0) (< net6.0) (>= netcoreapp2.1) (< xamarinios)) (&& (>= net461) (>= netstandard2.0)) (&& (< net6.0) (>= xamarinios)) (>= net6.0-android) (>= net6.0-ios) (>= net6.0-windows10.0.17763.0)
     Microsoft.Net.Native.Compiler (2.2.12-rel-31116-00) - restriction: >= uap10.1
       runtime.win10-arm.Microsoft.Net.Native.Compiler (>= 2.2.12-rel-31116-00)
       runtime.win10-arm64.Microsoft.Net.Native.Compiler (>= 2.2.12-rel-31116-00)
@@ -391,34 +391,34 @@ NUGET
       System.Xml.XDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
     Newtonsoft.Json (13.0.2) - restriction: || (>= net46) (>= netstandard2.0)
     NuGet.Frameworks (6.4) - restriction: >= netcoreapp3.1
-    OPCFoundation.NetStandard.Opc.Ua.Client (1.4.371.50)
-      OPCFoundation.NetStandard.Opc.Ua.Configuration (>= 1.4.371.50) - restriction: || (>= net462) (>= netstandard2.0)
-      OPCFoundation.NetStandard.Opc.Ua.Core (>= 1.4.371.50) - restriction: || (>= net462) (>= netstandard2.0)
-    OPCFoundation.NetStandard.Opc.Ua.Configuration (1.4.371.50)
-      OPCFoundation.NetStandard.Opc.Ua.Core (>= 1.4.371.50) - restriction: || (>= net462) (>= netstandard2.0)
-    OPCFoundation.NetStandard.Opc.Ua.Core (1.4.371.50) - restriction: || (>= net462) (>= netstandard2.0)
+    OPCFoundation.NetStandard.Opc.Ua.Client (1.4.371.60)
+      OPCFoundation.NetStandard.Opc.Ua.Configuration (>= 1.4.371.60) - restriction: || (>= net462) (>= netstandard2.0)
+      OPCFoundation.NetStandard.Opc.Ua.Core (>= 1.4.371.60) - restriction: || (>= net462) (>= netstandard2.0)
+    OPCFoundation.NetStandard.Opc.Ua.Configuration (1.4.371.60)
+      OPCFoundation.NetStandard.Opc.Ua.Core (>= 1.4.371.60) - restriction: || (>= net462) (>= netstandard2.0)
+    OPCFoundation.NetStandard.Opc.Ua.Core (1.4.371.60) - restriction: || (>= net462) (>= netstandard2.0)
       Microsoft.Extensions.Logging.Abstractions (>= 3.1.28) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.1)) (&& (>= netstandard2.0) (< netstandard2.1))
       Microsoft.Extensions.Logging.Abstractions (>= 6.0.2) - restriction: >= net6.0
       Newtonsoft.Json (>= 13.0.2) - restriction: || (>= net462) (>= netstandard2.0)
-      OPCFoundation.NetStandard.Opc.Ua.Security.Certificates (>= 1.4.371.50) - restriction: || (>= net462) (>= netstandard2.0)
-    OPCFoundation.NetStandard.Opc.Ua.PubSub (1.4.371.50-beta)
+      OPCFoundation.NetStandard.Opc.Ua.Security.Certificates (>= 1.4.371.60) - restriction: || (>= net462) (>= netstandard2.0)
+    OPCFoundation.NetStandard.Opc.Ua.PubSub (1.4.371.60-beta)
       MQTTnet (>= 3.1.1) - restriction: || (>= net462) (>= netstandard2.0)
-      OPCFoundation.NetStandard.Opc.Ua.Core (>= 1.4.371.50) - restriction: || (>= net462) (>= netstandard2.0)
+      OPCFoundation.NetStandard.Opc.Ua.Core (>= 1.4.371.60) - restriction: || (>= net462) (>= netstandard2.0)
       System.Net.NetworkInformation (>= 4.3) - restriction: || (>= net462) (>= netstandard2.0)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: && (>= net462) (< net48)
-    OPCFoundation.NetStandard.Opc.Ua.Security.Certificates (1.4.371.50) - restriction: || (>= net462) (>= netstandard2.0)
+    OPCFoundation.NetStandard.Opc.Ua.Security.Certificates (1.4.371.60) - restriction: || (>= net462) (>= netstandard2.0)
       Portable.BouncyCastle (>= 1.9) - restriction: || (>= net462) (&& (>= netstandard2.0) (< netstandard2.1))
       System.Formats.Asn1 (>= 6.0) - restriction: || (>= net462) (>= netstandard2.0)
-    OPCFoundation.NetStandard.Opc.Ua.Server (1.4.371.50)
-      OPCFoundation.NetStandard.Opc.Ua.Configuration (>= 1.4.371.50) - restriction: || (>= net462) (>= netstandard2.0)
-      OPCFoundation.NetStandard.Opc.Ua.Core (>= 1.4.371.50) - restriction: || (>= net462) (>= netstandard2.0)
+    OPCFoundation.NetStandard.Opc.Ua.Server (1.4.371.60)
+      OPCFoundation.NetStandard.Opc.Ua.Configuration (>= 1.4.371.60) - restriction: || (>= net462) (>= netstandard2.0)
+      OPCFoundation.NetStandard.Opc.Ua.Core (>= 1.4.371.60) - restriction: || (>= net462) (>= netstandard2.0)
     Oryx (5.0.2) - restriction: >= netstandard2.0
       FSharp.Core (>= 6.0.3) - restriction: >= netstandard2.0
       FsToolkit.ErrorHandling (>= 2.13) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 5.0) - restriction: >= netstandard2.0
-    Oryx.Cognite (3.6) - restriction: >= netstandard2.0
+    Oryx.Cognite (3.7) - restriction: >= netstandard2.0
       CogniteSdk.Protobuf (>= 1.0.3) - restriction: >= netstandard2.0
-      CogniteSdk.Types (>= 3.6) - restriction: >= netstandard2.0
+      CogniteSdk.Types (>= 3.7) - restriction: >= netstandard2.0
       FSharp.Core (>= 6.0.3) - restriction: >= netstandard2.0
       Oryx (>= 5.0.2) - restriction: >= netstandard2.0
       Oryx.Protobuf (>= 5.0.2) - restriction: >= netstandard2.0
@@ -1298,7 +1298,7 @@ NUGET
       Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
       Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid9.0
       Xamarin.Android.Support.CustomView (28.0.0.3) - restriction: >= monoandroid9.0
-    Xamarin.AndroidX.Browser (1.4.0.3) - restriction: && (>= monoandroid10.0) (< net6.0)
+    Xamarin.AndroidX.Browser (1.4.0.4) - restriction: && (>= monoandroid10.0) (< net6.0)
     xunit (2.4.2)
       xunit.analyzers (>= 1.0)
       xunit.assert (>= 2.4.2)


### PR DESCRIPTION
Adds support for deletes to the CDF Pusher. Relationships cannot be soft deleted in any practical way, so there is a separate option to hard-delete them.