### PR TITLE
Catch null callbacks in client

### DIFF
--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -1044,6 +1044,12 @@ namespace Cognite.OpcUa
         {
             if (sender is not Subscription sub || !sub.PublishingStopped) return;
 
+            if (Callbacks?.TaskScheduler == null)
+            {
+                log.LogWarning("Failed to recreate subscription, client callbacks are not set");
+                return;
+            }
+
             Callbacks.TaskScheduler.ScheduleTask(null, t => RecreateSubscription(sub, t));
         }
 


### PR DESCRIPTION
This should not be possible, I cannot find a code path that produces this, but I have a log that shows a nullreferenceexception in OnSubscriptionPublishStatusChange, and this is the only thing that could cause that.