### PR TITLE
Fix FileNotFound issue when pushing datapoints on windows

### DIFF
--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="MQTTnet" Version="3.1.2" />
     <PackageReference Include="CogniteSdk" Version="3.11.2" />
     <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="Google.Protobuf" Version="3.23.4" />
   </ItemGroup>
   <!--ItemGroup>
     <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config\" />

--- a/MQTTCDFBridge/MQTTCDFBridge.csproj
+++ b/MQTTCDFBridge/MQTTCDFBridge.csproj
@@ -11,5 +11,6 @@
     <PackageReference Include="Cognite.ExtractorUtils" Version="1.12.5" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="MQTTnet" Version="3.1.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.23.3" />
   </ItemGroup>
 </Project>

--- a/manifest.yml
+++ b/manifest.yml
@@ -60,6 +60,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.20.3":
+    description: Fix issue causing the extractor to fail to push datapoints on windows.
+    changelog:
+      fixed:
+        - "Fix FileNotFound issue when pushing datapoints on windows"
   "2.20.2":
     description: Improve error messages
   "2.20.0":


### PR DESCRIPTION
It's some bizarre dependency error. Makes no damn sense, probably something really weird with how the protobuf library is loaded.