### PR TITLE
Add metadata about properties to FDM nodes

### DIFF
--- a/Extractor/Config/CogniteConfig.cs
+++ b/Extractor/Config/CogniteConfig.cs
@@ -115,12 +115,6 @@ namespace Cognite.OpcUa.Config
         public bool DeleteRelationships { get; set; }
 
         /// <summary>
-        /// Configuration for writing to a custom OPC-UA flexible data model.
-        /// </summary>
-        [Obsolete("Deprecated! Use MetadataTargetsConfig.FdmDestinationConfig instead.")]
-        public FdmDestinationConfig? FlexibleDataModels { get; set; }
-
-        /// <summary>
         /// This is the implementation of the metadata targets 
         /// </summary>
         public MetadataTargetsConfig? MetadataTargets { get; set; }

--- a/Extractor/Pushers/FDM/BaseDataModelDefinitions.cs
+++ b/Extractor/Pushers/FDM/BaseDataModelDefinitions.cs
@@ -39,6 +39,12 @@ namespace Cognite.OpcUa.Pushers.FDM
                         Type = BasePropertyType.Text(),
                         Name = "BrowseName",
                         Nullable = true
+                    } },
+                    { "NodeMeta", new ContainerPropertyDefinition
+                    {
+                        Type = BasePropertyType.Create(PropertyTypeVariant.json),
+                        Name = "NodeMeta",
+                        Nullable = true
                     } }
                 },
                 Indexes = new Dictionary<string, BaseIndex>

--- a/Extractor/Pushers/Writers/WriterUtils.cs
+++ b/Extractor/Pushers/Writers/WriterUtils.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using Cognite.Extractor.Utils;
 using Cognite.OpcUa.Config;


### PR DESCRIPTION
We need this because there is no way to distinguish between a property being null and not existing in FDM. The map is to the original NodeId of the property, which will be useful if we ever need to map those over.