### PR TITLE
Add extra metadata per type

### DIFF
--- a/Extractor/Pushers/FDM/BaseDataModelDefinitions.cs
+++ b/Extractor/Pushers/FDM/BaseDataModelDefinitions.cs
@@ -330,5 +330,40 @@ namespace Cognite.OpcUa.Pushers.FDM
                 }
             };
         }
+
+        public static ContainerCreate TypeMeta(string space)
+        {
+            return new ContainerCreate
+            {
+                Description = "Metadata for OPC UA types",
+                ExternalId = "TypeMeta",
+                Name = "TypeMeta",
+                Space = space,
+                UsedFor = UsedFor.node,
+                Properties = new Dictionary<string, ContainerPropertyDefinition>
+                {
+                    { "properties", new ContainerPropertyDefinition
+                    {
+                        Type = BasePropertyType.Create(PropertyTypeVariant.json),
+                        Nullable = false
+                    } },
+                    { "nodeId", new ContainerPropertyDefinition
+                    {
+                        Type = BasePropertyType.Text(),
+                        Nullable = false
+                    } },
+                    { "isSimple", new ContainerPropertyDefinition
+                    {
+                        Type = BasePropertyType.Create(PropertyTypeVariant.boolean),
+                        Nullable = false
+                    } },
+                    { "parent", new ContainerPropertyDefinition
+                    {
+                        Type = BasePropertyType.Text(),
+                        Nullable = true
+                    } }
+                }
+            };
+        }
     }
 }

--- a/Extractor/Pushers/FDM/FDMWriter.cs
+++ b/Extractor/Pushers/FDM/FDMWriter.cs
@@ -277,6 +277,20 @@ namespace Cognite.OpcUa.Pushers.FDM
                 Space = instSpace
             };
 
+            var typeMeta = types.Types.Values.Select(v => (BaseInstanceWrite)new NodeWrite
+            {
+                ExternalId = $"{v.ExternalId}_TypeMetadata",
+                Space = instSpace,
+                Sources = new[]
+                {
+                    new InstanceData<TypeMetadata>
+                    {
+                        Source = new ContainerIdentifier(instSpace, "TypeMeta"),
+                        Properties = v.GetTypeMetadata()
+                    }
+                }
+            });
+
             // Ingest types first
             log.LogInformation("Ingesting {Count1} object types, {Count2} reference types, {Count3} dataTypes",
                 instanceBuilder.ObjectTypes.Count,
@@ -285,6 +299,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             await IngestInstances(instanceBuilder.ObjectTypes
                 .Concat(instanceBuilder.ReferenceTypes)
                 .Concat(instanceBuilder.DataTypes)
+                .Concat(typeMeta)
                 .Append(serverMeta), 1000, token);
 
             // Then ingest variable types

--- a/Extractor/Pushers/FDM/NodeTypeCollector.cs
+++ b/Extractor/Pushers/FDM/NodeTypeCollector.cs
@@ -173,15 +173,15 @@ namespace Cognite.OpcUa.Pushers.FDM
                 return;
             }
 
+            var nextPath = path.Append(name);
             if (node.Node is UAVariable variable)
             {
-                type.Properties[fullName] = new DMSReferenceNode(variable, node.Reference.Reference, fullName)
+                type.Properties[fullName] = new DMSReferenceNode(variable, node.Reference.Reference, fullName, nextPath)
                 {
                     ModellingRule = node.Reference.ModellingRule
                 };
             }
 
-            var nextPath = path.Append(name);
             foreach (var child in node.Children.Values)
             {
                 CollectChild(type, child, nextPath);

--- a/Extractor/Pushers/FDM/NodeTypeCollector.cs
+++ b/Extractor/Pushers/FDM/NodeTypeCollector.cs
@@ -176,7 +176,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             var nextPath = path.Append(name);
             if (node.Node is UAVariable variable)
             {
-                type.Properties[fullName] = new DMSReferenceNode(variable, node.Reference.Reference, fullName, nextPath)
+                type.Properties[fullName] = new DMSReferenceNode(variable, node.Reference.Reference, fullName)
                 {
                     ModellingRule = node.Reference.ModellingRule
                 };

--- a/Extractor/Pushers/FDM/NodeTypeCollector.cs
+++ b/Extractor/Pushers/FDM/NodeTypeCollector.cs
@@ -142,25 +142,25 @@ namespace Cognite.OpcUa.Pushers.FDM
             {
                 foreach (var child in type.Children.Values)
                 {
-                    CollectChild(type, child, Enumerable.Empty<string>());
+                    CollectChild(type, child, Enumerable.Empty<QualifiedName>());
                 }
             }
         }
 
-        private string GetPath(IEnumerable<string> path, string name)
+        private string GetPath(IEnumerable<QualifiedName> path, string name)
         {
             if (path.Any())
             {
-                return $"{string.Join('_', path)}_{name}";
+                return $"{string.Join('_', path.Select(p => p.Name))}_{name}";
             }
             return name;
         }
 
-        private void CollectChild(FullUANodeType type, ChildNode node, IEnumerable<string> path)
+        private void CollectChild(FullUANodeType type, ChildNode node, IEnumerable<QualifiedName> path)
         {
             var name = node.Reference.BrowseName;
             var nodeType = Types[node.Node.TypeDefinition!];
-            var fullName = GetPath(path, name);
+            var fullName = GetPath(path, name.Name);
             if (!nodeType.IsSimple()
                 || node.Reference.ModellingRule != ModellingRule.Optional && node.Reference.ModellingRule != ModellingRule.Mandatory
                 || !node.Reference.Reference.IsHierarchical)

--- a/Extractor/Pushers/FDM/TypeHierarchyBuilder.cs
+++ b/Extractor/Pushers/FDM/TypeHierarchyBuilder.cs
@@ -249,6 +249,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             batch.Add(BaseDataModelDefinitions.ReferenceType(space), "BaseType");
             batch.Add(BaseDataModelDefinitions.DataType(space), "BaseType");
             batch.Add(BaseDataModelDefinitions.ServerMeta(space));
+            batch.Add(BaseDataModelDefinitions.TypeMeta(space));
 
             nodeTypes.MapNodeTypes(nodes);
 

--- a/Extractor/Pushers/FDM/TypeHierarchyBuilder.cs
+++ b/Extractor/Pushers/FDM/TypeHierarchyBuilder.cs
@@ -108,8 +108,8 @@ namespace Cognite.OpcUa.Pushers.FDM
                 {
                     view.Properties.Add(rf.ExternalId, new ConnectionDefinition
                     {
-                        Description = rf.BrowseName,
-                        Name = rf.BrowseName,
+                        Description = rf.BrowseName.Name,
+                        Name = rf.BrowseName.Name,
                         Direction = ConnectionDirection.outwards,
                         Source = GetViewIdentifier(rf.ExternalId, type.ExternalId, rf, config),
                         Type = new DirectRelationIdentifier(space, rf.Reference.Type.Id.ToString())
@@ -167,7 +167,7 @@ namespace Cognite.OpcUa.Pushers.FDM
                 res[kvp.Value.ExternalId] = new ContainerPropertyDefinition
                 {
                     Description = type.Node.Attributes.Description,
-                    Name = kvp.Value.BrowseName,
+                    Name = kvp.Value.BrowseName.Name,
                     Type = typ,
                     Nullable = kvp.Value.ModellingRule != ModellingRule.Mandatory || (typ is DirectRelationPropertyType) || config.IgnoreMandatory,
                     DefaultValue = (typ.Type == PropertyTypeVariant.direct || kvp.Value.Node.IsArray && typ.Type != PropertyTypeVariant.json)

--- a/Extractor/Pushers/FDM/TypeMetadata.cs
+++ b/Extractor/Pushers/FDM/TypeMetadata.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Cognite.OpcUa.Pushers.FDM
+{
+    public class PropertyMetadata
+    {
+        public IEnumerable<string>? BrowsePath { get; set; }
+        public string? NodeId { get; set; }
+        public string? DataType { get; set; }
+        public string? TypeDefinition { get; set; }
+        public int[]? ArrayDimensions { get; set; }
+        public int? ValueRank { get; set; }
+    }
+
+    public class TypeMetadata
+    {
+        public Dictionary<string, PropertyMetadata>? Properties { get; set; }
+        public string? NodeId { get; set; }
+        public bool IsSimple { get; set; }
+        public string? Parent { get; set; }
+    }
+}

--- a/Extractor/Pushers/FDM/TypeMetadata.cs
+++ b/Extractor/Pushers/FDM/TypeMetadata.cs
@@ -5,19 +5,20 @@ using System.Text.Json.Serialization;
 
 namespace Cognite.OpcUa.Pushers.FDM
 {
-    public class PropertyMetadata
+    public class PropertyNode
     {
-        public IEnumerable<string>? BrowsePath { get; set; }
         public string? NodeId { get; set; }
-        public string? DataType { get; set; }
         public string? TypeDefinition { get; set; }
+        public string? DataType { get; set; }
         public int[]? ArrayDimensions { get; set; }
         public int? ValueRank { get; set; }
+        public string? BrowseName { get; set; }
     }
+
 
     public class TypeMetadata
     {
-        public Dictionary<string, PropertyMetadata>? Properties { get; set; }
+        public Dictionary<string, IEnumerable<PropertyNode>>? Properties { get; set; }
         public string? NodeId { get; set; }
         public bool IsSimple { get; set; }
         public string? Parent { get; set; }

--- a/Extractor/Pushers/FDM/Types/NodeTypes.cs
+++ b/Extractor/Pushers/FDM/Types/NodeTypes.cs
@@ -34,11 +34,11 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
             {
                 IsSimple = IsSimple(),
                 NodeId = NodeId.ToString(),
-                Parent = Parent?.NodeId?.ToString(),
+                Parent = Parent?.ExternalId,
                 Properties = Properties.ToDictionary(kvp => kvp.Key, kvp => new PropertyMetadata
                 {
                     ArrayDimensions = kvp.Value.Node.ArrayDimensions,
-                    BrowsePath = kvp.Value.BrowsePath,
+                    BrowsePath = kvp.Value.BrowsePath.Select(p => $"{p.NamespaceIndex}:{p.Name}"),
                     DataType = kvp.Value.Node.FullAttributes.DataType.Id.ToString(),
                     TypeDefinition = kvp.Value.Node.TypeDefinition?.ToString(),
                     NodeId = kvp.Value.Node.Id.ToString(),
@@ -55,7 +55,7 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
         {
             Reference = new ReferenceNode(
               node.NodeClass,
-              node.Attributes.BrowseName?.Name ?? node.Name ?? "",
+              node.Attributes.BrowseName ?? new QualifiedName(node.Name ?? ""),
               externalId ?? node.Attributes.BrowseName?.Name ?? node.Name ?? "",
               reference
             );
@@ -86,7 +86,7 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
         public ChildNode AddChild(BaseUANode node, UAReference reference)
         {
             var child = new ChildNode(node, reference);
-            Children[child.Reference.BrowseName] = child;
+            Children[child.Reference.BrowseName.Name] = child;
             return child;
         }
 

--- a/Extractor/Pushers/FDM/Types/ReferenceTypes.cs
+++ b/Extractor/Pushers/FDM/Types/ReferenceTypes.cs
@@ -8,7 +8,7 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
 {
     public class NodeTypeReference : ReferenceNode
     {
-        public NodeTypeReference(NodeClass nodeClass, string browseName, string externalId, UAReference uaReference)
+        public NodeTypeReference(NodeClass nodeClass, QualifiedName browseName, string externalId, UAReference uaReference)
             : base(nodeClass, browseName, externalId, uaReference)
         {
         }
@@ -20,9 +20,9 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
     {
         public UAVariable Node { get; set; }
         public BasePropertyType? DMSType { get; set; }
-        public IEnumerable<string> BrowsePath { get; set; }
-        public DMSReferenceNode(UAVariable node, UAReference reference, string externalId, IEnumerable<string> browsePath)
-            : base(node.NodeClass, node.Attributes.BrowseName?.Name ?? node.Name ?? "", externalId, reference)
+        public IEnumerable<QualifiedName> BrowsePath { get; set; }
+        public DMSReferenceNode(UAVariable node, UAReference reference, string externalId, IEnumerable<QualifiedName> browsePath)
+            : base(node.NodeClass, node.Attributes.BrowseName ?? new QualifiedName(node.Name ?? ""), externalId, reference)
         {
             Node = node;
             BrowsePath = browsePath;
@@ -31,12 +31,12 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
     public class ReferenceNode
     {
         public NodeClass NodeClass { get; }
-        public string BrowseName { get; }
+        public QualifiedName BrowseName { get; }
         public string ExternalId { get; }
         public UAReference Reference { get; }
         public ModellingRule ModellingRule { get; set; } = ModellingRule.Optional;
 
-        public ReferenceNode(NodeClass nodeClass, string browseName, string externalId, UAReference uaReference)
+        public ReferenceNode(NodeClass nodeClass, QualifiedName browseName, string externalId, UAReference uaReference)
         {
             Reference = uaReference;
             BrowseName = browseName;

--- a/Extractor/Pushers/FDM/Types/ReferenceTypes.cs
+++ b/Extractor/Pushers/FDM/Types/ReferenceTypes.cs
@@ -2,6 +2,7 @@ using Cognite.OpcUa.Nodes;
 using Cognite.OpcUa.Types;
 using CogniteSdk.Beta.DataModels;
 using Opc.Ua;
+using System.Collections.Generic;
 
 namespace Cognite.OpcUa.Pushers.FDM.Types
 {
@@ -19,10 +20,12 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
     {
         public UAVariable Node { get; set; }
         public BasePropertyType? DMSType { get; set; }
-        public DMSReferenceNode(UAVariable node, UAReference reference, string externalId)
+        public IEnumerable<string> BrowsePath { get; set; }
+        public DMSReferenceNode(UAVariable node, UAReference reference, string externalId, IEnumerable<string> browsePath)
             : base(node.NodeClass, node.Attributes.BrowseName?.Name ?? node.Name ?? "", externalId, reference)
         {
             Node = node;
+            BrowsePath = browsePath;
         }
     }
     public class ReferenceNode

--- a/Extractor/Pushers/FDM/Types/ReferenceTypes.cs
+++ b/Extractor/Pushers/FDM/Types/ReferenceTypes.cs
@@ -20,12 +20,10 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
     {
         public UAVariable Node { get; set; }
         public BasePropertyType? DMSType { get; set; }
-        public IEnumerable<QualifiedName> BrowsePath { get; set; }
-        public DMSReferenceNode(UAVariable node, UAReference reference, string externalId, IEnumerable<QualifiedName> browsePath)
+        public DMSReferenceNode(UAVariable node, UAReference reference, string externalId)
             : base(node.NodeClass, node.Attributes.BrowseName ?? new QualifiedName(node.Name ?? ""), externalId, reference)
         {
             Node = node;
-            BrowsePath = browsePath;
         }
     }
     public class ReferenceNode

--- a/Test/Unit/FDMTests.cs
+++ b/Test/Unit/FDMTests.cs
@@ -57,14 +57,14 @@ namespace Test.Unit
             // FolderType, BaseObjectType, BaseVariableType, BaseDataVariableType, PropertyType,
             // 3 custom object types, 2 custom variable types
             // BaseNode, BaseType, +4 type types, and ModellingRuleType
-            Assert.Equal(18, handler.Views.Count);
+            Assert.Equal(19, handler.Views.Count);
             // 8 base types, 2 custom object types, 1 custom variable type have container data
-            Assert.Equal(12, handler.Containers.Count);
+            Assert.Equal(13, handler.Containers.Count);
             foreach (var inst in handler.Instances)
             {
                 tester.Log.LogInformation("{Key}", inst.Key);
             }
-            Assert.Equal(52, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "node"));
+            Assert.Equal(63, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "node"));
             Assert.Equal(71, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "edge"));
         }
 
@@ -83,10 +83,10 @@ namespace Test.Unit
             // FolderType, BaseObjectType, BaseVariableType, BaseDataVariableType, PropertyType,
             // 3 custom object types, 1 custom variable type
             // BaseNode, BaseType, +4 type types, and ModellingRuleType
-            Assert.Equal(17, handler.Views.Count);
+            Assert.Equal(18, handler.Views.Count);
             // 8 base types, 2 custom object types, 1 custom variable type have container data
-            Assert.Equal(12, handler.Containers.Count);
-            Assert.Equal(52, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "node"));
+            Assert.Equal(13, handler.Containers.Count);
+            Assert.Equal(62, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "node"));
             Assert.Equal(71, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "edge"));
         }
 
@@ -105,10 +105,10 @@ namespace Test.Unit
             // FolderType, BaseObjectType, BaseVariableType, BaseDataVariableType, PropertyType,
             // 3 custom object types, 1 custom variable type
             // BaseNode, BaseType, +4 type types, ModellingRuleType, and DataTypeSystemType
-            Assert.Equal(18, handler.Views.Count);
+            Assert.Equal(19, handler.Views.Count);
             // 8 base types, 2 custom object types, 1 custom variable type have container data
-            Assert.Equal(12, handler.Containers.Count);
-            Assert.Equal(2144, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "node"));
+            Assert.Equal(13, handler.Containers.Count);
+            Assert.Equal(2155, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "node"));
             Assert.Equal(6137, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "edge"));
         }
 
@@ -124,11 +124,11 @@ namespace Test.Unit
             await extractor.RunExtractor(true);
 
             Assert.Single(handler.Spaces);
-            Assert.Equal(213, handler.Views.Count);
-            Assert.Equal(132, handler.Containers.Count);
+            Assert.Equal(214, handler.Views.Count);
+            Assert.Equal(133, handler.Containers.Count);
             // Numbers are lower because more types are mapped, so more nodes are mapped as metadata.
             // This isn't always desired. You may want the entire type hierarchy without the types for all nodes.
-            Assert.Equal(1668, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "node"));
+            Assert.Equal(1874, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "node"));
             Assert.Equal(3824, handler.Instances.Count(inst => inst.Value["instanceType"].ToString() == "edge"));
         }
     }


### PR DESCRIPTION
This is necessary for the interface, it turns out. We _could_ try to infer this information from the node hierarchy, but this is probably a better solution.