### PR TITLE
Workaround for servers behind NAT

### DIFF
--- a/Extractor/Config.cs
+++ b/Extractor/Config.cs
@@ -50,6 +50,8 @@ namespace Cognite.OpcUa
         /// Alternate endpoint URLs, used for redundancy if the server supports it.
         /// </summary>
         public IEnumerable<string>? AltEndpointUrls { get; set; }
+
+        public EndpointDetails? EndpointDetails { get; set; }
         /// <summary>
         /// True to auto accept untrusted certificates.
         /// If this is false, server certificates must be trusted by manually moving them to the "trusted" certificates folder.
@@ -203,6 +205,11 @@ namespace Cognite.OpcUa
         /// </summary>
         public UARetryConfig Retries { get => retries; set => retries = value ?? retries; }
         private UARetryConfig retries = new UARetryConfig();
+    }
+
+    public class EndpointDetails
+    {
+        public string? OverrideEndpointUrl { get; set; }
     }
 
     public class UARetryConfig : RetryUtilConfig

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -10,7 +10,8 @@
 version: 1
 
 source:
-    # The URL of the OPC-UA server to connect to
+    # The URL of the OPC-UA server to connect to.
+    # This is used as discovery URL.
     endpoint-url: "opc.tcp://localhost:4840"
     # A list of URLs to connect to if the endpoint-url fails.
     # These are connected to in order, and the one with the highest ServiceLevel is selected.
@@ -20,6 +21,11 @@ source:
     alt-endpoint-urls:
     # - opc.tcp://some-other-server:1234
     # - opc.tcp://some-third-server:4321
+    # Details used to override default endpoint behavior.
+    endpoint-details:
+        # Endpoint URL to override URLs returned from discovery.
+        # This can be used if the server is behind NAT, or similar URL rewrites.
+        override-endpoint-url:
     # Auto accept connections from unknown servers.
     # There is not yet a feature to accept new certificates, but you can manually move rejected certificates to accepted.
     # Paths are defined in opc.ua.net.extractor.Config.xml

--- a/schema/source_config.schema.json
+++ b/schema/source_config.schema.json
@@ -16,6 +16,17 @@
                 "description": "URL of OPC-UA server endpoint"
             }
         },
+        "endpoint-details": {
+            "type": "object",
+            "description": "Details used to override default endpoint behavior",
+            "unevaluatedProperties": false,
+            "properties": {
+                "override-endpoint-url": {
+                    "type": "string",
+                    "description": "Endpoint URL to override URLs returned from discovery. This can be used if the server is behind NAT, or similar URL rewrites."
+                }
+            }
+        },
         "auto-accept": {
             "type": "boolean",
             "default": true,


### PR DESCRIPTION
NAT (Network Address Translation) lets a server appear with a different discovery URL to the client than what it sees itself. Since the server likely doesn't know about this, the endpoints it exposes through discovery may have wrong host, port, etc.

This lets users override the returned endpoint URL.