### PR TITLE
Allow sharing server between extractors

### DIFF
--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -13,14 +13,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AdysTech.InfluxDB.Client.Net.Core" Version="0.25.0" />
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.13.1" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.14.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.4.371.60" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.4.371.96" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.4.371.60-beta" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="MQTTnet" Version="3.1.2" />
-    <PackageReference Include="CogniteSdk" Version="3.11.2" />
     <PackageReference Include="System.Text.Json" Version="7.0.3" />
     <PackageReference Include="Google.Protobuf" Version="3.24.3" />
   </ItemGroup>

--- a/Extractor/Pushers/FDM/BaseDataModelDefinitions.cs
+++ b/Extractor/Pushers/FDM/BaseDataModelDefinitions.cs
@@ -58,37 +58,6 @@ namespace Cognite.OpcUa.Pushers.FDM
             };
         }
 
-        public static ViewCreate ViewFromContainer(ContainerCreate container, string version, string? baseView)
-        {
-            var properties = new Dictionary<string, ICreateViewProperty>();
-            foreach (var kvp in container.Properties)
-            {
-                properties[kvp.Key] = new ViewPropertyCreate
-                {
-                    Container = new ContainerIdentifier(container.Space, container.ExternalId),
-                    Description = kvp.Value.Description,
-                    Name = kvp.Value.Name,
-                    ContainerPropertyIdentifier = kvp.Key,
-                    Source = kvp.Value.Type is DirectRelationPropertyType dt ?
-                        new ViewIdentifier(container.Space, dt.Container.ExternalId, version) : null
-                };
-            }
-
-            return new ViewCreate
-            {
-                Description = container.Description,
-                ExternalId = container.ExternalId,
-                Name = container.Name,
-                Space = container.Space,
-                Version = version,
-                Properties = properties,
-                Implements = baseView is not null ? new[]
-                {
-                    new ViewIdentifier(container.Space, baseView, version)
-                } : null
-            };
-        }
-
         public static ContainerCreate BaseVariable(string space)
         {
             return new ContainerCreate

--- a/Extractor/Pushers/FDM/FDMWriter.cs
+++ b/Extractor/Pushers/FDM/FDMWriter.cs
@@ -102,7 +102,7 @@ namespace Cognite.OpcUa.Pushers.FDM
 
             var serverMetaContainer = BaseDataModelDefinitions.ServerMeta(instSpace);
             await destination.CogniteClient.Beta.DataModels.UpsertContainers(new[] { serverMetaContainer }, token);
-            await destination.CogniteClient.Beta.DataModels.UpsertViews(new[] { BaseDataModelDefinitions.ViewFromContainer(serverMetaContainer, "1", null) }, token);
+            await destination.CogniteClient.Beta.DataModels.UpsertViews(new[] { serverMetaContainer.ToView("1") }, token);
         }
 
         private async Task Initialize(FDMTypeBatch types, CancellationToken token)

--- a/Extractor/Pushers/FDM/NodeIdContext.cs
+++ b/Extractor/Pushers/FDM/NodeIdContext.cs
@@ -1,0 +1,41 @@
+﻿using Opc.Ua;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Cognite.OpcUa.Pushers.FDM
+{
+    public class NodeIdContext
+    {
+        private Dictionary<ushort, ushort> namespaceIndexMap { get; }
+
+        public NodeIdContext(Dictionary<ushort, ushort> namespaceIndexMap)
+        {
+            this.namespaceIndexMap = namespaceIndexMap;
+        }
+
+        public NodeIdContext(List<string> finalNamespaces, IEnumerable<string> serverNamespaces)
+        {
+            var namespaceIndexMap = new Dictionary<ushort, ushort>();
+
+            foreach (var (ns, idx) in serverNamespaces.Select((v, i) => (v, i)))
+            {
+                var mappedIndex = finalNamespaces.IndexOf(ns);
+                if (mappedIndex == -1) throw new InvalidOperationException("Failed to map namespace indices");
+                namespaceIndexMap.Add((ushort)idx, (ushort)mappedIndex);
+            }
+            this.namespaceIndexMap = namespaceIndexMap;
+        }
+
+
+        public string NodeIdToString(NodeId id)
+        {
+            var buf = new StringBuilder();
+            var idx = namespaceIndexMap[id.NamespaceIndex];
+            NodeId.Format(buf, id.Identifier, id.IdType, idx);
+            return buf.ToString();
+        }
+    }
+}

--- a/Extractor/Pushers/FDM/TypeHierarchyBuilder.cs
+++ b/Extractor/Pushers/FDM/TypeHierarchyBuilder.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Cognite.Extensions.DataModels;
 using Cognite.OpcUa.Config;
 using Cognite.OpcUa.Pushers.FDM.Types;
 using CogniteSdk.Beta.DataModels;
@@ -30,7 +31,13 @@ namespace Cognite.OpcUa.Pushers.FDM
         public void Add(ContainerCreate container, string? baseView = null)
         {
             Containers.Add(container.Name, container);
-            Views.Add(container.Name, BaseDataModelDefinitions.ViewFromContainer(container, viewVersion, baseView));
+            Views.Add(container.Name,
+                container.ToView(viewVersion,
+                    baseView == null
+                    ? new ViewIdentifier[0] 
+                    : new[] { new ViewIdentifier(container.Space, baseView, viewVersion) }
+                )
+            );
         }
 
         public void Add(FullUANodeType type, DMSValueConverter converter, FdmDestinationConfig config)
@@ -69,7 +76,7 @@ namespace Cognite.OpcUa.Pushers.FDM
                     Properties = GetContainerProperties(type, converter, config)
                 };
                 Containers.Add(ct.Name!, ct);
-                view = BaseDataModelDefinitions.ViewFromContainer(ct, viewVersion, type.Parent.ExternalId);
+                view = ct.ToView(viewVersion, new ViewIdentifier(space, type.Parent.ExternalId, viewVersion));
             }
             else
             {

--- a/Extractor/Pushers/FDM/Types/NodeTypes.cs
+++ b/Extractor/Pushers/FDM/Types/NodeTypes.cs
@@ -29,7 +29,7 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
                 && (Parent == null || Parent.IsSimple());
         }
 
-        public TypeMetadata GetTypeMetadata()
+        public TypeMetadata GetTypeMetadata(NodeIdContext context)
         {
             var properties = new Dictionary<string, IEnumerable<PropertyNode>>();
             foreach (var kvp in Properties)
@@ -52,10 +52,10 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
                     {
                         TypeDefinition = pair.node.TypeDefinition?.ToString(),
                         BrowseName = $"{pair.node.Attributes.BrowseName?.NamespaceIndex ?? 0}:{pair.node.Attributes.BrowseName?.Name ?? pair.node.Name ?? ""}",
-                        NodeId = pair.node.Id.ToString(),
+                        NodeId = context.NodeIdToString(pair.node.Id),
                         NodeClass = (int)pair.node.NodeClass,
                         IsMandatory = pair.mandatory,
-                        ReferenceType = pair.reference.Type.Id.ToString(),
+                        ReferenceType = context.NodeIdToString(pair.reference.Type.Id),
                         DisplayName = pair.node.Name ?? "",
                         ExternalId = FDMUtils.SanitizeExternalId(pair.node.Name ?? ""),
                         IsTimeseries = !pair.node.IsRawProperty && pair.node.NodeClass == NodeClass.Variable,
@@ -65,7 +65,7 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
                     if (pair.node is UAVariable nVar)
                     {
                         prop.ValueRank = nVar.ValueRank;
-                        prop.DataType = nVar.FullAttributes.DataType.Id.ToString();
+                        prop.DataType = context.NodeIdToString(nVar.FullAttributes.DataType.Id);
                         prop.ArrayDimensions = nVar.ArrayDimensions;
                     }
                     return prop;
@@ -75,7 +75,7 @@ namespace Cognite.OpcUa.Pushers.FDM.Types
             return new TypeMetadata
             {
                 IsSimple = IsSimple(),
-                NodeId = NodeId.ToString(),
+                NodeId = context.NodeIdToString(NodeId),
                 Parent = Parent?.ExternalId,
                 Properties = properties
             };

--- a/MQTTCDFBridge/MQTTCDFBridge.csproj
+++ b/MQTTCDFBridge/MQTTCDFBridge.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.13.1" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.14.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="MQTTnet" Version="3.1.2" />
     <PackageReference Include="Google.Protobuf" Version="3.24.3" />

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -10,7 +10,7 @@
     <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.13.1" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.14.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageReference Include="MQTTnet" Version="3.1.2" />

--- a/Test/CDFMockHandler.cs
+++ b/Test/CDFMockHandler.cs
@@ -245,6 +245,12 @@ namespace Test
                         case "/models/instances":
                             res = HandleCreateInstances(content);
                             break;
+                        case "/models/instances/list":
+                            res = new HttpResponseMessage(HttpStatusCode.OK)
+                            {
+                                Content = new StringContent("{\"items\":[]}")
+                            };
+                            break;
                         default:
                             log.LogWarning("Unknown path: {DummyFactoryUnknownPath}", reqPath);
                             res = new HttpResponseMessage(HttpStatusCode.InternalServerError);

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cognite.Extractor.Testing" Version="1.13.1" />
+    <PackageReference Include="Cognite.Extractor.Testing" Version="1.14.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This was originally planned for later, but this also happens to solve the issue that we need to reserve the namespace-index 1.

This is painful, because it means we need to translate node ID namespace indices to a shared set used by the server.

The change should not be too complicated. The information necessary to translate is kept in a NodeIdContext class, then we just need to make sure to use that everywhere we did `NodeId.ToString()`