### PR TITLE
Monitor service level

### DIFF
--- a/ConfigurationTool/ConfigToolRuntime.cs
+++ b/ConfigurationTool/ConfigToolRuntime.cs
@@ -50,7 +50,7 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public async Task Run(CancellationToken token)
         {
-            using var explorer = new UAServerExplorer(provider, config, baseConfig);
+            using var explorer = new UAServerExplorer(provider, config, baseConfig, token);
 
             using var source = CancellationTokenSource.CreateLinkedTokenSource(token);
 

--- a/ConfigurationTool/UAServerExplorer.cs
+++ b/ConfigurationTool/UAServerExplorer.cs
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. */
 
+using Cognite.Extractor.Common;
 using Cognite.OpcUa.Types;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -29,7 +30,7 @@ using System.Threading.Tasks;
 [assembly: CLSCompliant(false)]
 namespace Cognite.OpcUa.Config
 {
-    public partial class UAServerExplorer : UAClient
+    public partial class UAServerExplorer : UAClient, IClientCallbacks
     {
         private readonly FullConfig baseConfig;
         private readonly HashSet<UANode> dataTypes = new HashSet<UANode>();
@@ -44,17 +45,19 @@ namespace Cognite.OpcUa.Config
         private bool dataTypesRead;
         private bool nodeDataRead;
 
-        public UAServerExplorer(IServiceProvider provider, FullConfig config, FullConfig baseConfig) : base(provider, config)
+        public UAServerExplorer(IServiceProvider provider, FullConfig config, FullConfig baseConfig, CancellationToken token) : base(provider, config)
         {
             log = provider.GetRequiredService<ILogger<UAServerExplorer>>();
             this.provider = provider;
             this.baseConfig = baseConfig ?? new FullConfig();
             this.Config = config ?? throw new ArgumentNullException(nameof(config));
+            this.Callbacks = this;
 
             this.baseConfig.Source.EndpointUrl = config.Source.EndpointUrl;
             this.baseConfig.Source.Password = config.Source.Password;
             this.baseConfig.Source.Username = config.Source.Username;
             this.baseConfig.Source.Secure = config.Source.Secure;
+            scheduler = new PeriodicScheduler(token);
         }
         public Summary Summary { get; private set; } = new Summary();
         public void ResetSummary()
@@ -247,6 +250,29 @@ namespace Cognite.OpcUa.Config
             baseConfig.Extraction.NamespaceMap = namespaceMap;
         }
 
+        public Task OnServerDisconnect(UAClient source)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OnServerReconnect(UAClient source)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OnServiceLevelAboveThreshold(UAClient source)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OnServicelevelBelowThreshold(UAClient source)
+        {
+            return Task.CompletedTask;
+        }
+
         public FullConfig FinalConfig => baseConfig;
+
+        private PeriodicScheduler scheduler = null!;
+        public PeriodicScheduler TaskScheduler => scheduler;
     }
 }

--- a/Extractor/Config/SourceConfig.cs
+++ b/Extractor/Config/SourceConfig.cs
@@ -207,7 +207,8 @@ namespace Cognite.OpcUa.Config
 
         public bool IsRedundancyEnabled => EndpointUrl != null
             && AltEndpointUrls != null
-            && AltEndpointUrls.Any();
+            && AltEndpointUrls.Any()
+            && string.IsNullOrEmpty(ReverseConnectUrl);
     }
 
     public class EndpointDetails

--- a/Extractor/Config/SourceConfig.cs
+++ b/Extractor/Config/SourceConfig.cs
@@ -44,6 +44,11 @@ namespace Cognite.OpcUa.Config
         /// Alternate endpoint URLs, used for redundancy if the server supports it.
         /// </summary>
         public IEnumerable<string>? AltEndpointUrls { get; set; }
+        /// <summary>
+        /// Extra configuration options for redundancy
+        /// </summary>
+        public RedundancyConfig Redundancy { get => _redundancy; set => _redundancy = value ?? _redundancy; }
+        private RedundancyConfig _redundancy = new RedundancyConfig();
 
         public EndpointDetails? EndpointDetails { get; set; }
         /// <summary>
@@ -199,6 +204,10 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public UARetryConfig Retries { get => retries; set => retries = value ?? retries; }
         private UARetryConfig retries = new UARetryConfig();
+
+        public bool IsRedundancyEnabled => EndpointUrl != null
+            && AltEndpointUrls != null
+            && AltEndpointUrls.Any();
     }
 
     public class EndpointDetails
@@ -253,6 +262,14 @@ namespace Cognite.OpcUa.Config
                 return finalRetryStatusCodes;
             }
         }
+    }
+
+    public class RedundancyConfig
+    {
+        public int ServiceLevelThreshold { get; set; } = 200;
+        public TimeSpanWrapper ReconnectIntervalValue { get; } = new TimeSpanWrapper(true, "m", "10m");
+        public string ReconnectInterval { get => ReconnectIntervalValue.RawValue; set => ReconnectIntervalValue.RawValue = value; }
+        public bool MonitorServiceLevel { get; set; }
     }
 
     public enum X509CertificateLocation

--- a/Extractor/FailureBuffer.cs
+++ b/Extractor/FailureBuffer.cs
@@ -192,7 +192,7 @@ namespace Cognite.OpcUa
                     if (state == null || state.FrontfillEnabled) continue;
                     nodeBufferStates[key] = bufferState = new InfluxBufferState(state);
                 }
-                bufferState.UpdateDestinationRange(value.First, value.Last);
+                if (extractor.AllowUpdateState) bufferState.UpdateDestinationRange(value.First, value.Last);
             }
             if (config.InfluxStateStore && extractor.StateStorage != null)
             {
@@ -314,7 +314,7 @@ namespace Cognite.OpcUa
                     if (emitterState == null) continue;
                     eventBufferStates[group.Id] = bufferState = new InfluxBufferState(emitterState);
                 }
-                bufferState.UpdateDestinationRange(group.Range.Min, group.Range.Max);
+                if (extractor.AllowUpdateState) bufferState.UpdateDestinationRange(group.Range.Min, group.Range.Max);
             }
 
             if (config.InfluxStateStore && extractor.StateStorage != null)
@@ -459,7 +459,7 @@ namespace Cognite.OpcUa
                     {
                         var state = extractor.State.GetNodeState(group.Id);
                         if (state == null) continue;
-                        state.UpdateDestinationRange(group.Range.Min, group.Range.Max);
+                        if (extractor.AllowUpdateState) state.UpdateDestinationRange(group.Range.Min, group.Range.Max);
                     }
 
                 } while (!final && !token.IsCancellationRequested);
@@ -528,7 +528,7 @@ namespace Cognite.OpcUa
                     {
                         var state = extractor.State.GetEmitterState(group.Id);
                         if (state == null) continue;
-                        state.UpdateDestinationRange(group.Range.Min, group.Range.Max);
+                        if (extractor.AllowUpdateState) state.UpdateDestinationRange(group.Range.Min, group.Range.Max);
                     }
 
                 } while (!final && !token.IsCancellationRequested);

--- a/Extractor/History/HistoryScheduler.cs
+++ b/Extractor/History/HistoryScheduler.cs
@@ -499,11 +499,11 @@ namespace Cognite.OpcUa.History
 
             if (Frontfill)
             {
-                node.State.UpdateFromFrontfill(last, node.Completed);
+                if (extractor.AllowUpdateState) node.State.UpdateFromFrontfill(last, node.Completed);
             }
             else
             {
-                node.State.UpdateFromBackfill(first, node.Completed);
+                if (extractor.AllowUpdateState) node.State.UpdateFromBackfill(first, node.Completed);
             }
 
             int cnt = 0;
@@ -531,7 +531,7 @@ namespace Cognite.OpcUa.History
             if (buffered.Any())
             {
                 log.LogDebug("Read {Count} datapoints from buffer of state {Id}", buffered.Count(), node.State.Id);
-                nodeState.UpdateFromStream(buffered);
+                if (extractor.AllowUpdateState) nodeState.UpdateFromStream(buffered);
                 extractor.Streamer.Enqueue(buffered);
             }
         }
@@ -643,11 +643,11 @@ namespace Cognite.OpcUa.History
 
             if (Frontfill)
             {
-                node.State.UpdateFromFrontfill(last, node.Completed);
+                if (extractor.AllowUpdateState) node.State.UpdateFromFrontfill(last, node.Completed);
             }
             else
             {
-                node.State.UpdateFromBackfill(first, node.Completed);
+                if (extractor.AllowUpdateState) node.State.UpdateFromBackfill(first, node.Completed);
             }
 
             extractor.Streamer.Enqueue(createdEvents);
@@ -663,7 +663,7 @@ namespace Cognite.OpcUa.History
             if (buffered.Any())
             {
                 var (smin, smax) = buffered.MinMax(dp => dp.Time);
-                emitterState.UpdateFromStream(smin, smax);
+                if (extractor.AllowUpdateState) emitterState.UpdateFromStream(smin, smax);
                 log.LogDebug("Read {Count} events from buffer of state {Id}", buffered.Count(), node.State.Id);
                 extractor.Streamer.Enqueue(buffered);
             }

--- a/Extractor/History/HistoryScheduler.cs
+++ b/Extractor/History/HistoryScheduler.cs
@@ -324,6 +324,10 @@ namespace Cognite.OpcUa.History
             await base.RunAsync();
             log.LogInformation("Finish reading history of type {Type} for {Count} nodes. " +
                 "Took a total of {NumOps} operations", type, nodeCount, numReads);
+            if (!extractor.AllowUpdateState)
+            {
+                log.LogWarning("ServiceLevel is low, so known ranges are not currently beign updated. History will run again once ServiceLevel improves");
+            }
             if (exceptions.Any())
             {
                 throw new AggregateException(exceptions);

--- a/Extractor/History/HistoryScheduler.cs
+++ b/Extractor/History/HistoryScheduler.cs
@@ -326,7 +326,7 @@ namespace Cognite.OpcUa.History
                 "Took a total of {NumOps} operations", type, nodeCount, numReads);
             if (!extractor.AllowUpdateState)
             {
-                log.LogWarning("ServiceLevel is low, so known ranges are not currently beign updated. History will run again once ServiceLevel improves");
+                log.LogWarning("ServiceLevel is low, so destination ranges are not currently beign updated. History will run again once ServiceLevel improves");
             }
             if (exceptions.Any())
             {
@@ -503,11 +503,11 @@ namespace Cognite.OpcUa.History
 
             if (Frontfill)
             {
-                if (extractor.AllowUpdateState) node.State.UpdateFromFrontfill(last, node.Completed);
+                node.State.UpdateFromFrontfill(last, node.Completed);
             }
             else
             {
-                if (extractor.AllowUpdateState) node.State.UpdateFromBackfill(first, node.Completed);
+                node.State.UpdateFromBackfill(first, node.Completed);
             }
 
             int cnt = 0;
@@ -535,7 +535,7 @@ namespace Cognite.OpcUa.History
             if (buffered.Any())
             {
                 log.LogDebug("Read {Count} datapoints from buffer of state {Id}", buffered.Count(), node.State.Id);
-                if (extractor.AllowUpdateState) nodeState.UpdateFromStream(buffered);
+                nodeState.UpdateFromStream(buffered);
                 extractor.Streamer.Enqueue(buffered);
             }
         }
@@ -647,11 +647,11 @@ namespace Cognite.OpcUa.History
 
             if (Frontfill)
             {
-                if (extractor.AllowUpdateState) node.State.UpdateFromFrontfill(last, node.Completed);
+                node.State.UpdateFromFrontfill(last, node.Completed);
             }
             else
             {
-                if (extractor.AllowUpdateState) node.State.UpdateFromBackfill(first, node.Completed);
+                node.State.UpdateFromBackfill(first, node.Completed);
             }
 
             extractor.Streamer.Enqueue(createdEvents);
@@ -667,7 +667,7 @@ namespace Cognite.OpcUa.History
             if (buffered.Any())
             {
                 var (smin, smax) = buffered.MinMax(dp => dp.Time);
-                if (extractor.AllowUpdateState) emitterState.UpdateFromStream(smin, smax);
+                emitterState.UpdateFromStream(smin, smax);
                 log.LogDebug("Read {Count} events from buffer of state {Id}", buffered.Count(), node.State.Id);
                 extractor.Streamer.Enqueue(buffered);
             }

--- a/Extractor/History/UAHistoryExtractionState.cs
+++ b/Extractor/History/UAHistoryExtractionState.cs
@@ -22,6 +22,17 @@ using System;
 
 namespace Cognite.OpcUa.History
 {
+    /// <summary>
+    /// History extraction state.
+    /// 
+    /// History in the utils works using a two-step process, which we use extensively:
+    /// 
+    ///  - History is read from the source, and SourceExtractedRange is updated.
+    ///  - Data is written to destinations, and DestinationExtractedRange is updated.
+    ///  
+    /// This lets us consider SourceExtractedRange our internal history range, and DestinationExtractedRange
+    /// a subset of this, which is the data actually committed to CDF.
+    /// </summary>
     public class UAHistoryExtractionState : HistoryExtractionState
     {
         public NodeId SourceId { get; }

--- a/Extractor/IClientCallbacks.cs
+++ b/Extractor/IClientCallbacks.cs
@@ -1,0 +1,29 @@
+﻿using Cognite.Extractor.Common;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cognite.OpcUa
+{
+    public interface IClientCallbacks
+    {
+        PeriodicScheduler TaskScheduler { get; }
+
+        /// <summary>
+        /// Invoked when client loses connection to server.
+        /// </summary>
+        Task OnServerDisconnect(UAClient source);
+
+        /// <summary>
+        /// Invoked whenever the session reconnects to the server.
+        /// </summary>
+        Task OnServerReconnect(UAClient source);
+
+        /// <summary>
+        /// Invoked whenever the client service level goes from below to above
+        /// the configured threshold.
+        /// </summary>
+        Task OnServiceLevelAboveThreshold(UAClient source);
+    }
+}

--- a/Extractor/IClientCallbacks.cs
+++ b/Extractor/IClientCallbacks.cs
@@ -25,5 +25,11 @@ namespace Cognite.OpcUa
         /// the configured threshold.
         /// </summary>
         Task OnServiceLevelAboveThreshold(UAClient source);
+
+        /// <summary>
+        /// Invoked whenever the client service level goes from above to below
+        /// the configured threshold.
+        /// </summary>
+        Task OnServicelevelBelowThreshold(UAClient source);
     }
 }

--- a/Extractor/Streamer.cs
+++ b/Extractor/Streamer.cs
@@ -349,13 +349,13 @@ namespace Cognite.OpcUa
             {
                 var evt = DpAsEvent(datapoint, node);
                 log.LogTrace("Subscription DataPoint treated as event {Event}", node);
-                node.UpdateFromStream(DateTime.MaxValue, datapoint.SourceTimestamp);
+                if (extractor.AllowUpdateState) node.UpdateFromStream(DateTime.MaxValue, datapoint.SourceTimestamp);
                 Enqueue(evt);
                 return;
             }
 
             var buffDps = ToDataPoint(datapoint, node);
-            node.UpdateFromStream(buffDps);
+            if (extractor.AllowUpdateState) node.UpdateFromStream(buffDps);
 
             if ((extractor.StateStorage == null || config.StateStorage.IntervalValue.Value == Timeout.InfiniteTimeSpan)
                  && (node.IsFrontfilling && datapoint.SourceTimestamp > node.SourceExtractedRange.Last
@@ -478,7 +478,7 @@ namespace Cognite.OpcUa
 
                 timeToExtractorEvents.Observe((DateTime.UtcNow - buffEvent.Time).TotalSeconds);
 
-                eventState.UpdateFromStream(buffEvent);
+                if (extractor.AllowUpdateState) eventState.UpdateFromStream(buffEvent);
 
                 // Either backfill/frontfill is done, or we are not outside of each respective bound
                 if ((extractor.StateStorage == null || config.StateStorage.IntervalValue.Value == Timeout.InfiniteTimeSpan)

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -47,10 +47,12 @@ namespace Cognite.OpcUa
     public class UAClient : IDisposable, IUAClientAccess
     {
         protected FullConfig Config { get; set; }
-        protected ISession? Session => sessionManager?.Session;
+        protected ISession? Session => SessionManager?.Session;
         protected ApplicationConfiguration? AppConfig { get; set; }
         public DataTypeManager DataTypeManager { get; }
         public NodeTypeManager ObjectTypeManager { get; }
+
+        public IClientCallbacks Callbacks { get; set; } = null!;
 
         private readonly SemaphoreSlim subscriptionSem = new SemaphoreSlim(1);
         private readonly Dictionary<NodeId, string> nodeOverrides = new Dictionary<NodeId, string>();
@@ -59,9 +61,6 @@ namespace Cognite.OpcUa
         private Dictionary<NodeId, UAEventType>? eventFields;
 
         private readonly Dictionary<ushort, string> nsPrefixMap = new Dictionary<ushort, string>();
-
-        public event EventHandler? OnServerDisconnect;
-        public event EventHandler? OnServerReconnect;
 
         private static readonly Counter attributeRequests = Metrics
             .CreateCounter("opcua_attribute_requests", "Number of attributes fetched from the server");
@@ -80,7 +79,7 @@ namespace Cognite.OpcUa
 
         private readonly NodeMetricsManager? metricsManager;
 
-        private SessionManager? sessionManager;
+        public SessionManager? SessionManager { get; private set; }
 
         private readonly ILogger<UAClient> log;
         private readonly ILogger<Tracing> traceLog;
@@ -126,9 +125,9 @@ namespace Cognite.OpcUa
         {
             try
             {
-                if (sessionManager != null)
+                if (SessionManager != null)
                 {
-                    await sessionManager.Close(token);
+                    await SessionManager.Close(token);
                 }
             }
             finally
@@ -235,6 +234,8 @@ namespace Cognite.OpcUa
         /// </summary>
         private async Task StartSession(int timeout = -1)
         {
+            if (Callbacks == null) throw new InvalidOperationException("Attempted to start UAClient without setting callbacks");
+
             Browser.ResetVisitedNodes();
             // A restarted Session might mean a restarted server, so all server-relevant data must be cleared.
             // This includes any stored NodeId, which may refer to an outdated namespaceIndex
@@ -243,31 +244,21 @@ namespace Cognite.OpcUa
 
             await LoadAppConfig();
 
-            if (sessionManager == null)
+            if (SessionManager == null)
             {
-                sessionManager = new SessionManager(Config.Source, this, AppConfig!, log, liveToken, timeout);
+                SessionManager = new SessionManager(Config.Source, this, AppConfig!, log, liveToken, timeout);
             }
             else
             {
-                sessionManager.Timeout = timeout;
+                SessionManager.Timeout = timeout;
             }
 
-            await sessionManager.Connect();
+            await SessionManager.Connect();
 
             liveToken.ThrowIfCancellationRequested();
 
             Started = true;
-            log.LogInformation("Successfully connected to server at {EndpointURL}", sessionManager.EndpointUrl);
-        }
-
-        public void TriggerOnServerDisconnect()
-        {
-            OnServerDisconnect?.Invoke(this, EventArgs.Empty);
-        }
-
-        public void TriggerOnServerReconnect()
-        {
-            OnServerReconnect?.Invoke(this, EventArgs.Empty);
+            log.LogInformation("Successfully connected to server at {EndpointURL}", SessionManager.EndpointUrl);
         }
 
         private bool ShouldRetryException(Exception ex)
@@ -1627,7 +1618,7 @@ namespace Cognite.OpcUa
                 AppConfig.CertificateValidator.CertificateValidation -= CertificateValidationHandler;
             }
             subscriptionSem.Dispose();
-            sessionManager?.Dispose();
+            SessionManager?.Dispose();
         }
         #endregion
     }

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -224,6 +224,26 @@ namespace Cognite.OpcUa
             }
         }
 
+        public Task OnServicelevelBelowThreshold(UAClient source)
+        {
+            if (Source.IsCancellationRequested) return Task.CompletedTask;
+
+            if (historyReader != null)
+            {
+                foreach (var state in State.NodeStates)
+                {
+                    if (!state.IsFrontfilling && !state.IsBackfilling) state.RestartHistory();
+                }
+
+                foreach (var state in State.EmitterStates)
+                {
+                    if (!state.IsFrontfilling && !state.IsBackfilling) state.RestartHistory();
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
         /// <summary>
         /// Event handler for UAClient reconnect
         /// </summary>

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -35,6 +35,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -45,7 +46,7 @@ namespace Cognite.OpcUa
     /// <summary>
     /// Main extractor class, tying together the <see cref="uaClient"/> and CDF client.
     /// </summary>
-    public class UAExtractor : BaseExtractor<FullConfig>, IUAClientAccess
+    public class UAExtractor : BaseExtractor<FullConfig>, IUAClientAccess, IClientCallbacks
     {
         private readonly UAClient uaClient;
         public Looper Looper { get; private set; } = null!;
@@ -54,6 +55,8 @@ namespace Cognite.OpcUa
         public State State { get; }
         public Streamer Streamer { get; }
         public DataTypeManager DataTypeManager => uaClient.DataTypeManager;
+
+        public PeriodicScheduler TaskScheduler => Scheduler;
 
         private HistoryReader historyReader = null!;
         public ReferenceTypeManager? ReferenceTypeManager { get; private set; }
@@ -100,6 +103,11 @@ namespace Cognite.OpcUa
 
         public static readonly DateTime StartTime = DateTime.UtcNow;
 
+        public bool AllowUpdateState =>
+            !Config.Source.IsRedundancyEnabled
+            || uaClient.SessionManager != null
+            && uaClient.SessionManager.CurrentServiceLevel >= Config.Source.Redundancy.ServiceLevelThreshold;
+
         /// <summary>
         /// Construct extractor with list of pushers
         /// </summary>
@@ -116,12 +124,10 @@ namespace Cognite.OpcUa
         {
             this.uaClient = uaClient;
             this.pushers = pushers.Where(pusher => pusher != null).ToList();
+            this.uaClient.Callbacks = this;
             log = provider.GetRequiredService<ILogger<UAExtractor>>();
 
             log.LogDebug("Config:{NewLine}{Config}", Environment.NewLine, ExtractorUtils.ConfigToString(Config));
-
-            this.uaClient.OnServerReconnect += UaClient_OnServerReconnect;
-            this.uaClient.OnServerDisconnect += UaClient_OnServerDisconnect;
 
             State = new State();
             Streamer = new Streamer(provider.GetRequiredService<ILogger<Streamer>>(), this, config);
@@ -190,12 +196,32 @@ namespace Cognite.OpcUa
         /// </summary>
         /// <param name="sender">UAClient that generated this event</param>
         /// <param name="e">EventArgs for this event</param>
-        private void UaClient_OnServerDisconnect(object sender, EventArgs e)
+        public Task OnServerDisconnect(UAClient source)
         {
-            /* if (Config.Source.ForceRestart && !Source.IsCancellationRequested)
+            return Task.CompletedTask;
+        }
+
+        public async Task OnServiceLevelAboveThreshold(UAClient source)
+        {
+            if (Source.IsCancellationRequested) return;
+
+            if (historyReader != null)
             {
-                Close().Wait();
-            } */
+                await historyReader.Terminate(Source.Token);
+                foreach (var state in State.NodeStates)
+                {
+                    state.RestartHistory();
+                }
+
+                foreach (var state in State.EmitterStates)
+                {
+                    state.RestartHistory();
+                }
+                Scheduler.ScheduleTask(null, async t =>
+                {
+                    await RestartHistory();
+                });
+            }
         }
 
         /// <summary>
@@ -203,40 +229,37 @@ namespace Cognite.OpcUa
         /// </summary>
         /// <param name="sender">UAClient that generated this event</param>
         /// <param name="e">EventArgs for this event</param>
-        private void UaClient_OnServerReconnect(object sender, EventArgs e)
+        public async Task OnServerReconnect(UAClient source)
         {
-            if (sender is not UAClient client || Source.IsCancellationRequested) return;
+            if (Source.IsCancellationRequested) return;
 
-            Scheduler.ScheduleTask(null, async t =>
+            await EnsureSubscriptions();
+            if (Config.Source.RestartOnReconnect)
             {
-                await EnsureSubscriptions();
-                if (Config.Source.RestartOnReconnect)
+                source.DataTypeManager.Configure();
+                source.ClearNodeOverrides();
+                source.ClearEventFields();
+                source.Browser.ResetVisitedNodes();
+                await RestartExtractor();
+            }
+            else
+            {
+                if (historyReader != null)
                 {
-                    client.DataTypeManager.Configure();
-                    client.ClearNodeOverrides();
-                    client.ClearEventFields();
-                    client.Browser.ResetVisitedNodes();
-                    await RestartExtractor();
-                }
-                else
-                {
-                    if (historyReader != null)
+                    await historyReader.Terminate(Source.Token);
+                    foreach (var state in State.NodeStates)
                     {
-                        await historyReader.Terminate(Source.Token);
-                        foreach (var state in State.NodeStates)
-                        {
-                            state.RestartHistory();
-                        }
-
-                        foreach (var state in State.EmitterStates)
-                        {
-                            state.RestartHistory();
-                        }
-
-                        await RestartHistory();
+                        state.RestartHistory();
                     }
+
+                    foreach (var state in State.EmitterStates)
+                    {
+                        state.RestartHistory();
+                    }
+
+                    Scheduler.ScheduleTask(null, async (_) => await RestartHistory());
                 }
-            });
+            }
         }
         #region Interface
 
@@ -722,6 +745,11 @@ namespace Cognite.OpcUa
             if (rebrowseTriggerManager is not null)
             {
                 await rebrowseTriggerManager.EnableCustomServerSubscriptions(Source.Token);
+            }
+
+            if (Config.Source.Redundancy.MonitorServiceLevel && uaClient.SessionManager != null)
+            {
+                await uaClient.SessionManager.EnsureServiceLevelSubscription();
             }
         }
 
@@ -1235,8 +1263,6 @@ namespace Cognite.OpcUa
             {
                 Starting.Set(0);
                 historyReader?.Dispose();
-                uaClient.OnServerDisconnect -= UaClient_OnServerDisconnect;
-                uaClient.OnServerReconnect -= UaClient_OnServerReconnect;
                 pubSubManager?.Dispose();
             }
             base.Dispose(disposing);

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -104,7 +104,7 @@ namespace Cognite.OpcUa
         public static readonly DateTime StartTime = DateTime.UtcNow;
 
         public bool AllowUpdateState =>
-            !Config.Source.IsRedundancyEnabled
+            !Config.Source.Redundancy.MonitorServiceLevel
             || uaClient.SessionManager != null
             && uaClient.SessionManager.CurrentServiceLevel >= Config.Source.Redundancy.ServiceLevelThreshold;
 

--- a/Server/NodeManager.cs
+++ b/Server/NodeManager.cs
@@ -367,6 +367,7 @@ namespace Server
 
                 // update server capabilities.
                 serverObject.ServiceLevel.Value = serviceLevel;
+                serverObject.ServiceLevel.ClearChangeMasks(SystemContext, true);
                 serverObject.ServerRedundancy.RedundancySupport.Value = support;
             }
         }

--- a/Test/Integration/DataPointTests.cs
+++ b/Test/Integration/DataPointTests.cs
@@ -765,6 +765,56 @@ namespace Test.Integration
             Assert.Equal(3u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith("DataChangeListener", StringComparison.InvariantCulture)).MonitoredItemCount);
             await TestUtils.WaitForCondition(() => CommonTestUtils.TestMetricValue("opcua_frontfill_data_count", 3), 5);
         }
+
+        [Fact]
+        public async Task TestLowServiceLevelStates()
+        {
+            using var pusher = new DummyPusher(new DummyPusherConfig());
+            using var extractor = tester.BuildExtractor(true, null, pusher);
+
+            var ids = tester.Server.Ids.Base;
+
+            tester.Config.History.Enabled = true;
+            tester.Config.History.Data = true;
+            tester.Config.Source.Redundancy.MonitorServiceLevel = true;
+
+            tester.Config.Extraction.RootNode = CommonTestUtils.ToProtoNodeId(tester.Server.Ids.Base.Root, tester.Client);
+
+            // Need to reset connection to server in order to begin measuring service level
+            tester.Server.SetServerRedundancyStatus(190, RedundancySupport.Hot);
+
+            await tester.Client.Run(tester.Source.Token);
+            var start = DateTime.UtcNow.AddSeconds(-5);
+            tester.WipeBaseHistory();
+            tester.Server.PopulateBaseHistory(start);
+
+            try
+            {
+                var runTask = extractor.RunExtractor();
+                await extractor.WaitForSubscriptions();
+
+                await TestUtils.WaitForCondition(() => pusher.DataPoints.ContainsKey((ids.DoubleVar1, -1))
+                    && pusher.DataPoints[(ids.DoubleVar1, -1)].Count == 1000, 10);
+
+                var state = extractor.State.GetNodeState(ids.DoubleVar1);
+                // Range should be empty
+                tester.Log.LogInformation("Test {Test}", state.SourceExtractedRange);
+                Assert.True(state.SourceExtractedRange.First == CogniteTime.DateTimeEpoch);
+                Assert.True(state.SourceExtractedRange.Last == CogniteTime.DateTimeEpoch);
+                // Frontfill should not be set as completed
+                Assert.True(state.IsFrontfilling);
+
+                // Set service level back up and wait for history to catch up.
+                tester.Server.SetServerRedundancyStatus(255, RedundancySupport.Hot);
+                await TestUtils.WaitForCondition(() => extractor.State.NodeStates.All(node =>
+                    !node.IsFrontfilling && !node.IsBackfilling), 10);
+            }
+            finally
+            {
+                tester.Config.Source.Redundancy.MonitorServiceLevel = false;
+                await tester.Client.Run(tester.Source.Token);
+            }
+        }
         #endregion
 
         #region buffer

--- a/Test/Unit/ConfigToolTest.cs
+++ b/Test/Unit/ConfigToolTest.cs
@@ -46,8 +46,8 @@ namespace Test.Unit
         {
             await Server.Start();
 
-            Explorer = new UAServerExplorer(Provider, Config, BaseConfig);
             Source = new CancellationTokenSource();
+            Explorer = new UAServerExplorer(Provider, Config, BaseConfig, Source.Token);
             await Explorer.Run(Source.Token, 0);
         }
 

--- a/Test/Unit/UAExtractorTest.cs
+++ b/Test/Unit/UAExtractorTest.cs
@@ -60,18 +60,6 @@ namespace Test.Unit
             Assert.Contains(pusher.PushedNodes.Values, node => node.DisplayName == "DeepObject 4, 25");
             Assert.Contains(pusher.PushedVariables.Values, node => node.DisplayName == "SubVariable 1234");
         }
-        private static void TriggerEventExternally(string field, object parent)
-        {
-            var dg = parent.GetType()
-                .GetField(field, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                .GetValue(parent) as MulticastDelegate;
-            foreach (var handler in dg.GetInvocationList())
-            {
-                handler.Method.Invoke(
-                    handler.Target,
-                    new object[] { parent, EventArgs.Empty });
-            }
-        }
 
         [Fact]
         public async Task TestRestartOnReconnect()
@@ -87,7 +75,7 @@ namespace Test.Unit
             await extractor.WaitForSubscriptions();
             Assert.True(pusher.PushedNodes.Any());
             pusher.PushedNodes.Clear();
-            TriggerEventExternally("OnServerReconnect", tester.Client);
+            await extractor.OnServerReconnect(tester.Client);
 
             Assert.True(pusher.OnReset.WaitOne(10000));
 

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -29,6 +29,7 @@ namespace Test.Utils
         public ServiceProvider Provider { get; protected set; }
         protected ServiceCollection Services { get; }
         protected PredefinedSetup[] Setups { get; }
+        public DummyClientCallbacks Callbacks { get; private set; }
         public ILogger Log { get; }
         protected BaseExtractorTestFixture(PredefinedSetup[] setups = null)
         {
@@ -60,6 +61,8 @@ namespace Test.Utils
 
             Client = new UAClient(Provider, Config);
             Source = new CancellationTokenSource();
+            Callbacks = new DummyClientCallbacks(Source.Token);
+            Client.Callbacks = Callbacks;
             await Client.Run(Source.Token, 0);
         }
 

--- a/Test/Utils/DummyClientCallbacks.cs
+++ b/Test/Utils/DummyClientCallbacks.cs
@@ -1,0 +1,37 @@
+﻿using Cognite.Extractor.Common;
+using Cognite.OpcUa;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Test.Utils
+{
+    public class DummyClientCallbacks : IClientCallbacks
+    {
+        public PeriodicScheduler TaskScheduler { get; }
+        public bool Connected { get; set; }
+        public int ServiceLevelCbCount { get; set; }
+
+        public DummyClientCallbacks(CancellationToken token)
+        {
+            TaskScheduler = new PeriodicScheduler(token);
+        }
+
+        public Task OnServerDisconnect(UAClient source)
+        {
+            Connected = false;
+            return Task.CompletedTask;
+        }
+
+        public Task OnServerReconnect(UAClient source)
+        {
+            Connected = true;
+            return Task.CompletedTask;
+        }
+
+        public Task OnServiceLevelAboveThreshold(UAClient source)
+        {
+            ServiceLevelCbCount++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Test/Utils/DummyClientCallbacks.cs
+++ b/Test/Utils/DummyClientCallbacks.cs
@@ -10,6 +10,7 @@ namespace Test.Utils
         public PeriodicScheduler TaskScheduler { get; }
         public bool Connected { get; set; }
         public int ServiceLevelCbCount { get; set; }
+        public int LowServiceLevelCbCount { get; set; }
 
         public DummyClientCallbacks(CancellationToken token)
         {
@@ -31,6 +32,12 @@ namespace Test.Utils
         public Task OnServiceLevelAboveThreshold(UAClient source)
         {
             ServiceLevelCbCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task OnServicelevelBelowThreshold(UAClient source)
+        {
+            LowServiceLevelCbCount++;
             return Task.CompletedTask;
         }
     }

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -26,6 +26,21 @@ source:
         # Endpoint URL to override URLs returned from discovery.
         # This can be used if the server is behind NAT, or similar URL rewrites.
         override-endpoint-url:
+    # Extra configuration options related to redundancy and ServiceLevel monitoring
+    redundancy:
+        # Servers above this threshold are considered "good"
+        service-level-threshold: 200
+        # If using redundancy, the extractor will attempt to find a better server
+        # with this interval if service level is below threshold.
+        reconnect-interval: 10m
+        # If true, the extractor will subscribe to changes in ServiceLevel
+        # and trigger reconnect once it drops below service-level-threshold,
+        # and history restart once it goes back above the threshold.
+        # This also makes the server not update extraction state if it is connected to a server
+        # with service level below the threshold.
+        # If a server does not want the extractor to trust the available data ranges
+        # it should set the ServiceLevel below the threshold.
+        monitor-service-level: false
     # Auto accept connections from unknown servers.
     # There is not yet a feature to accept new certificates, but you can manually move rejected certificates to accepted.
     # Paths are defined in opc.ua.net.extractor.Config.xml

--- a/manifest.yml
+++ b/manifest.yml
@@ -60,6 +60,13 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.15.0":
+    description: Add live monitoring of ServiceLevel
+    changelog:
+      fixed:
+        - "Fix issue causing delete states to not be properly fetched"
+      added:
+        - "Support for monitoring ServiceLevel and not updating extraction state if it drops below a threshold"
   "2.14.1":
     description: Avoid crashing on duplicated namespaces
     changelog:

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,14 +1,8 @@
 source https://www.nuget.org/api/v2
 storage: none
 
-nuget Cognite.ExtractorUtils 1.6.1
-nuget Cognite.Extractor.Testing 1.6.1
-nuget Cognite.Extensions 1.6.1
-nuget Cognite.Extractor.Common 1.6.1
-nuget Cognite.Extractor.Configuration 1.6.1
-nuget Cognite.Extractor.Logging 1.6.1
-nuget Cognite.Extractor.Metrics 1.6.1
-nuget Cognite.Extractor.StateStorage 1.6.1
+nuget Cognite.ExtractorUtils
+nuget Cognite.Extractor.Testing
 nuget Microsoft.CSharp
 nuget coverlet.msbuild
 nuget Microsoft.NET.Test.Sdk

--- a/paket.lock
+++ b/paket.lock
@@ -3,24 +3,24 @@ NUGET
   remote: https://www.nuget.org/api/v2
     AdysTech.InfluxDB.Client.Net.Core (0.25)
       Newtonsoft.Json (>= 10.0.3) - restriction: || (>= net46) (>= netstandard2.0)
-    Cognite.Extensions (1.6.1)
-      Cognite.Extractor.Common (>= 1.6.1) - restriction: >= netstandard2.0
+    Cognite.Extensions (1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Common (>= 1.6.2) - restriction: >= netstandard2.0
       CogniteSdk (>= 3.7) - restriction: >= netstandard2.0
       Microsoft.Extensions.Http (>= 7.0) - restriction: >= netstandard2.0
       Microsoft.Extensions.Http.Polly (>= 7.0.3) - restriction: >= netstandard2.0
       Microsoft.Identity.Client (>= 4.50) - restriction: >= netstandard2.0
       Polly.Extensions.Http (>= 3.0) - restriction: >= netstandard2.0
       prometheus-net (>= 8.0) - restriction: >= netstandard2.0
-    Cognite.Extractor.Common (1.6.1)
+    Cognite.Extractor.Common (1.6.2) - restriction: >= netstandard2.0
       Cronos (>= 0.7.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 7.0) - restriction: >= netstandard2.0
       System.Text.Json (>= 7.0.2) - restriction: >= netstandard2.0
-    Cognite.Extractor.Configuration (1.6.1)
-      Cognite.Extractor.Common (>= 1.6.1) - restriction: >= netstandard2.0
+    Cognite.Extractor.Configuration (1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Common (>= 1.6.2) - restriction: >= netstandard2.0
       Microsoft.CSharp (>= 4.7) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 7.0) - restriction: >= netstandard2.0
       YamlDotNet (>= 13.0.1) - restriction: >= netstandard2.0
-    Cognite.Extractor.Logging (1.6.1)
+    Cognite.Extractor.Logging (1.6.2) - restriction: >= netstandard2.0
       Microsoft.Bcl.AsyncInterfaces (>= 7.0) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 7.0) - restriction: >= netstandard2.0
       Serilog (>= 2.12) - restriction: >= netstandard2.0
@@ -28,29 +28,29 @@ NUGET
       Serilog.Sinks.Async (>= 1.5) - restriction: >= netstandard2.0
       Serilog.Sinks.Console (>= 4.1) - restriction: >= netstandard2.0
       Serilog.Sinks.File (>= 5.0) - restriction: >= netstandard2.0
-    Cognite.Extractor.Metrics (1.6.1)
-      Cognite.Extractor.Common (>= 1.6.1) - restriction: >= netstandard2.0
-      Cognite.Extractor.Logging (>= 1.6.1) - restriction: >= netstandard2.0
+    Cognite.Extractor.Metrics (1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Common (>= 1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Logging (>= 1.6.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Http (>= 7.0) - restriction: >= netstandard2.0
       Microsoft.Extensions.Http.Polly (>= 7.0.3) - restriction: >= netstandard2.0
       Polly.Extensions.Http (>= 3.0) - restriction: >= netstandard2.0
       prometheus-net (>= 8.0) - restriction: >= netstandard2.0
-    Cognite.Extractor.StateStorage (1.6.1)
-      Cognite.Extractor.Common (>= 1.6.1) - restriction: >= netstandard2.0
-      Cognite.Extractor.Logging (>= 1.6.1) - restriction: >= netstandard2.0
-      Cognite.Extractor.Metrics (>= 1.6.1) - restriction: >= netstandard2.0
+    Cognite.Extractor.StateStorage (1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Common (>= 1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Logging (>= 1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Metrics (>= 1.6.2) - restriction: >= netstandard2.0
       LiteDB (>= 5.0.15) - restriction: >= netstandard2.0
-    Cognite.Extractor.Testing (1.6.1)
-      Cognite.ExtractorUtils (>= 1.6.1) - restriction: >= netstandard2.0
+    Cognite.Extractor.Testing (1.6.2)
+      Cognite.ExtractorUtils (>= 1.6.2) - restriction: >= netstandard2.0
       xunit.assert (>= 2.4.2) - restriction: >= netstandard2.0
       xunit.core (>= 2.4.2) - restriction: >= netstandard2.0
-    Cognite.ExtractorUtils (1.6.1)
-      Cognite.Extensions (>= 1.6.1) - restriction: >= netstandard2.0
-      Cognite.Extractor.Common (>= 1.6.1) - restriction: >= netstandard2.0
-      Cognite.Extractor.Configuration (>= 1.6.1) - restriction: >= netstandard2.0
-      Cognite.Extractor.Logging (>= 1.6.1) - restriction: >= netstandard2.0
-      Cognite.Extractor.Metrics (>= 1.6.1) - restriction: >= netstandard2.0
-      Cognite.Extractor.StateStorage (>= 1.6.1) - restriction: >= netstandard2.0
+    Cognite.ExtractorUtils (1.6.2)
+      Cognite.Extensions (>= 1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Common (>= 1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Configuration (>= 1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Logging (>= 1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.Metrics (>= 1.6.2) - restriction: >= netstandard2.0
+      Cognite.Extractor.StateStorage (>= 1.6.2) - restriction: >= netstandard2.0
       Microsoft.Bcl.AsyncInterfaces (>= 7.0) - restriction: >= netstandard2.0
       Microsoft.CSharp (>= 4.7) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 7.0) - restriction: >= netstandard2.0
@@ -71,7 +71,7 @@ NUGET
     FsToolkit.ErrorHandling (4.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: && (>= netstandard2.0) (< netstandard2.1)
       FSharp.Core (>= 7.0) - restriction: >= netstandard2.1
-    Google.Protobuf (3.22) - restriction: >= netstandard2.0
+    Google.Protobuf (3.22.1) - restriction: >= netstandard2.0
       System.Memory (>= 4.5.3) - restriction: || (>= net45) (&& (< net5.0) (>= netstandard2.0)) (&& (>= netstandard1.1) (< netstandard2.0))
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: && (< net45) (< net5.0) (>= netstandard2.0)
     LiteDB (5.0.15) - restriction: >= netstandard2.0
@@ -390,7 +390,7 @@ NUGET
       System.Threading.Timer (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net46) (< netstandard1.4)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
       System.Xml.XDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
-    Newtonsoft.Json (13.0.2) - restriction: || (>= net46) (>= netstandard2.0)
+    Newtonsoft.Json (13.0.3) - restriction: || (>= net46) (>= netstandard2.0)
     NuGet.Frameworks (6.5) - restriction: >= netcoreapp3.1
     OPCFoundation.NetStandard.Opc.Ua.Client (1.4.371.60)
       OPCFoundation.NetStandard.Opc.Ua.Configuration (>= 1.4.371.60) - restriction: || (>= net462) (>= netstandard2.0)
@@ -899,7 +899,7 @@ NUGET
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Timer (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Numerics.Vectors (4.5) - restriction: || (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net461) (>= netstandard2.0)) (>= net462) (&& (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= netstandard2.0))
+    System.Numerics.Vectors (4.5) - restriction: || (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net462) (>= netstandard2.0)) (&& (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= netstandard2.0))
     System.ObjectModel (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81))
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1346,10 +1346,10 @@ NUGET
       Xamarin.AndroidX.Collection (>= 1.2.0.6) - restriction: >= monoandroid12.0
     Xamarin.Google.Guava.ListenableFuture (1.0.0.11) - restriction: && (>= monoandroid12.0) (< net6.0)
     Xamarin.Jetbrains.Annotations (24.0.0.1) - restriction: && (>= monoandroid12.0) (< net6.0)
-    Xamarin.Kotlin.StdLib (1.8.0.1) - restriction: && (>= monoandroid12.0) (< net6.0)
+    Xamarin.Kotlin.StdLib (1.8.10) - restriction: && (>= monoandroid12.0) (< net6.0)
       Xamarin.Jetbrains.Annotations (>= 24.0.0.1) - restriction: >= monoandroid12.0
-      Xamarin.Kotlin.StdLib.Common (>= 1.8.0.1) - restriction: >= monoandroid12.0
-    Xamarin.Kotlin.StdLib.Common (1.8.0.1) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.Kotlin.StdLib.Common (>= 1.8.10) - restriction: >= monoandroid12.0
+    Xamarin.Kotlin.StdLib.Common (1.8.10) - restriction: && (>= monoandroid12.0) (< net6.0)
     xunit (2.4.2)
       xunit.analyzers (>= 1.0)
       xunit.assert (>= 2.4.2)

--- a/schema/source_config.schema.json
+++ b/schema/source_config.schema.json
@@ -49,7 +49,7 @@
                     "description": "If true, the extractor will subscribe to changes in ServiceLevel and trigger reconnect once it drops below service-level-threshold, and history restart once it goes back above the threshold. This also makes the server not update extraction state if it is connected to a server with service level below the threshold. If a server does not want the extractor to trust the available data ranges it should set the ServiceLevel below the threshold."
                 }
             }
-        }
+        },
         "auto-accept": {
             "type": "boolean",
             "default": true,

--- a/schema/source_config.schema.json
+++ b/schema/source_config.schema.json
@@ -27,6 +27,29 @@
                 }
             }
         },
+        "redundancy": {
+            "type": "object",
+            "description": "Extra configuration options related to redundancy and ServiceLevel monitoring",
+            "unevaluatedProperties": false,
+            "properties": {
+                "service-level-threshold": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255,
+                    "default": 200,
+                    "description": "Servers above this threshold are considered good"
+                },
+                "reconnect-interval": {
+                    "type": "string",
+                    "description": "If using redundancy, the extractor will attempt to find a better server with this interval if service level is below threshold. Format is `N[timeunit]` where `timeunit` is one of `w`, `d`, `h`, `m`, `s`, or `ms`.",
+                    "default": "10m"
+                },
+                "monitor-service-level": {
+                    "type": "boolean",
+                    "description": "If true, the extractor will subscribe to changes in ServiceLevel and trigger reconnect once it drops below service-level-threshold, and history restart once it goes back above the threshold. This also makes the server not update extraction state if it is connected to a server with service level below the threshold. If a server does not want the extractor to trust the available data ranges it should set the ServiceLevel below the threshold."
+                }
+            }
+        }
         "auto-accept": {
             "type": "boolean",
             "default": true,


### PR DESCRIPTION
This ended up being a fairly complex feature.

The main goal of this is to monitor the server ServiceLevel, trigger callbacks once it drops below a certain level, and not update extractor state if the server is in a bad state.

This effectively required better support for asynchronous callbacks. Using events had become somewhat clunky and hard to work with, it also caused us to do a lot of `var _ = Task.Run(...)`, which isn't ideal as it makes it so that exceptions are completely lost.