### PR TITLE
Remove top level visited nodes logic

### DIFF
--- a/ConfigurationTool/Checks/Browse.cs
+++ b/ConfigurationTool/Checks/Browse.cs
@@ -105,14 +105,13 @@ namespace Cognite.OpcUa.Config
                     foreach (var rd in children)
                     {
                         var nodeId = ToNodeId(rd.NodeId);
-                        bool docb = true;
-                        if (docb)
-                        {
-                            log.LogTrace("Discovered new node {NodeId}", nodeId);
-                            callback?.Invoke(rd, parentId);
-                        }
+                        bool visited = !localVisitedNodes.Add(nodeId);
+
+                        log.LogTrace("Discovered new node {NodeId}", nodeId);
+                        callback?.Invoke(rd, parentId, visited);
+
                         if (rd.NodeClass == NodeClass.Variable) continue;
-                        if (localVisitedNodes.Add(nodeId))
+                        if (!visited)
                         {
                             nextIds.Add(nodeId);
                         }

--- a/ConfigurationTool/ToolUtil.cs
+++ b/ConfigurationTool/ToolUtil.cs
@@ -112,10 +112,11 @@ namespace Cognite.OpcUa.Config
         /// <param name="target">List to write to</param>
         /// <param name="client">UAClient instance for namespaces</param>
         /// <returns>Callback for Browse in UAClient</returns>
-        public static Action<ReferenceDescription, NodeId> GetSimpleListWriterCallback(ICollection<UANode> target, UAClient client, ILogger log)
+        public static Action<ReferenceDescription, NodeId, bool> GetSimpleListWriterCallback(ICollection<UANode> target, UAClient client, ILogger log)
         {
-            return (node, parentId) =>
+            return (node, parentId, visited) =>
             {
+                if (visited) return;
                 if (node.NodeClass == NodeClass.Object || node.NodeClass == NodeClass.DataType || node.NodeClass == NodeClass.ObjectType)
                 {
                     var bufferedNode = new UANode(client.ToNodeId(node.NodeId),

--- a/ConfigurationTool/UAServerExplorer.cs
+++ b/ConfigurationTool/UAServerExplorer.cs
@@ -100,7 +100,7 @@ namespace Cognite.OpcUa.Config
             var roots = Config.Extraction.GetRootNodes(this, log);
             try
             {
-                await Browser.BrowseNodeHierarchy(roots, ToolUtil.GetSimpleListWriterCallback(nodeList, this, log), token, false,
+                await Browser.BrowseNodeHierarchy(roots, ToolUtil.GetSimpleListWriterCallback(nodeList, this, log), token,
                     "populating the main node hierarchy");
                 nodesRead = true;
             }

--- a/Extractor/Browse/Browser.cs
+++ b/Extractor/Browse/Browser.cs
@@ -56,6 +56,7 @@ namespace Cognite.OpcUa.Browse
         /// </summary>
         /// <param name="root">Root node to browse for</param>
         /// <param name="callback">Callback to call for each found node</param>
+        /// <param name="purpose">Purpose of the browse, for logging</param>
         public Task BrowseNodeHierarchy(NodeId root,
             Action<ReferenceDescription, NodeId?, bool> callback,
             CancellationToken token,
@@ -68,6 +69,7 @@ namespace Cognite.OpcUa.Browse
         /// </summary>
         /// <param name="roots">Initial nodes to start mapping.</param>
         /// <param name="callback">Callback for each mapped node, takes a description of a single node, and its parent id</param>
+        /// <param name="purpose">Purpose of the browse, for logging</param>
         public async Task BrowseNodeHierarchy(IEnumerable<NodeId> roots,
             Action<ReferenceDescription, NodeId, bool> callback,
             CancellationToken token,
@@ -90,6 +92,14 @@ namespace Cognite.OpcUa.Browse
 
             await BrowseDirectory(roots, callback, token, null, classMask, true, purpose: purpose);
         }
+
+        /// <summary>
+        /// Get reference descriptions for a list of NodeIds, used to fetch root nodes when browsing.
+        /// </summary>
+        /// <param name="ids">NodeIds to retrieve</param>
+        /// <param name="token"></param>
+        /// <returns>A list of reference descriptions, order is not guaranteed to be the same as the input.</returns>
+        /// <exception cref="ExtractorFailureException"></exception>
         public async Task<IEnumerable<ReferenceDescription>> GetRootNodes(IEnumerable<NodeId> ids, CancellationToken token)
         {
             var attributes = new uint[]
@@ -180,6 +190,13 @@ namespace Cognite.OpcUa.Browse
             };
         }
 
+        /// <summary>
+        /// Browse a list of nodes, returning their children.
+        /// </summary>
+        /// <param name="baseParams">Browse parameters</param>
+        /// <param name="doFilter">True to apply the node filter to discovered nodes</param>
+        /// <param name="purpose">Purpose of the browse, for logging</param>
+        /// <returns>Map from given nodes to list of references. Nodes with no children are not guaranteed to be in the result.</returns>
         public async Task<Dictionary<NodeId, ReferenceDescriptionCollection>> BrowseLevel(
             BrowseParams baseParams,
             CancellationToken token,
@@ -217,6 +234,8 @@ namespace Cognite.OpcUa.Browse
         /// <param name="referenceTypes">Permitted reference types, defaults to HierarchicalReferences</param>
         /// <param name="nodeClassMask">Mask for node classes as described in the OPC-UA specification</param>
         /// <param name="doFilter">True to apply the node filter to discovered nodes</param>
+        /// <param name="maxDepth">Maximum depth to browse to. 0 will browse children of the given roots only.</param>
+        /// <param name="purpose">Purpose of the browse, for logging.</param>
         public async Task BrowseDirectory(
             IEnumerable<NodeId> roots,
             Action<ReferenceDescription, NodeId, bool>? callback,

--- a/Extractor/PubSub/ServerPubSubConfigurator.cs
+++ b/Extractor/PubSub/ServerPubSubConfigurator.cs
@@ -372,9 +372,8 @@ namespace Cognite.OpcUa.PubSub
             log.LogInformation("Browse server PubSub hierarchy to identify settings");
             await client.Browser.BrowseDirectory(
                 new[] { ObjectIds.PublishSubscribe },
-                (desc, id) => HandleNode(desc, id),
+                (desc, id, visited) => HandleNode(desc, id),
                 token,
-                ignoreVisited: false,
                 doFilter: false,
                 purpose: "identifying PubSub settings");
 

--- a/Extractor/RebrowseTriggerManager.cs
+++ b/Extractor/RebrowseTriggerManager.cs
@@ -51,7 +51,7 @@ namespace Cognite.OpcUa
 
             await _uaClient.Browser.BrowseDirectory(
                 new[] { serverNamespaces },
-                (refDef, parent) =>
+                (refDef, parent, visited) =>
                 {
                     var nodeId = (NodeId)refDef.NodeId;
 
@@ -77,8 +77,7 @@ namespace Cognite.OpcUa
                 },
                 token,
                 maxDepth: 1,
-                doFilter: false,
-                ignoreVisited: false
+                doFilter: false
             );
 
             // To be used in filtering namespaces

--- a/Extractor/TypeCollectors/DataTypeManager.cs
+++ b/Extractor/TypeCollectors/DataTypeManager.cs
@@ -296,7 +296,7 @@ namespace Cognite.OpcUa.TypeCollectors
 
             log.LogInformation("Browse datatype hierarchy to map out variable datatypes");
 
-            void Callback(ReferenceDescription child, NodeId parent)
+            void Callback(ReferenceDescription child, NodeId parent, bool visited)
             {
                 var id = uaClient.ToNodeId(child.NodeId);
                 parentIds[id] = parent;
@@ -311,8 +311,7 @@ namespace Cognite.OpcUa.TypeCollectors
                 token,
                 ReferenceTypeIds.HasSubtype,
                 (uint)NodeClass.DataType,
-                false,
-                false,
+                doFilter: false,
                 purpose: "the data type hierarchy");
         }
         /// <summary>

--- a/Extractor/TypeCollectors/EventFieldCollector.cs
+++ b/Extractor/TypeCollectors/EventFieldCollector.cs
@@ -123,8 +123,7 @@ namespace Cognite.OpcUa.TypeCollectors
                 token,
                 ReferenceTypeIds.HierarchicalReferences,
                 (uint)NodeClass.ObjectType | (uint)NodeClass.Variable | (uint)NodeClass.Object,
-                false,
-                false,
+                doFilter: false,
                 purpose: "the event type hierarchy");
 
             var result = new Dictionary<NodeId, UAEventType>();
@@ -151,7 +150,7 @@ namespace Cognite.OpcUa.TypeCollectors
         /// </summary>
         /// <param name="child">Type or property to be handled</param>
         /// <param name="parent">Parent type id</param>
-        private void EventTypeCallback(ReferenceDescription child, NodeId parent)
+        private void EventTypeCallback(ReferenceDescription child, NodeId parent, bool visited)
         {
             var id = uaClient.ToNodeId(child.NodeId);
 

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -34,10 +34,9 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
+using Browser = Cognite.OpcUa.Browse.Browser;
 
 namespace Cognite.OpcUa
 {
@@ -236,7 +235,6 @@ namespace Cognite.OpcUa
         {
             if (Callbacks == null) throw new InvalidOperationException("Attempted to start UAClient without setting callbacks");
 
-            Browser.ResetVisitedNodes();
             // A restarted Session might mean a restarted server, so all server-relevant data must be cleared.
             // This includes any stored NodeId, which may refer to an outdated namespaceIndex
             eventFields?.Clear();

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -259,7 +259,6 @@ namespace Cognite.OpcUa
                 source.DataTypeManager.Configure();
                 source.ClearNodeOverrides();
                 source.ClearEventFields();
-                source.Browser.ResetVisitedNodes();
                 await RestartExtractor();
             }
             else
@@ -371,7 +370,7 @@ namespace Cognite.OpcUa
                 pusher.Reset();
             }
 
-            var synchTasks = await RunMapping(RootNodes, true, true, true);
+            var synchTasks = await RunMapping(RootNodes, initial: true, isFull: true);
 
             if (Config.FailureBuffer.Enabled && FailureBuffer != null)
             {
@@ -463,9 +462,7 @@ namespace Cognite.OpcUa
             await uaClient.WaitForOperations(Source.Token);
             await ConfigureExtractor();
 
-            uaClient.Browser.ResetVisitedNodes();
-
-            var synchTasks = await RunMapping(RootNodes, true, false, true);
+            var synchTasks = await RunMapping(RootNodes, initial: true, isFull: true);
 
             foreach (var task in synchTasks)
             {
@@ -487,7 +484,7 @@ namespace Cognite.OpcUa
                 {
                     nodesToBrowse.Add(id);
                 }
-                var historyTasks = await RunMapping(nodesToBrowse.Distinct(), true, false, false);
+                var historyTasks = await RunMapping(nodesToBrowse.Distinct(), initial: false, isFull: false);
 
                 foreach (var task in historyTasks)
                 {
@@ -572,29 +569,15 @@ namespace Cognite.OpcUa
             }));
         }
 
-        private bool ShouldFullyRebrowse()
-        {
-            // If there are any updates, we need to do a full mapping
-            if (Config.Extraction.Update.AnyUpdate) return true;
-            // If relationships are enabled we need to fully map, other wise we won't be able to consistently discover new relationships.
-            if (Config.Extraction.Relationships.Enabled) return true;
-            // If deletes are enabled we want a full map as well, to discover deleted nodes.
-            if (deletesManager != null) return true;
-
-            return false;
-        }
-
         /// <summary>
         /// Redo browse, then schedule history on the looper.
         /// </summary>
         public async Task Rebrowse()
         {
-            var isFull = ShouldFullyRebrowse();
             // If we are updating we want to re-discover nodes in order to run them through mapping again.
             var historyTasks = await RunMapping(RootNodes,
-                ignoreVisited: !isFull,
                 initial: false,
-                isFull: isFull);
+                isFull: true);
 
             foreach (var task in historyTasks)
             {
@@ -620,7 +603,7 @@ namespace Cognite.OpcUa
 
         #region Mapping
 
-        private async Task<IEnumerable<Func<CancellationToken, Task>>> RunMapping(IEnumerable<NodeId> nodesToBrowse, bool ignoreVisited, bool initial, bool isFull)
+        private async Task<IEnumerable<Func<CancellationToken, Task>>> RunMapping(IEnumerable<NodeId> nodesToBrowse, bool initial, bool isFull)
         {
             bool readFromOpc = true;
 
@@ -689,7 +672,7 @@ namespace Cognite.OpcUa
                 var handler = new UANodeSource(Provider.GetRequiredService<ILogger<UANodeSource>>(), Config, this, uaClient, isFull);
                 try
                 {
-                    await uaClient.Browser.BrowseNodeHierarchy(nodesToBrowse, handler.Callback, Source.Token, ignoreVisited,
+                    await uaClient.Browser.BrowseNodeHierarchy(nodesToBrowse, handler.Callback, Source.Token,
                         "the main instance hierarchy");
                 }
                 catch (Exception ex)
@@ -709,7 +692,7 @@ namespace Cognite.OpcUa
                 {
                     tasks = tasks.Append(async token =>
                     {
-                        var tasks = await RunMapping(RootNodes, false, false, true);
+                        var tasks = await RunMapping(RootNodes, initial: false, isFull: true);
                         foreach (var task in tasks)
                         {
                             Looper.Scheduler.ScheduleTask(null, task);

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -462,7 +462,7 @@ namespace Cognite.OpcUa
             await uaClient.WaitForOperations(Source.Token);
             await ConfigureExtractor();
 
-            var synchTasks = await RunMapping(RootNodes, initial: true, isFull: true);
+            var synchTasks = await RunMapping(RootNodes, initial: false, isFull: true);
 
             foreach (var task in synchTasks)
             {

--- a/Test/Integration/DataPointTests.cs
+++ b/Test/Integration/DataPointTests.cs
@@ -755,7 +755,6 @@ namespace Test.Integration
                 extractor.State.Clear();
                 extractor.GetType().GetField("subscribed", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(extractor, 0);
                 extractor.GetType().GetField("subscribeFlag", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(extractor, false);
-                tester.Client.Browser.ResetVisitedNodes();
                 tester.Client.RemoveSubscription("DataChangeListener").Wait();
             }
 

--- a/Test/Integration/EventTests.cs
+++ b/Test/Integration/EventTests.cs
@@ -193,7 +193,6 @@ namespace Test.Integration
                 extractor.State.Clear();
                 extractor.GetType().GetField("subscribed", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(extractor, 0);
                 extractor.GetType().GetField("subscribeFlag", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(extractor, false);
-                tester.Client.Browser.ResetVisitedNodes();
                 tester.Client.RemoveSubscription("EventListener").Wait();
             }
 

--- a/Test/Integration/NodeExtractionTests.cs
+++ b/Test/Integration/NodeExtractionTests.cs
@@ -1295,7 +1295,6 @@ namespace Test.Integration
 
             // Enable types only
             tester.Config.Source.NodeSetSource.Types = true;
-            tester.Client.Browser.ResetVisitedNodes();
             tester.Client.ClearEventFields();
             tester.Client.DataTypeManager.Reset();
             tester.Client.ObjectTypeManager.Reset();
@@ -1307,7 +1306,6 @@ namespace Test.Integration
             pusher.Wipe();
 
             tester.Config.Source.NodeSetSource.Instance = true;
-            tester.Client.Browser.ResetVisitedNodes();
             tester.Client.ClearEventFields();
             tester.Client.DataTypeManager.Reset();
             tester.Client.ObjectTypeManager.Reset();

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -1151,7 +1151,6 @@ namespace Test.Unit
             Assert.Empty(handler.Assets);
 
             await extractor.WaitForSubscriptions();
-            tester.Client.Browser.ResetVisitedNodes();
             await tester.Client.RemoveSubscription("DataChangeListener");
 
             extractor.State.Clear();
@@ -1226,7 +1225,6 @@ namespace Test.Unit
             Assert.Empty(handler.Assets);
 
             await extractor.WaitForSubscriptions();
-            tester.Client.Browser.ResetVisitedNodes();
             await tester.Client.RemoveSubscription("EventListener");
 
             extractor.State.Clear();
@@ -1297,7 +1295,6 @@ namespace Test.Unit
             Assert.Empty(handler.Assets);
 
             await extractor.WaitForSubscriptions();
-            tester.Client.Browser.ResetVisitedNodes();
             await tester.Client.RemoveSubscription("EventListener");
 
             extractor.State.Clear();

--- a/Test/Unit/TypeManagerTest.cs
+++ b/Test/Unit/TypeManagerTest.cs
@@ -388,7 +388,6 @@ namespace Test.Unit
         {
             var log = tester.Provider.GetRequiredService<ILogger<EventFieldCollector>>();
 
-            tester.Client.Browser.ResetVisitedNodes();
             var config = new EventConfig() { Enabled = true, AllEvents = false };
             var collector = new EventFieldCollector(log, tester.Client, config);
 
@@ -426,7 +425,6 @@ namespace Test.Unit
         {
             var log = tester.Provider.GetRequiredService<ILogger<EventFieldCollector>>();
 
-            tester.Client.Browser.ResetVisitedNodes();
             var config = new EventConfig { Enabled = true, AllEvents = true };
             var collector = new EventFieldCollector(log, tester.Client, config);
 
@@ -457,7 +455,6 @@ namespace Test.Unit
         {
             var log = tester.Provider.GetRequiredService<ILogger<EventFieldCollector>>();
 
-            tester.Client.Browser.ResetVisitedNodes();
             // Audit and conditions/alarms account for most of the event types in the base namespace
             // Also check if we still get child events once the parent is excluded (should this be how it works?)
             var config = new EventConfig { Enabled = true, AllEvents = true, ExcludeEventFilter = "Audit|Condition|Alarm|SystemEventType" };
@@ -475,7 +472,6 @@ namespace Test.Unit
         {
             var log = tester.Provider.GetRequiredService<ILogger<EventFieldCollector>>();
 
-            tester.Client.Browser.ResetVisitedNodes();
             var config = new EventConfig { Enabled = true, AllEvents = false, ExcludeProperties = new List<string> { "SubType" } };
             var collector = new EventFieldCollector(log, tester.Client, config);
 
@@ -494,7 +490,6 @@ namespace Test.Unit
         {
             var log = tester.Provider.GetRequiredService<ILogger<EventFieldCollector>>();
 
-            tester.Client.Browser.ResetVisitedNodes();
             var eventIds = tester.Server.Ids.Event;
             var config = new EventConfig
             {

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -117,7 +117,6 @@ namespace Test.Utils
             {
                 Client.ClearNodeOverrides();
                 Client.ClearEventFields();
-                Client.Browser.ResetVisitedNodes();
                 Client.DataTypeManager.Reset();
                 Client.RemoveSubscription("EventListener").Wait();
                 Client.RemoveSubscription("DataChangeListener").Wait();


### PR DESCRIPTION
First of a series of PRs porting changes made in the FDM branch to master. Both to reduce the eventual complexity of the FDM change, and to actually get these fixes in without introducing too many bugs.

This is an old feature intended to reduce the load on rebrowse. In the very early days of the extractor, we did not do any form of updates at all, and only discovered new nodes. It was nice, then, to ignore nodes already when browsing, so that we don't read the values of these nodes.

In general though, users almost always want updates, and the cost is not that large. Reading attributes is usually the cheapest part of the rebrowse process.

This PR removes checking for visited nodes entirely, except within the current browse (we need to do this to avoid cycles). If we encounter a node we have already visited we now pass that along to the callback instead. This was necessary in the FDM branch in order to register all relationships, if a node appears twice in the hierarchy (which is valid!).

Note that this is _not_ a breaking change. It does not change the behavior of the extractor, since we still validate check for changes when writing to CDF. It will increase rebrowse time on servers with the default configuration.