### PR TITLE
Replace pusher debug with dry-run option

### DIFF
--- a/Extractor/Config/CogniteConfig.cs
+++ b/Extractor/Config/CogniteConfig.cs
@@ -34,7 +34,7 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public string? DataSetExternalId { get; set; }
         /// <summary>
-        ///  Debug mode, if true, Extractor will not push to target
+        /// DEPRECATED. Debug mode, if true, Extractor will not push to target
         /// </summary>
         public bool Debug { get; set; }
         /// <summary>

--- a/Extractor/Config/FullConfig.cs
+++ b/Extractor/Config/FullConfig.cs
@@ -95,6 +95,10 @@ namespace Cognite.OpcUa.Config
         /// Configuration for high availability support.
         /// </summary>
         public HighAvailabilityConfig HighAvailability { get; set; } = null!;
+        /// <summary>
+        /// Do not push any data to destinations.
+        /// </summary>
+        public bool DryRun { get; set; }
         public override void GenerateDefaults()
         {
             if (Source == null) Source = new SourceConfig();

--- a/Extractor/Config/InfluxConfig.cs
+++ b/Extractor/Config/InfluxConfig.cs
@@ -46,7 +46,7 @@ namespace Cognite.OpcUa.Config
         [DefaultValue(100_000)]
         public int PointChunkSize { get; set; } = 100000;
         /// <summary>
-        /// Debug mode, if true, Extractor will not push to target.
+        /// DEPRECATED. Debug mode, if true, Extractor will not push to target.
         /// </summary>
         public bool Debug { get; set; }
         /// <summary>

--- a/Extractor/Config/MqttConfig.cs
+++ b/Extractor/Config/MqttConfig.cs
@@ -101,7 +101,7 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public long InvalidateBefore { get; set; }
         /// <summary>
-        /// If true, pusher will not push to target.
+        /// DEPRECATED. If true, pusher will not push to target.
         /// </summary>
         public bool Debug { get; set; }
         public bool ReadExtractedRanges { get; set; }

--- a/Extractor/Deletes.cs
+++ b/Extractor/Deletes.cs
@@ -84,14 +84,14 @@ namespace Cognite.OpcUa
             if (deletedStates.Any())
             {
                 logger.LogInformation("Found {Del} stored nodes in {Tab} that no longer exist and will be marked as deleted", deletedStates.Count, tableName);
-                await stateStore.DeleteExtractionState(deletedStates.Select(d => new NodeExistsState(d.Id, time)), tableName, token);
+                if (!config.DryRun) await stateStore.DeleteExtractionState(deletedStates.Select(d => new NodeExistsState(d.Id, time)), tableName, token);
             }
 
             var newStates = states.Values.Where(s => !oldStates.ContainsKey(s.Id)).ToList();
             if (newStates.Any())
             {
                 logger.LogInformation("Found {New} new nodes in {Tab}, adding to state store...", newStates.Count, tableName);
-                await stateStore.StoreExtractionState(newStates, tableName, s => new BaseStorableState { Id = s.Id }, token);
+                if (!config.DryRun) await stateStore.StoreExtractionState(newStates, tableName, s => new BaseStorableState { Id = s.Id }, token);
             }
 
             return deletedStates.Select(d => d.Id);

--- a/Extractor/FailureBuffer.cs
+++ b/Extractor/FailureBuffer.cs
@@ -193,7 +193,7 @@ namespace Cognite.OpcUa
                 }
                 if (extractor.AllowUpdateState) bufferState.UpdateDestinationRange(value.First, value.Last);
             }
-            if (config.InfluxStateStore && extractor.StateStorage != null)
+            if (config.InfluxStateStore && extractor.StateStorage != null && !fullConfig.DryRun)
             {
                 log.LogInformation("Try to write {Count} states to state store", nodeBufferStates.Count);
                 await extractor.StateStorage.StoreExtractionState(nodeBufferStates.Values,
@@ -222,7 +222,7 @@ namespace Cognite.OpcUa
 
             log.LogInformation("Push {Count} points to failurebuffer", points.Count());
 
-            if (config.Influx && influxPusher != null)
+            if (config.Influx && influxPusher != null && !fullConfig.DryRun)
             {
                 await WriteDatapointsInflux(pointRanges, token);
             }
@@ -252,7 +252,7 @@ namespace Cognite.OpcUa
         {
             bool success = true;
 
-            if (UseInflux() && nodeBufferStates.Any())
+            if (UseInflux() && nodeBufferStates.Any() && !fullConfig.DryRun)
             {
                 try
                 {
@@ -316,7 +316,7 @@ namespace Cognite.OpcUa
                 if (extractor.AllowUpdateState) bufferState.UpdateDestinationRange(group.Range.Min, group.Range.Max);
             }
 
-            if (config.InfluxStateStore && extractor.StateStorage != null)
+            if (config.InfluxStateStore && extractor.StateStorage != null && !fullConfig.DryRun)
             {
                 await extractor.StateStorage.StoreExtractionState(eventBufferStates.Values,
                     fullConfig.StateStorage.InfluxEventStore, token);
@@ -343,7 +343,7 @@ namespace Cognite.OpcUa
 
             log.LogInformation("Push {Count} events to failurebuffer", events.Count());
 
-            if (config.Influx)
+            if (config.Influx && !fullConfig.DryRun)
             {
                 await WriteEventsInflux(events, token);
             }
@@ -373,7 +373,7 @@ namespace Cognite.OpcUa
         {
             bool success = true;
 
-            if (UseInflux() && eventBufferStates.Any())
+            if (UseInflux() && eventBufferStates.Any() && !fullConfig.DryRun)
             {
                 try
                 {

--- a/Extractor/FailureBuffer.cs
+++ b/Extractor/FailureBuffer.cs
@@ -211,7 +211,7 @@ namespace Cognite.OpcUa
         /// <returns>True on success</returns>
         public async Task<bool> WriteDatapoints(IEnumerable<UADataPoint> points, IDictionary<string, TimeRange> pointRanges, CancellationToken token)
         {
-            if (points == null || !points.Any() || pointRanges == null || !pointRanges.Any()) return true;
+            if (points == null || !points.Any() || pointRanges == null || !pointRanges.Any() || fullConfig.DryRun) return true;
 
             points = points.GroupBy(pt => pt.Id)
                 .Where(group => !extractor.State.GetNodeState(group.Key)?.FrontfillEnabled ?? false)
@@ -222,7 +222,7 @@ namespace Cognite.OpcUa
 
             log.LogInformation("Push {Count} points to failurebuffer", points.Count());
 
-            if (config.Influx && influxPusher != null && !fullConfig.DryRun)
+            if (config.Influx && influxPusher != null)
             {
                 await WriteDatapointsInflux(pointRanges, token);
             }
@@ -332,7 +332,7 @@ namespace Cognite.OpcUa
         /// <returns>True on success</returns>
         public async Task<bool> WriteEvents(IEnumerable<UAEvent> events, CancellationToken token)
         {
-            if (events == null || !events.Any()) return true;
+            if (events == null || !events.Any() || fullConfig.DryRun) return true;
 
             events = events.GroupBy(evt => evt.EmittingNode)
                 .Where(group => !extractor.State.GetEmitterState(group.Key)?.FrontfillEnabled ?? false)
@@ -343,7 +343,7 @@ namespace Cognite.OpcUa
 
             log.LogInformation("Push {Count} events to failurebuffer", events.Count());
 
-            if (config.Influx && !fullConfig.DryRun)
+            if (config.Influx)
             {
                 await WriteEventsInflux(events, token);
             }

--- a/Extractor/Looper.cs
+++ b/Extractor/Looper.cs
@@ -16,6 +16,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. */
 
 using Cognite.Extractor.Common;
+using Cognite.Extractor.Logging;
 using Cognite.OpcUa.Config;
 using Microsoft.Extensions.Logging;
 using Prometheus;
@@ -78,7 +79,7 @@ namespace Cognite.OpcUa
             Scheduler.SchedulePeriodicTask(nameof(ExtraTasks), Timeout.InfiniteTimeSpan, ExtraTasks, false);
 
             Scheduler.SchedulePeriodicTask(nameof(Rebrowse), config.Extraction.AutoRebrowsePeriodValue, Rebrowse, false);
-            if (extractor.StateStorage != null)
+            if (extractor.StateStorage != null && !config.DryRun)
             {
                 var interval = config.StateStorage.IntervalValue.Value;
                 Scheduler.SchedulePeriodicTask(nameof(StoreState), interval, StoreState, interval != Timeout.InfiniteTimeSpan);
@@ -126,70 +127,79 @@ namespace Cognite.OpcUa
         }
 
 
+        private async Task CheckFailingPushers(CancellationToken token)
+        {
+            if (!failingPushers.Any()) return;
+
+            var result = await Task.WhenAll(failingPushers.Select(pusher => pusher.TestConnection(config, token)));
+            var recovered = result.Select((res, idx) => (result: res, pusher: failingPushers.ElementAt(idx)))
+                .Where(x => x.result == true).ToList();
+
+            if (recovered.Any())
+            {
+                log.LogInformation("Pushers {Names} recovered", string.Join(", ", recovered.Select(val => val.pusher.GetType())));
+            }
+
+
+            if (recovered.Any(pair => !pair.pusher.Initialized))
+            {
+                var tasks = new List<Task>();
+                var toInit = recovered.Select(pair => pair.pusher).Where(pusher => !pusher.Initialized);
+                foreach (var pusher in toInit)
+                {
+                    pusher.NoInit = false;
+                    tasks.Add(extractor.PushNodes(pusher.PendingNodes, pusher, true));
+                    pusher.PendingNodes = null;
+                }
+
+                await Task.WhenAll(tasks);
+            }
+            foreach (var pair in recovered)
+            {
+                if (pair.pusher.Initialized)
+                {
+                    pair.pusher.DataFailing = true;
+                    pair.pusher.EventsFailing = true;
+                    failingPushers.Remove(pair.pusher);
+                    passingPushers.Add(pair.pusher);
+                }
+            }
+        }
+
+
         private async Task Pushers(CancellationToken token)
         {
             if (token.IsCancellationRequested) return;
-            if (failingPushers.Any())
+
+            if (!config.DryRun)
             {
-                var result = await Task.WhenAll(failingPushers.Select(pusher => pusher.TestConnection(config, token)));
-                var recovered = result.Select((res, idx) => (result: res, pusher: failingPushers.ElementAt(idx)))
-                    .Where(x => x.result == true).ToList();
+                await CheckFailingPushers(token);
 
-                if (recovered.Any())
-                {
-                    log.LogInformation("Pushers {Names} recovered", string.Join(", ", recovered.Select(val => val.pusher.GetType())));
-                }
-
-
-                if (recovered.Any(pair => !pair.pusher.Initialized))
-                {
-                    var tasks = new List<Task>();
-                    var toInit = recovered.Select(pair => pair.pusher).Where(pusher => !pusher.Initialized);
-                    foreach (var pusher in toInit)
-                    {
-                        pusher.NoInit = false;
-                        tasks.Add(extractor.PushNodes(pusher.PendingNodes, pusher, true));
-                        pusher.PendingNodes = null;
-                    }
-
-                    await Task.WhenAll(tasks);
-                }
-                foreach (var pair in recovered)
-                {
-                    if (pair.pusher.Initialized)
-                    {
-                        pair.pusher.DataFailing = true;
-                        pair.pusher.EventsFailing = true;
-                        failingPushers.Remove(pair.pusher);
-                        passingPushers.Add(pair.pusher);
-                    }
-                }
-            }
-
-            var results = await Task.WhenAll(
+                var results = await Task.WhenAll(
                 Task.Run(async () =>
                     await extractor.Streamer.PushDataPoints(passingPushers, failingPushers, token), token),
                 Task.Run(async () => await extractor.Streamer.PushEvents(passingPushers, failingPushers, token), token));
 
-            if (results.Any(res => res))
-            {
-                try
+                if (results.Any(res => res))
                 {
-                    Scheduler.TryTriggerTask(nameof(HistoryRestart));
+                    try
+                    {
+                        Scheduler.TryTriggerTask(nameof(HistoryRestart));
+                    }
+                    catch { }
                 }
-                catch { }
-            }
 
-            var failedPushers = passingPushers.Where(pusher =>
+                var failedPushers = passingPushers.Where(pusher =>
                 pusher.DataFailing && extractor.Streamer.AllowData
                 || pusher.EventsFailing && extractor.Streamer.AllowEvents
                 || !pusher.Initialized).ToList();
-            foreach (var pusher in failedPushers)
-            {
-                pusher.DataFailing = extractor.Streamer.AllowData;
-                pusher.EventsFailing = extractor.Streamer.AllowEvents;
-                failingPushers.Add(pusher);
-                passingPushers.Remove(pusher);
+                foreach (var pusher in failedPushers)
+                {
+                    pusher.DataFailing = extractor.Streamer.AllowData;
+                    pusher.EventsFailing = extractor.Streamer.AllowEvents;
+                    failingPushers.Add(pusher);
+                    passingPushers.Remove(pusher);
+                }
             }
 
             numPushes.Inc();

--- a/Extractor/PubSub/PubSubManager.cs
+++ b/Extractor/PubSub/PubSubManager.cs
@@ -35,11 +35,13 @@ namespace Cognite.OpcUa.PubSub
         private UaPubSubApplication? app;
         private readonly ILogger<PubSubManager> log;
         private readonly PubSubConfig config;
+        private readonly FullConfig fullConfig;
         private readonly UAExtractor extractor;
-        public PubSubManager(ILogger<PubSubManager> logger, UAClient client, UAExtractor extractor, PubSubConfig config)
+        public PubSubManager(ILogger<PubSubManager> logger, UAClient client, UAExtractor extractor, FullConfig config)
         {
-            this.config = config;
-            configurator = new ServerPubSubConfigurator(logger, client, config);
+            this.config = config.PubSub;
+            fullConfig = config;
+            configurator = new ServerPubSubConfigurator(logger, client, this.config);
             this.extractor = extractor;
             log = logger;
         }
@@ -119,7 +121,7 @@ namespace Cognite.OpcUa.PubSub
 
         private void SaveConfig(PubSubConfigurationDataType config)
         {
-            if (string.IsNullOrWhiteSpace(this.config.FileName)) return;
+            if (string.IsNullOrWhiteSpace(this.config.FileName) || fullConfig.DryRun) return;
             log.LogInformation("Saving PubSub configuration to {Name}", this.config.FileName);
             using var stream = new FileStream(this.config.FileName, FileMode.Create, FileAccess.Write);
 

--- a/Extractor/Pushers/CDFPusher.cs
+++ b/Extractor/Pushers/CDFPusher.cs
@@ -129,7 +129,6 @@ namespace Cognite.OpcUa.Pushers
                 kvp => kvp.Value.Select(
                     dp => dp.IsString ? new Datapoint(dp.Timestamp, dp.StringValue) : new Datapoint(dp.Timestamp, dp.DoubleValue.Value))
                 );
-            if (config.Debug) return null;
 
             try
             {
@@ -203,7 +202,7 @@ namespace Cognite.OpcUa.Pushers
                 count++;
             }
 
-            if (count == 0 || config.Debug) return null;
+            if (count == 0) return null;
 
             try
             {
@@ -269,7 +268,7 @@ namespace Cognite.OpcUa.Pushers
 
             if (!variables.Any() && !objects.Any() && !references.Any())
             {
-                if (!config.Debug && callback != null)
+                if (callback != null)
                 {
                     await callback.Call(report, token);
                 }
@@ -278,15 +277,6 @@ namespace Cognite.OpcUa.Pushers
             }
 
             log.LogInformation("Testing {TotalNodesToTest} nodes against CDF", variables.Count() + objects.Count());
-            if (config.Debug)
-            {
-                foreach (var node in objects.Concat(variables))
-                {
-                    log.LogDebug("{Node}", node);
-                }
-                log.LogInformation("Pusher is in debug mode, no nodes will be pushed to CDF");
-                return result;
-            }
 
             try
             {
@@ -369,7 +359,7 @@ namespace Cognite.OpcUa.Pushers
             bool backfillEnabled,
             CancellationToken token)
         {
-            if (!states.Any() || config.Debug || !config.ReadExtractedRanges) return true;
+            if (!states.Any() || !config.ReadExtractedRanges) return true;
             var ids = new List<string>();
             foreach (var state in states)
             {
@@ -448,7 +438,6 @@ namespace Cognite.OpcUa.Pushers
         /// <returns>True if pushing is possible, false if not.</returns>
         public async Task<bool?> TestConnection(FullConfig fullConfig, CancellationToken token)
         {
-            if (config.Debug) return true;
             try
             {
                 await destination.TestCogniteConfig(token);

--- a/Extractor/Pushers/CDFPusher.cs
+++ b/Extractor/Pushers/CDFPusher.cs
@@ -291,7 +291,7 @@ namespace Cognite.OpcUa.Pushers
 
             if (!variables.Any() && !objects.Any() && !references.Any())
             {
-                if (callback != null)
+                if (callback != null && !fullConfig.DryRun)
                 {
                     await callback.Call(report, token);
                 }

--- a/Extractor/Pushers/CDFPusher.cs
+++ b/Extractor/Pushers/CDFPusher.cs
@@ -146,7 +146,6 @@ namespace Cognite.OpcUa.Pushers
                         foreach (var skipped in missing.Skipped)
                         {
                             missingTimeseries.Add(skipped.Id.ExternalId);
-                            realCount -= skipped.DataPoints.Count();
                         }
                         missingTimeseriesCnt.Set(missing.Skipped.Count());
                     }
@@ -158,11 +157,23 @@ namespace Cognite.OpcUa.Pushers
                         foreach (var skipped in mismatched.Skipped)
                         {
                             mismatchedTimeseries.Add(skipped.Id.ExternalId);
-                            realCount -= skipped.DataPoints.Count();
                         }
                         mismatchedTimeseriesCnt.Set(mismatched.Skipped.Count());
                     }
+
+                    foreach (var err in result.Errors)
+                    {
+                        if (err.Skipped != null)
+                        {
+                            foreach (var skipped in err.Skipped)
+                            {
+                                realCount -= skipped.DataPoints.Count();
+                            }
+                        }
+                    }
                 }
+
+                
 
                 result.ThrowOnFatal();
                 log.LogDebug("Successfully pushed {Real} / {Total} points to CDF", realCount, count);

--- a/Extractor/Pushers/InfluxPusher.cs
+++ b/Extractor/Pushers/InfluxPusher.cs
@@ -127,8 +127,6 @@ namespace Cognite.OpcUa
                 ipoints.AddRange(group.Select(dp => UADataPointToInflux(ts, dp)));
             }
 
-            if (config.Debug) return null;
-
             try
             {
                 await client.PostPointsAsync(config.Database, ipoints, config.PointChunkSize);
@@ -190,7 +188,6 @@ namespace Cognite.OpcUa
             if (count == 0) return null;
 
             var points = evts.Select(UAEventToInflux);
-            if (config.Debug) return null;
             try
             {
                 await client.PostPointsAsync(config.Database, points, config.PointChunkSize);
@@ -217,7 +214,7 @@ namespace Cognite.OpcUa
             bool backfillEnabled,
             CancellationToken token)
         {
-            if (states == null || !states.Any() || config.Debug || !config.ReadExtractedRanges) return true;
+            if (states == null || !states.Any() || !config.ReadExtractedRanges) return true;
             if (Extractor == null) throw new InvalidOperationException("Extractor must be set");
             var ranges = new ConcurrentDictionary<string, TimeRange>();
 
@@ -383,7 +380,7 @@ namespace Cognite.OpcUa
             bool backfillEnabled,
             CancellationToken token)
         {
-            if (states == null || !states.Any() || config.Debug || !config.ReadExtractedEventRanges) return true;
+            if (states == null || !states.Any() || !config.ReadExtractedEventRanges) return true;
             IEnumerable<string> eventSeries;
             try
             {
@@ -424,7 +421,6 @@ namespace Cognite.OpcUa
         /// <returns>True on success</returns>
         public async Task<bool?> TestConnection(FullConfig fullConfig, CancellationToken token)
         {
-            if (config.Debug) return true;
             IEnumerable<string> dbs;
             try
             {
@@ -570,7 +566,6 @@ namespace Cognite.OpcUa
             IDictionary<string, InfluxBufferState> states,
             CancellationToken token)
         {
-            if (config.Debug) return Array.Empty<UADataPoint>();
             token.ThrowIfCancellationRequested();
 
             var fetchTasks = states.Select(state => client.QueryMultiSeriesAsync(config.Database,
@@ -682,7 +677,7 @@ namespace Cognite.OpcUa
             CancellationToken token)
         {
             if (Extractor == null) throw new InvalidOperationException("Extractor must be set");
-            if (config.Debug || states == null) return Array.Empty<UAEvent>();
+            if (states == null) return Array.Empty<UAEvent>();
             token.ThrowIfCancellationRequested();
 
             var fetchTasks = states.Select(state => client.QueryMultiSeriesAsync(config.Database,

--- a/Extractor/Pushers/InfluxPusher.cs
+++ b/Extractor/Pushers/InfluxPusher.cs
@@ -197,13 +197,14 @@ namespace Cognite.OpcUa
 
             if (count == 0) return null;
 
+            var points = evts.Select(UAEventToInflux);
+
             if (fullConfig.DryRun)
             {
                 log.LogInformation("Dry run enabled. Would insert {Count} events to influxdb", count);
                 return null;
             }
 
-            var points = evts.Select(UAEventToInflux);
             try
             {
                 await client.PostPointsAsync(config.Database, points, config.PointChunkSize);

--- a/ExtractorLauncher/ExtractorStarter.cs
+++ b/ExtractorLauncher/ExtractorStarter.cs
@@ -89,6 +89,21 @@ namespace Cognite.OpcUa
                 log.LogWarning("source.queue-length is deprecated. Use subscriptions.queue-length instead.");
                 config.Subscriptions.QueueLength = config.Source.QueueLength.Value;
             }
+            if (config.Cognite?.Debug ?? false)
+            {
+                log.LogWarning("cognite.debug is deprecated. Use dry-run instead.");
+                config.DryRun = true;
+            }
+            if (config.Mqtt?.Debug ?? false)
+            {
+                log.LogWarning("mqtt.debug is deprecated. Use dry-run instead.");
+                config.DryRun = true;
+            }
+            if (config.Influx?.Debug ?? false)
+            {
+                log.LogWarning("influx.debug is deprecated. Use dry-run instead.");
+                config.DryRun = true;
+            }
 
             return null;
         }
@@ -120,6 +135,7 @@ namespace Cognite.OpcUa
             }
             config.Source.AutoAccept |= setup.AutoAccept;
             config.Source.ExitOnFailure |= setup is ExtractorParams p2 && p2.Exit;
+            config.DryRun |= setup.DryRun;
 
             if (options != null)
             {

--- a/ExtractorLauncher/ExtractorStarter.cs
+++ b/ExtractorLauncher/ExtractorStarter.cs
@@ -292,7 +292,7 @@ namespace Cognite.OpcUa
                 var conf = provider.GetService<FullConfig>();
                 var log = provider.GetRequiredService<ILogger<InfluxPusher>>();
                 if (conf?.Influx == null) return null!;
-                return new InfluxPusher(log, conf.Influx);
+                return new InfluxPusher(log, conf);
             });
             services.AddSingleton<IPusher, MQTTPusher>(provider =>
             {

--- a/ExtractorLauncher/Program.cs
+++ b/ExtractorLauncher/Program.cs
@@ -58,6 +58,8 @@ namespace Cognite.OpcUa
         public string? WorkingDir { get; set; }
         [CommandLineOption("Run extractor without a yml config file. The .xml config file is still needed", true, "-n")]
         public bool NoConfig { get; set; }
+        [CommandLineOption("Run the extractor in dry-run mode. In this mode, it will not push anything to destinations")]
+        public bool DryRun { get; set; }
 
         public bool ConfigTool { get; set; }
         public FullConfig? Config { get; set; }

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -122,8 +122,6 @@ namespace Test.Unit
                 new UADataPoint(time.AddSeconds(1), "test-ts-double", double.NaN)
             };
 
-            Assert.Null(await pusher.PushDataPoints(invalidDps, tester.Source.Token));
-
             var dps = new[]
             {
                 new UADataPoint(time, "test-ts-double", 123),

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -122,6 +122,8 @@ namespace Test.Unit
                 new UADataPoint(time.AddSeconds(1), "test-ts-double", double.NaN)
             };
 
+            Assert.Null(await pusher.PushDataPoints(invalidDps, tester.Source.Token));
+
             var dps = new[]
             {
                 new UADataPoint(time, "test-ts-double", 123),
@@ -180,7 +182,7 @@ namespace Test.Unit
             Assert.Null(await pusher.PushDataPoints(invalidDps, tester.Source.Token));
 
             Assert.True(CommonTestUtils.TestMetricValue("opcua_datapoints_pushed_cdf", 6));
-            Assert.True(CommonTestUtils.TestMetricValue("opcua_datapoint_pushes_cdf", 2));
+            Assert.True(CommonTestUtils.TestMetricValue("opcua_datapoint_pushes_cdf", 3));
         }
         [Fact]
         public async Task TestPushEvents()

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -55,6 +55,10 @@ namespace Test.Unit
         {
             handler.AllowConnectionTest = false;
 
+            tester.Config.DryRun = true;
+            Assert.True(await pusher.TestConnection(tester.Config, tester.Source.Token));
+            tester.Config.DryRun = false;
+
             Assert.False(await pusher.TestConnection(tester.Config, tester.Source.Token));
 
             handler.AllowConnectionTest = true;
@@ -114,6 +118,8 @@ namespace Test.Unit
             // Null input
             Assert.Null(await pusher.PushDataPoints(null, tester.Source.Token));
 
+            tester.Config.DryRun = true;
+
             var time = DateTime.UtcNow;
 
             var invalidDps = new[]
@@ -132,6 +138,11 @@ namespace Test.Unit
                 new UADataPoint(time.AddSeconds(1), "test-ts-string", "string2"),
                 new UADataPoint(time, "test-ts-missing", "value")
             };
+
+            // Debug true
+            Assert.Null(await pusher.PushDataPoints(dps, tester.Source.Token));
+
+            tester.Config.DryRun = false;
 
             handler.FailedRoutes.Add("/timeseries/data");
 
@@ -182,7 +193,7 @@ namespace Test.Unit
             Assert.Null(await pusher.PushDataPoints(invalidDps, tester.Source.Token));
 
             Assert.True(CommonTestUtils.TestMetricValue("opcua_datapoints_pushed_cdf", 6));
-            Assert.True(CommonTestUtils.TestMetricValue("opcua_datapoint_pushes_cdf", 3));
+            Assert.True(CommonTestUtils.TestMetricValue("opcua_datapoint_pushes_cdf", 2));
         }
         [Fact]
         public async Task TestPushEvents()
@@ -236,6 +247,10 @@ namespace Test.Unit
                 }
             };
 
+            tester.Config.DryRun = true;
+            Assert.Null(await pusher.PushEvents(events, tester.Source.Token));
+            tester.Config.DryRun = false;
+
             handler.FailedRoutes.Add("/events");
             Assert.False(await pusher.PushEvents(events, tester.Source.Token));
             Assert.True(CommonTestUtils.TestMetricValue("opcua_event_push_failures_cdf", 1));
@@ -273,8 +288,15 @@ namespace Test.Unit
             var update = new UpdateConfig();
             Assert.True((await pusher.PushNodes(Enumerable.Empty<BaseUANode>(), tss, rels, update, tester.Source.Token)).Objects);
 
-            // Fail to create assets
+            // Test debug mode
             var node = new UAObject(tester.Server.Ids.Base.Root, "BaseRoot", null, null, NodeId.Null, null);
+            tester.Config.DryRun = true;
+            Assert.True((await pusher.PushNodes(new[] { node }, tss, rels, update, tester.Source.Token)).Objects);
+            tester.Config.DryRun = false;
+            Assert.Empty(handler.Assets);
+
+            // Fail to create assets
+            node = new UAObject(tester.Server.Ids.Base.Root, "BaseRoot", null, null, NodeId.Null, null);
             handler.FailedRoutes.Add("/assets");
             Assert.False((await pusher.PushNodes(new[] { node }, tss, rels, update, tester.Source.Token)).Objects);
             handler.FailedRoutes.Clear();
@@ -408,8 +430,16 @@ namespace Test.Unit
             var assets = Enumerable.Empty<BaseUANode>();
             var update = new UpdateConfig();
 
-            // Fail to create timeseries
+            // Test debug mode
             var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            node.FullAttributes.DataType = dt;
+            tester.Config.DryRun = true;
+            Assert.True((await pusher.PushNodes(assets, new[] { node }, rels, update, tester.Source.Token)).Variables);
+            tester.Config.DryRun = false;
+            Assert.Empty(handler.Timeseries);
+
+            // Fail to create timeseries
+            node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
             node.FullAttributes.DataType = dt;
             handler.FailedRoutes.Add("/timeseries");
             Assert.False((await pusher.PushNodes(assets, new[] { node }, rels, update, tester.Source.Token)).Variables);

--- a/Test/Unit/FailureBufferTest.cs
+++ b/Test/Unit/FailureBufferTest.cs
@@ -92,7 +92,7 @@ namespace Test.Unit
 
             cfg.FailureBuffer.Influx = true;
             var iflog = tester.Provider.GetRequiredService<ILogger<InfluxPusher>>();
-            using var pusher = new InfluxPusher(iflog, tester.Config.Influx);
+            using var pusher = new InfluxPusher(iflog, tester.Config);
             Assert.Throws<ConfigurationException>(() => new FailureBuffer(log, cfg, extractor, null));
 
             var fb3 = new FailureBuffer(log, cfg, extractor, pusher);
@@ -109,7 +109,7 @@ namespace Test.Unit
             var log = tester.Provider.GetRequiredService<ILogger<FailureBuffer>>();
             var iflog = tester.Provider.GetRequiredService<ILogger<InfluxPusher>>();
 
-            using var pusher = new InfluxPusher(iflog, tester.Config.Influx);
+            using var pusher = new InfluxPusher(iflog, tester.Config);
             var fb1 = new FailureBuffer(log, cfg, extractor, pusher);
 
             Assert.False(fb1.AnyPoints);
@@ -194,7 +194,7 @@ namespace Test.Unit
             var log = tester.Provider.GetRequiredService<ILogger<FailureBuffer>>();
             var iflog = tester.Provider.GetRequiredService<ILogger<InfluxPusher>>();
 
-            using var pusher = new InfluxPusher(iflog, tester.Config.Influx);
+            using var pusher = new InfluxPusher(iflog, tester.Config);
             var fb1 = new FailureBuffer(log, cfg, extractor, pusher);
 
             var dt = new UADataType(DataTypeIds.Double);
@@ -282,7 +282,7 @@ namespace Test.Unit
             var log = tester.Provider.GetRequiredService<ILogger<FailureBuffer>>();
             var iflog = tester.Provider.GetRequiredService<ILogger<InfluxPusher>>();
 
-            using var pusher = new InfluxPusher(iflog, tester.Config.Influx);
+            using var pusher = new InfluxPusher(iflog, tester.Config);
             var fb1 = new FailureBuffer(log, cfg, extractor, pusher);
 
             var estate1 = new EventExtractionState(extractor, new NodeId("emitter1"), false, false, true);

--- a/Test/Unit/InfluxPusherTest.cs
+++ b/Test/Unit/InfluxPusherTest.cs
@@ -46,6 +46,11 @@ namespace Test.Unit
             tester.Config.Influx.Host = "http://localhost:8000";
             pusher.Reconfigure();
 
+            // Debug true
+            tester.Config.DryRun = true;
+            Assert.True(await pusher.TestConnection(tester.Config, tester.Source.Token));
+            tester.Config.DryRun = false;
+
             // Fail due to bad host
             Assert.False(await pusher.TestConnection(tester.Config, tester.Source.Token));
 
@@ -113,6 +118,8 @@ namespace Test.Unit
             };
             Assert.Null(await pusher.PushDataPoints(invalidDps, tester.Source.Token));
 
+            tester.Config.DryRun = true;
+
             var time = DateTime.UtcNow;
 
             var dps = new[]
@@ -122,6 +129,14 @@ namespace Test.Unit
                 new UADataPoint(time, "test-ts-string", "string"),
                 new UADataPoint(time.AddSeconds(1), "test-ts-string", "string2")
             };
+
+            // Debug true
+            Assert.Null(await pusher.PushDataPoints(dps, tester.Source.Token));
+
+            Assert.Empty(await GetAllDataPoints(pusher, extractor, "test-ts-double"));
+            Assert.Empty(await GetAllDataPoints(pusher, extractor, "test-ts-string", true));
+
+            tester.Config.DryRun = false;
 
             tester.Config.Influx.Host = "http://localhost:8000";
             pusher.Reconfigure();
@@ -242,6 +257,11 @@ namespace Test.Unit
                     }
                 }
             };
+
+            tester.Config.DryRun = true;
+            Assert.Null(await pusher.PushEvents(events, tester.Source.Token));
+            tester.Config.DryRun = false;
+
 
             tester.Config.Influx.Host = "http://localhost:8000";
             pusher.Reconfigure();

--- a/Test/Unit/InfluxPusherTest.cs
+++ b/Test/Unit/InfluxPusherTest.cs
@@ -46,11 +46,6 @@ namespace Test.Unit
             tester.Config.Influx.Host = "http://localhost:8000";
             pusher.Reconfigure();
 
-            // Debug true
-            tester.Config.Influx.Debug = true;
-            Assert.True(await pusher.TestConnection(tester.Config, tester.Source.Token));
-            tester.Config.Influx.Debug = false;
-
             // Fail due to bad host
             Assert.False(await pusher.TestConnection(tester.Config, tester.Source.Token));
 
@@ -118,8 +113,6 @@ namespace Test.Unit
             };
             Assert.Null(await pusher.PushDataPoints(invalidDps, tester.Source.Token));
 
-            tester.Config.Influx.Debug = true;
-
             var time = DateTime.UtcNow;
 
             var dps = new[]
@@ -129,14 +122,6 @@ namespace Test.Unit
                 new UADataPoint(time, "test-ts-string", "string"),
                 new UADataPoint(time.AddSeconds(1), "test-ts-string", "string2")
             };
-
-            // Debug true
-            Assert.Null(await pusher.PushDataPoints(dps, tester.Source.Token));
-
-            Assert.Empty(await GetAllDataPoints(pusher, extractor, "test-ts-double"));
-            Assert.Empty(await GetAllDataPoints(pusher, extractor, "test-ts-string", true));
-
-            tester.Config.Influx.Debug = false;
 
             tester.Config.Influx.Host = "http://localhost:8000";
             pusher.Reconfigure();
@@ -257,11 +242,6 @@ namespace Test.Unit
                     }
                 }
             };
-
-            tester.Config.Influx.Debug = true;
-            Assert.Null(await pusher.PushEvents(events, tester.Source.Token));
-            tester.Config.Influx.Debug = false;
-
 
             tester.Config.Influx.Host = "http://localhost:8000";
             pusher.Reconfigure();

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -142,7 +142,7 @@ namespace Test.Utils
             {
                 ClearLiteDB(client).Wait();
             }
-            var pusher = new InfluxPusher(Provider.GetRequiredService<ILogger<InfluxPusher>>(), Config.Influx);
+            var pusher = new InfluxPusher(Provider.GetRequiredService<ILogger<InfluxPusher>>(), Config);
             return (pusher, client);
         }
 

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -9,6 +9,11 @@
 # Version of the config schema
 version: 1
 
+# Set this to true to run the extractor in dry-run mode.
+# In this mode, the extractor will read data from OPC-UA, but not push it to any destination.
+# The extractor will still read data from destinations, if configured.
+dry-run: false
+
 source:
     # The URL of the OPC-UA server to connect to.
     # This is used as discovery URL.
@@ -214,8 +219,6 @@ cognite:
     api-key:
     # Cognite service url
     host: "https://api.cognitedata.com"
-    # Debug mode, if true, Extractor will not push to target
-    debug: false
     # Replace all instances of NaN with this floating point number. If left empty, ignore instead.
     nan-replacement:
     # Whether to read start/end-points on startup, where possible. At least one pusher should be able to do this,
@@ -408,8 +411,6 @@ influx:
     password:
     # Database to connect to, will not be created automatically
     database:
-    # Debug mode, if true, Extractor will not push to target
-    debug:
     # Replace all instances of NaN or Infinity with this floating point number. If left empty, ignore instead.
     non-finite-replacement:
     # Whether to read start/end-points on startup, where possible. At least one pusher should be able to do this,
@@ -461,8 +462,6 @@ mqtt:
     # On extractor restart, assets/timeseries created before this will be attempted re-created in CDF.
     # They will not be deleted or updated.
     invalidate-before: 0
-    # If true, pusher will not push to target
-    debug: false
     # Replace all instances of NaN, Infinity or values greater than 1E100 with this floating point number. If left empty, ignore instead.
     non-finite-replacement:
     # Do not push any metadata at all. If this is true, plain timeseries without metadata will be created,


### PR DESCRIPTION
This is a bit more general, the pusher debug option was always a bit artificial. This is intended as a proper way to prevent the extractor from persisting anything, while still letting users see what the extractor would do.

This should mostly not access destinations at all. The exception is if CDF is configured as source, which is intentional.