### PR TITLE
Fix reconnect after service level change

### DIFF
--- a/Extractor/SessionManager.cs
+++ b/Extractor/SessionManager.cs
@@ -50,7 +50,6 @@ namespace Cognite.OpcUa
             this.log = log;
             liveToken = token;
             Timeout = timeout;
-            EndpointUrl = config.EndpointUrl;
         }
 
         private async Task TryWithBackoff(Func<Task> method, int maxBackoff, CancellationToken token)
@@ -113,6 +112,7 @@ namespace Cognite.OpcUa
                 if (!string.IsNullOrEmpty(config.ReverseConnectUrl))
                 {
                     newSession = await WaitForReverseConnect();
+                    EndpointUrl = config.EndpointUrl;
                 }
                 else if (config.IsRedundancyEnabled)
                 {
@@ -124,6 +124,7 @@ namespace Cognite.OpcUa
                 else
                 {
                     newSession = await CreateSessionDirect(config.EndpointUrl!);
+                    EndpointUrl = config.EndpointUrl;
                 }
                 SetNewSession(newSession);
             };
@@ -232,7 +233,6 @@ namespace Cognite.OpcUa
                     0,
                     identity,
                     null);
-                EndpointUrl = config.EndpointUrl;
                 return session;
             }
             catch (Exception ex)
@@ -282,7 +282,6 @@ namespace Cognite.OpcUa
                     identity,
                     null
                 );
-                EndpointUrl = endpointUrl;
                 return session;
             }
             catch (Exception ex)

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -320,7 +320,7 @@ namespace Test.Unit
             await tester.Client.Close(tester.Source.Token);
             tester.Server.SetServerRedundancyStatus(230, RedundancySupport.Hot);
             tester.Config.Source.Redundancy.MonitorServiceLevel = true;
-            tester.Callbacks.ServiceLevelCbCount = 0;
+            tester.Callbacks.Reset();
             var altServer = new ServerController(new[] {
                 PredefinedSetup.Base
             }, tester.Provider, 62300)
@@ -348,6 +348,8 @@ namespace Test.Unit
 
                 Assert.Equal(230, sm.CurrentServiceLevel);
                 Assert.Equal(0, tester.Callbacks.ServiceLevelCbCount);
+                Assert.Equal(1, tester.Callbacks.LowServiceLevelCbCount);
+                Assert.Equal(1, tester.Callbacks.ReconnectCbCount);
                 Assert.Equal(sm.EndpointUrl, tester.Config.Source.EndpointUrl);
 
 
@@ -361,6 +363,7 @@ namespace Test.Unit
                 await TestUtils.WaitForCondition(() => sm.CurrentServiceLevel == 190, 10, "Expected service level to drop");
 
                 Assert.Equal(sm.EndpointUrl, tester.Config.Source.EndpointUrl);
+                Assert.Equal(2, tester.Callbacks.LowServiceLevelCbCount);
 
                 // Set the servicelevel back up, should trigger a callback, but no switch
                 tester.Server.SetServerRedundancyStatus(255, RedundancySupport.Hot);

--- a/Test/Utils/DummyClientCallbacks.cs
+++ b/Test/Utils/DummyClientCallbacks.cs
@@ -11,6 +11,8 @@ namespace Test.Utils
         public bool Connected { get; set; }
         public int ServiceLevelCbCount { get; set; }
         public int LowServiceLevelCbCount { get; set; }
+        public int ReconnectCbCount { get; set; }
+        public int DisconnectCbCount { get; set; }
 
         public DummyClientCallbacks(CancellationToken token)
         {
@@ -20,12 +22,14 @@ namespace Test.Utils
         public Task OnServerDisconnect(UAClient source)
         {
             Connected = false;
+            DisconnectCbCount++;
             return Task.CompletedTask;
         }
 
         public Task OnServerReconnect(UAClient source)
         {
             Connected = true;
+            ReconnectCbCount++;
             return Task.CompletedTask;
         }
 
@@ -39,6 +43,14 @@ namespace Test.Utils
         {
             LowServiceLevelCbCount++;
             return Task.CompletedTask;
+        }
+
+        public void Reset()
+        {
+            DisconnectCbCount = 0;
+            ReconnectCbCount = 0;
+            ServiceLevelCbCount = 0;
+            LowServiceLevelCbCount = 0;
         }
     }
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -60,6 +60,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.16.1":
+    description: "Correctly restart history after reconnect due to service level threshold"
+    changelog:
+      fixed:
+        - "Fixed a bug causing the extractor to not properly detect that the server had changed when reconnecting due to service level change"
   "2.16.0":
     description: "Support for certificate authentication to CDF"
     changelog:


### PR DESCRIPTION
The extractor uses the stored EndpointUrl to check for whether the endpoint has changed after an attempted redundant reconnect. This didn't work properly, because it was set inside CreateSessionDirect.

This removes that, which should fix the problem.