### PR TITLE
Improve logging in node sources

### DIFF
--- a/Extractor/NodeSources/CDFNodeSource.cs
+++ b/Extractor/NodeSources/CDFNodeSource.cs
@@ -84,7 +84,7 @@ namespace Cognite.OpcUa.NodeSources
             return Task.CompletedTask;
         }
 
-        public async Task<NodeLoadResult> LoadNodes(IEnumerable<NodeId> nodesToBrowse, uint nodeClassMask, HierarchicalReferenceMode hierarchicalReferences, CancellationToken token)
+        public async Task<NodeLoadResult> LoadNodes(IEnumerable<NodeId> nodesToBrowse, uint nodeClassMask, HierarchicalReferenceMode hierarchicalReferences, string purpose, CancellationToken token)
         {
             // Ignores nodesToBrowse, nothing really to do with that here
             var options = new JsonSerializerOptions();
@@ -109,7 +109,7 @@ namespace Cognite.OpcUa.NodeSources
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError("Failed to retrieve and deserialize raw timeseries from CDF: {Message}", ex.Message);
+                    logger.LogError(ex, "Failed to retrieve and deserialize raw timeseries from CDF: {Message}", ex.Message);
                     TakeResults();
                     return new NodeLoadResult(new UANodeCollection(), Enumerable.Empty<UAReference>(), true, true);
                 }
@@ -139,7 +139,7 @@ namespace Cognite.OpcUa.NodeSources
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError("Failed to retrieve and deserialize raw assets from CDF: {Message}", ex.Message);
+                    logger.LogError(ex, "Failed to retrieve and deserialize raw assets from CDF: {Message}", ex.Message);
                     TakeResults();
                     return new NodeLoadResult(new UANodeCollection(), Enumerable.Empty<UAReference>(), true, true);
                 }
@@ -159,7 +159,7 @@ namespace Cognite.OpcUa.NodeSources
             return TakeResults();
         }
 
-        public Task<NodeLoadResult> LoadNonHierarchicalReferences(IReadOnlyDictionary<NodeId, BaseUANode> parentNodes, bool getTypeReferences, bool initUnknownNodes, CancellationToken token)
+        public Task<NodeLoadResult> LoadNonHierarchicalReferences(IReadOnlyDictionary<NodeId, BaseUANode> parentNodes, bool getTypeReferences, bool initUnknownNodes, string purpose, CancellationToken token)
         {
             return Task.FromResult(
                 new NodeLoadResult(new UANodeCollection(), Enumerable.Empty<UAReference>(), true, true)

--- a/Extractor/NodeSources/CDFNodeSourceWithFallback.cs
+++ b/Extractor/NodeSources/CDFNodeSourceWithFallback.cs
@@ -26,24 +26,24 @@ namespace Cognite.OpcUa.NodeSources
             await cdfSource.Initialize(token);
         }
 
-        public async Task<NodeLoadResult> LoadNodes(IEnumerable<NodeId> nodesToBrowse, uint nodeClassMask, HierarchicalReferenceMode hierarchicalReferences, CancellationToken token)
+        public async Task<NodeLoadResult> LoadNodes(IEnumerable<NodeId> nodesToBrowse, uint nodeClassMask, HierarchicalReferenceMode hierarchicalReferences, string purpose, CancellationToken token)
         {
-            var res = await cdfSource.LoadNodes(nodesToBrowse, nodeClassMask, hierarchicalReferences, token);
+            var res = await cdfSource.LoadNodes(nodesToBrowse, nodeClassMask, hierarchicalReferences, purpose, token);
             if (!res.Nodes.Any())
             {
                 usingFallback = true;
-                return await fallbackSource.LoadNodes(nodesToBrowse, nodeClassMask, hierarchicalReferences, token);
+                return await fallbackSource.LoadNodes(nodesToBrowse, nodeClassMask, hierarchicalReferences, purpose, token);
             }
             return res;
         }
 
-        public async Task<NodeLoadResult> LoadNonHierarchicalReferences(IReadOnlyDictionary<NodeId, BaseUANode> parentNodes, bool getTypeReferences, bool initUnknownNodes, CancellationToken token)
+        public async Task<NodeLoadResult> LoadNonHierarchicalReferences(IReadOnlyDictionary<NodeId, BaseUANode> parentNodes, bool getTypeReferences, bool initUnknownNodes, string purpose, CancellationToken token)
         {
             if (usingFallback)
             {
-                return await fallbackSource.LoadNonHierarchicalReferences(parentNodes, getTypeReferences, initUnknownNodes, token);
+                return await fallbackSource.LoadNonHierarchicalReferences(parentNodes, getTypeReferences, initUnknownNodes, purpose, token);
             }
-            return await cdfSource.LoadNonHierarchicalReferences(parentNodes, getTypeReferences, initUnknownNodes, token);
+            return await cdfSource.LoadNonHierarchicalReferences(parentNodes, getTypeReferences, initUnknownNodes, purpose, token);
         }
     }
 }

--- a/Extractor/NodeSources/INodeSource.cs
+++ b/Extractor/NodeSources/INodeSource.cs
@@ -49,11 +49,13 @@ namespace Cognite.OpcUa.NodeSources
             IEnumerable<NodeId> nodesToBrowse,
             uint nodeClassMask,
             HierarchicalReferenceMode hierarchicalReferences,
+            string purpose,
             CancellationToken token);
         Task<NodeLoadResult> LoadNonHierarchicalReferences(
             IReadOnlyDictionary<NodeId, BaseUANode> parentNodes,
             bool getTypeReferences,
             bool initUnknownNodes,
+            string purpose,
             CancellationToken token);
     }
 

--- a/Extractor/NodeSources/NodeHierarchyBuilder.cs
+++ b/Extractor/NodeSources/NodeHierarchyBuilder.cs
@@ -82,7 +82,7 @@ namespace Cognite.OpcUa.NodeSources
             }
 
             // Load nodes from the source, this is the main operation
-            var initialNodes = await nodeSource.LoadNodes(nodesToRead, classMask, config.Extraction.Relationships.Mode, token);
+            var initialNodes = await nodeSource.LoadNodes(nodesToRead, classMask, config.Extraction.Relationships.Mode, "the main instance hierarchy", token);
             // Refresh any newly loaded type data. Since TypeManager is lazy, we need to do this after loading nodes,
             // but before processing them.
             await client.TypeManager.LoadTypeData(typeSource, token);
@@ -103,6 +103,7 @@ namespace Cognite.OpcUa.NodeSources
                     knownNodes.DistinctBy(n => n.Id).ToDictionary(n => n.Id),
                     usesFdm || config.Extraction.NodeTypes.AsNodes,
                     usesFdm || config.Extraction.Relationships.CreateReferencedNodes,
+                    "non-hierarchical relationships in the main instance hierarchy",
                     token);
                 // Refresh type data. This may have discovered new types.
                 await client.TypeManager.LoadTypeData(typeSource, token);

--- a/Extractor/NodeSources/UANodeSource.cs
+++ b/Extractor/NodeSources/UANodeSource.cs
@@ -67,14 +67,14 @@ namespace Cognite.OpcUa.NodeSources
             IEnumerable<NodeId> nodesToBrowse,
             uint nodeClassMask,
             HierarchicalReferenceMode hierarchicalReferences,
+            string purpose,
             CancellationToken token)
         {
             this.hierarchicalReferences = hierarchicalReferences;
 
-            await client.Browser.BrowseNodeHierarchy(nodesToBrowse, HandleNode, token,
-                "the main instance hierarchy", nodeClassMask);
+            await client.Browser.BrowseNodeHierarchy(nodesToBrowse, HandleNode, token, purpose, nodeClassMask);
 
-            if (nodeMap.Any()) await client.ReadNodeData(nodeMap, token, "the main instance hierarchy");
+            if (nodeMap.Any()) await client.ReadNodeData(nodeMap, token, purpose);
 
             return TakeResults(false);
         }
@@ -83,9 +83,10 @@ namespace Cognite.OpcUa.NodeSources
             IReadOnlyDictionary<NodeId, BaseUANode> knownNodes,
             bool getTypeReferences,
             bool initUnknownNodes,
+            string purpose,
             CancellationToken token)
         {
-            await LoadNonHierarchicalReferencesInternal(knownNodes, getTypeReferences, initUnknownNodes, token);
+            await LoadNonHierarchicalReferencesInternal(knownNodes, getTypeReferences, initUnknownNodes, purpose, token);
 
             if (nodeMap.Any()) await client.ReadNodeData(nodeMap, token, "new non-hierarchical instances");
 
@@ -106,6 +107,7 @@ namespace Cognite.OpcUa.NodeSources
             IReadOnlyDictionary<NodeId, BaseUANode> knownNodes,
             bool getTypeReferences,
             bool initUnknownNodes,
+            string purpose,
             CancellationToken token)
         {
             if (!knownNodes.Any()) return;
@@ -125,7 +127,7 @@ namespace Cognite.OpcUa.NodeSources
                 Nodes = nodesToQuery
             };
 
-            var foundReferences = await client.Browser.BrowseLevel(baseParams, token, purpose: "non-hierarchical references");
+            var foundReferences = await client.Browser.BrowseLevel(baseParams, token, purpose: purpose);
 
             int count = 0;
             foreach (var (parentId, children) in foundReferences)

--- a/Extractor/TypeCollectors/TypeManager.cs
+++ b/Extractor/TypeCollectors/TypeManager.cs
@@ -156,7 +156,7 @@ namespace Cognite.OpcUa.TypeCollectors
             }
             if (!rootNodes.Any()) return;
 
-            var result = await source.LoadNodes(rootNodes, mask, HierarchicalReferenceMode.Disabled, token);
+            var result = await source.LoadNodes(rootNodes, mask, HierarchicalReferenceMode.Disabled, "the type hierarchy", token);
             foreach (var node in result.Nodes)
             {
                 NodeMap[node.Id] = node;

--- a/Extractor/Types/UAPropertySerializer.cs
+++ b/Extractor/Types/UAPropertySerializer.cs
@@ -568,6 +568,8 @@ namespace Cognite.OpcUa.Types
 
         public override NodeId? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (uaClient.NamespaceTable == null) throw new InvalidOperationException("Attempted to deserialize NodeId without initialized client");
+
             if (reader.TokenType != JsonTokenType.StartObject) return NodeId.Null;
             var obj = JsonElement.ParseValue(ref reader);
             if (obj.ValueKind != JsonValueKind.Object) return NodeId.Null;
@@ -581,7 +583,7 @@ namespace Cognite.OpcUa.Types
             int nsIdx = 0;
             if (ns != null)
             {
-                nsIdx = uaClient.NamespaceTable!.GetIndex(ns);
+                nsIdx = uaClient.NamespaceTable.GetIndex(ns);
                 if (nsIdx < 0) return NodeId.Null;
             }
 
@@ -612,6 +614,7 @@ namespace Cognite.OpcUa.Types
 
         public override void Write(Utf8JsonWriter writer, NodeId value, JsonSerializerOptions options)
         {
+            if (uaClient.NamespaceTable == null) throw new InvalidOperationException("Attempted to serialize NodeId without initialized client");
             if (value == null)
             {
                 writer.WriteNullValue();
@@ -620,7 +623,7 @@ namespace Cognite.OpcUa.Types
             writer.WriteStartObject();
             if (value.NamespaceIndex != 0)
             {
-                var ns = uaClient.NamespaceTable!.GetString(value.NamespaceIndex);
+                var ns = uaClient.NamespaceTable.GetString(value.NamespaceIndex);
                 writer.WriteString("namespace", ns);
             }
 


### PR DESCRIPTION
I wasn't able to reproduce the bug (DOG-2235), and I won't be able to without better logging, so this just improves logging in a few places. Part of this is due to a small regression caused by the node sources change. We still want to communicate the context in which data is being extracted, it is really important for ensuring that users understand what the extractor is doing.