### PR TITLE
Add cache for subscription states

### DIFF
--- a/Extractor/RebrowseTriggerManager.cs
+++ b/Extractor/RebrowseTriggerManager.cs
@@ -19,8 +19,6 @@ namespace Cognite.OpcUa
         private readonly RebrowseTriggersConfig _config;
         private readonly UAExtractor _extractor;
 
-        public readonly static string SubscriptionName = "TriggerRebrowse";
-
         public RebrowseTriggerManager(
             ILogger<RebrowseTriggerManager> logger,
             UAClient uaClient,

--- a/Extractor/Subscriptions/AuditSubscriptionTask.cs
+++ b/Extractor/Subscriptions/AuditSubscriptionTask.cs
@@ -13,7 +13,7 @@ namespace Cognite.OpcUa.Subscriptions
     {
         private readonly MonitoredItemNotificationEventHandler handler;
         public AuditSubscriptionTask(MonitoredItemNotificationEventHandler handler)
-            : base("AuditListener", new Dictionary<NodeId, string>
+            : base(SubscriptionName.Audit, new Dictionary<NodeId, string>
             {
                 { ObjectIds.Server, "Audit: Server" }
             })

--- a/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
+++ b/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
@@ -16,14 +16,14 @@ namespace Cognite.OpcUa.Subscriptions
 {
     public abstract class BaseCreateSubscriptionTask<T> : PendingSubscriptionTask
     {
-        protected string SubscriptionName { get; }
+        protected SubscriptionName SubscriptionName { get; }
         protected Dictionary<NodeId, T> Items { get; }
         private static readonly Gauge numSubscriptions = Metrics
             .CreateGauge("opcua_subscriptions", "Number of active monitored items");
 
-        protected BaseCreateSubscriptionTask(string subscriptionName, Dictionary<NodeId, T> items)
+        protected BaseCreateSubscriptionTask(SubscriptionName name, Dictionary<NodeId, T> items)
         {
-            SubscriptionName = subscriptionName;
+            SubscriptionName = name;
             Items = items;
         }
 
@@ -35,7 +35,7 @@ namespace Cognite.OpcUa.Subscriptions
             var numToCreate = subscription.MonitoredItems.Count(m => !m.Created);
             if (numToCreate == 0) return;
 
-            await RetryUtil.RetryAsync("create monitored items", async () =>
+            await RetryUtil.RetryAsync($"create monitored items for {SubscriptionName}", async () =>
             {
                 try
                 {
@@ -49,7 +49,7 @@ namespace Cognite.OpcUa.Subscriptions
             }, retries, retries.ShouldRetryException, logger, token);
         }
 
-        private async Task CreateMonitoredItems(ILogger logger, FullConfig config, Subscription subscription, CancellationToken token)
+        private async Task CreateMonitoredItems(ILogger logger, FullConfig config, Subscription subscription, SubscriptionManager manager, CancellationToken token)
         {
             var hasSubscription = subscription.MonitoredItems.Select(s => s.ResolvedNodeId).ToHashSet();
             var toAdd = Items.Where(i => !hasSubscription.Contains(i.Key)).ToList();
@@ -69,6 +69,8 @@ namespace Cognite.OpcUa.Subscriptions
                     subscription.AddItems(items);
 
                     await CreateItemsWithRetry(logger, config.Source.Retries, subscription, token);
+
+                    manager.Cache.IncrementMonitoredItems(SubscriptionName, items.Count);
                 }
             }
 
@@ -77,7 +79,7 @@ namespace Cognite.OpcUa.Subscriptions
 
         private async Task<Subscription> EnsureSubscriptionExists(ILogger logger, ISession session, FullConfig config, SubscriptionManager subManager, CancellationToken token)
         {
-            var subscription = session.Subscriptions.FirstOrDefault(sub => sub.DisplayName.StartsWith(SubscriptionName, StringComparison.InvariantCulture));
+            var subscription = session.Subscriptions.FirstOrDefault(sub => sub.DisplayName.StartsWith(SubscriptionName.ToString(), StringComparison.InvariantCulture));
 
             if (subscription == null)
             {
@@ -85,7 +87,7 @@ namespace Cognite.OpcUa.Subscriptions
                 subscription = new Subscription(session.DefaultSubscription)
                 {
                     PublishingInterval = config.Source.PublishingInterval,
-                    DisplayName = SubscriptionName,
+                    DisplayName = SubscriptionName.ToString(),
                     KeepAliveCount = config.Subscriptions.KeepAliveCount,
                     LifetimeCount = config.Subscriptions.LifetimeCount
                 };
@@ -97,6 +99,7 @@ namespace Cognite.OpcUa.Subscriptions
                 {
                     session.AddSubscription(subscription);
                     await subscription.CreateAsync(token);
+                    subManager.Cache.InitSubscription(SubscriptionName, subscription.Id);
                 }
                 catch (Exception ex)
                 {
@@ -120,14 +123,14 @@ namespace Cognite.OpcUa.Subscriptions
             var session = await sessionManager.WaitForSession();
 
             var subscription = await RetryUtil.RetryResultAsync(
-                "ensure subscription",
+                $"ensure subscription {SubscriptionName}",
                 () => EnsureSubscriptionExists(logger, session, config, subManager, token),
                 config.Source.Retries,
                 config.Source.Retries.ShouldRetryException,
                 logger,
                 token);
 
-            await CreateMonitoredItems(logger, config, subscription, token);
+            await CreateMonitoredItems(logger, config, subscription, subManager, token);
         }
 
         // Only retry a few status codes in the outer scope. If inner retries are exhausted
@@ -141,13 +144,13 @@ namespace Cognite.OpcUa.Subscriptions
         public override async Task Run(ILogger logger, SessionManager sessionManager, FullConfig config, SubscriptionManager subManager, CancellationToken token)
         {
             await RetryUtil.RetryAsync(
-                "create subscription",
+                $"create subscription {SubscriptionName}",
                 () => RunInternal(logger, sessionManager, config, subManager, token),
                 config.Source.Retries,
                 ex => config.Source.Retries.ShouldRetryException(ex, outerStatusCodes),
                 logger,
                 token);
-            logger.LogDebug("Finished creating subscription");
+            logger.LogDebug("Finished creating subscription {Name}", SubscriptionName);
         }
     }
 }

--- a/Extractor/Subscriptions/DataPointSubscriptionTask.cs
+++ b/Extractor/Subscriptions/DataPointSubscriptionTask.cs
@@ -18,7 +18,7 @@ namespace Cognite.OpcUa.Subscriptions
     {
         private readonly MonitoredItemNotificationEventHandler handler;
         public DataPointSubscriptionTask(MonitoredItemNotificationEventHandler handler, IEnumerable<VariableExtractionState> states)
-            : base("DataChangeListener", states.ToDictionary(s => s.SourceId))
+            : base(SubscriptionName.DataPoints, states.ToDictionary(s => s.SourceId))
         {
             this.handler = handler;
         }

--- a/Extractor/Subscriptions/EventSubscriptionTask.cs
+++ b/Extractor/Subscriptions/EventSubscriptionTask.cs
@@ -19,7 +19,7 @@ namespace Cognite.OpcUa.Subscriptions
             MonitoredItemNotificationEventHandler handler,
             IEnumerable<EventExtractionState> states,
             EventFilter filter)
-            : base("EventListener", states.ToDictionary(s => s.SourceId))
+            : base(SubscriptionName.Events, states.ToDictionary(s => s.SourceId))
         {
             this.filter = filter;
             this.handler = handler;

--- a/Extractor/Subscriptions/NodeMetricsSubscriptionTask.cs
+++ b/Extractor/Subscriptions/NodeMetricsSubscriptionTask.cs
@@ -15,7 +15,7 @@ namespace Cognite.OpcUa.Subscriptions
     {
         private readonly MonitoredItemNotificationEventHandler handler;
         public NodeMetricsSubscriptionTask(MonitoredItemNotificationEventHandler handler, Dictionary<NodeId, NodeMetricState> states)
-            : base("NodeMetrics", states)
+            : base(SubscriptionName.NodeMetrics, states)
         {
             this.handler = handler;
         }

--- a/Extractor/Subscriptions/RebrowseTriggerSubscriptionTask.cs
+++ b/Extractor/Subscriptions/RebrowseTriggerSubscriptionTask.cs
@@ -14,7 +14,7 @@ namespace Cognite.OpcUa.Subscriptions
     {
         private MonitoredItemNotificationEventHandler handler;
         public RebrowseTriggerSubscriptionTask(MonitoredItemNotificationEventHandler handler,
-            Dictionary<NodeId, (NodeId, string)> ids) : base("TriggerRebrowse", ids)
+            Dictionary<NodeId, (NodeId, string)> ids) : base(SubscriptionName.RebrowseTriggers, ids)
         {
             this.handler = handler;
         }

--- a/Extractor/Subscriptions/ServiceLevelSubscriptionTask.cs
+++ b/Extractor/Subscriptions/ServiceLevelSubscriptionTask.cs
@@ -14,7 +14,7 @@ namespace Cognite.OpcUa.Subscriptions
     {
         private MonitoredItemNotificationEventHandler handler;
         public ServiceLevelSubscriptionTask(MonitoredItemNotificationEventHandler handler)
-            : base("ServiceLevel", new Dictionary<NodeId, NodeId> { { VariableIds.Server_ServiceLevel, VariableIds.Server_ServiceLevel } })
+            : base(SubscriptionName.ServiceLevel, new Dictionary<NodeId, NodeId> { { VariableIds.Server_ServiceLevel, VariableIds.Server_ServiceLevel } })
         {
             this.handler = handler;
         }

--- a/Extractor/Subscriptions/SubscriptionManager.cs
+++ b/Extractor/Subscriptions/SubscriptionManager.cs
@@ -32,6 +32,8 @@ namespace Cognite.OpcUa.Subscriptions
         private readonly Queue<PendingSubscriptionTask> taskQueue = new();
         private readonly AutoResetEvent taskQueueEvent = new AutoResetEvent(false);
 
+        public SubscriptionStateCache Cache { get; } = new();
+
         public SubscriptionManager(SessionManager sessionManager, FullConfig config, ILogger logger)
         {
             this.sessionManager = sessionManager;
@@ -123,7 +125,7 @@ namespace Cognite.OpcUa.Subscriptions
                     {
                         ExtractorUtils.LogException(logger, ex, $"Failed subscription task: {task.TaskName}");
                     }
-                } 
+                }
             }
         }
     }

--- a/Extractor/Subscriptions/SubscriptionStateCache.cs
+++ b/Extractor/Subscriptions/SubscriptionStateCache.cs
@@ -13,6 +13,23 @@ namespace Cognite.OpcUa.Subscriptions
         RebrowseTriggers,
     }
 
+    public static class SubscriptionNameMethods
+    {
+        public static string Name(this SubscriptionName name)
+        {
+            return name switch
+            {
+                SubscriptionName.Audit => "Audit",
+                SubscriptionName.DataPoints => "DataPoints",
+                SubscriptionName.Events => "Events",
+                SubscriptionName.ServiceLevel => "ServiceLevel",
+                SubscriptionName.NodeMetrics => "NodeMetrics",
+                SubscriptionName.RebrowseTriggers => "RebrowseTriggers",
+                _ => throw new ArgumentException("Subscription name is not valid")
+            };
+        }
+    }
+
     public interface ISubscriptionState
     {
         public uint SubscriptionId { get; }

--- a/Extractor/Subscriptions/SubscriptionStateCache.cs
+++ b/Extractor/Subscriptions/SubscriptionStateCache.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+
+namespace Cognite.OpcUa.Subscriptions
+{
+    public enum SubscriptionName
+    {
+        Audit,
+        DataPoints,
+        Events,
+        ServiceLevel,
+        NodeMetrics,
+        RebrowseTriggers,
+    }
+
+    public interface ISubscriptionState
+    {
+        public uint SubscriptionId { get; }
+        public SubscriptionName Name { get; }
+        public DateTime LastModifiedTime { get; }
+        public int NumMonitoredItems { get; }
+    }
+
+    public class SubscriptionStateCache
+    {
+        private class SubscriptionState : ISubscriptionState
+        {
+            public uint SubscriptionId { get; private set; }
+            public SubscriptionName Name { get; private set; }
+            public DateTime LastModifiedTime { get; private set; }
+            public int NumMonitoredItems { get; private set; }
+
+            public SubscriptionState(SubscriptionName name, uint id)
+            {
+                Name = name;
+                SubscriptionId = id;
+                LastModifiedTime = DateTime.UtcNow;
+            }
+
+            public void IncrementMonitoredItems(int num)
+            {
+                NumMonitoredItems += num;
+                LastModifiedTime = DateTime.UtcNow;
+            }
+        }
+
+        private readonly Dictionary<SubscriptionName, SubscriptionState> subscriptions = new();
+
+        private readonly object subLock = new();
+
+        public void InitSubscription(SubscriptionName name, uint id)
+        {
+            lock (subLock)
+            {
+                subscriptions[name] = new SubscriptionState(name, id);
+            }
+        }
+
+        public void IncrementMonitoredItems(SubscriptionName name, int num)
+        {
+            lock (subLock)
+            {
+                if (!subscriptions.TryGetValue(name, out var sub)) return;
+                sub.IncrementMonitoredItems(num);
+            }
+        }
+
+        public ISubscriptionState? GetSubscriptionState(SubscriptionName name)
+        {
+            lock (subLock)
+            {
+                return subscriptions.GetValueOrDefault(name);
+            }
+        }
+    }
+}

--- a/ExtractorLauncher/ExtractorLauncher.csproj
+++ b/ExtractorLauncher/ExtractorLauncher.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\Extractor\Extractor.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config\" />
+    <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />

--- a/Server/TestServer.cs
+++ b/Server/TestServer.cs
@@ -72,6 +72,7 @@ namespace Server
         private readonly string mqttUrl;
         private readonly bool logTrace;
         private readonly ILogger traceLog;
+        private readonly ILogger logger;
         private readonly IServiceProvider provider;
         private readonly IEnumerable<string> nodeSetFiles;
 
@@ -80,8 +81,9 @@ namespace Server
             this.setups = setups;
             this.mqttUrl = mqttUrl;
             this.logTrace = logTrace;
+            logger = provider.GetRequiredService<ILogger<TestServer>>();
             this.provider = provider;
-            this.traceLog = provider.GetRequiredService<ILogger<Tracing>>();
+            traceLog = provider.GetRequiredService<ILogger<Tracing>>();
             this.nodeSetFiles = nodeSetFiles;
         }
 
@@ -344,7 +346,7 @@ namespace Server
             }
             if (cnt > 0)
             {
-                Console.WriteLine($"Deleted {cnt} subscriptions manually");
+                logger.LogDebug("Deleted {Cnt} subscriptions manually", cnt);
             }
         }
     }

--- a/Test/Integration/DataPointTests.cs
+++ b/Test/Integration/DataPointTests.cs
@@ -3,6 +3,7 @@ using Cognite.Extractor.StateStorage;
 using Cognite.Extractor.Testing;
 using Cognite.OpcUa;
 using Cognite.OpcUa.Config;
+using Cognite.OpcUa.Subscriptions;
 using Cognite.OpcUa.Types;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -754,7 +755,7 @@ namespace Test.Integration
                 extractor.State.Clear();
                 extractor.GetType().GetField("subscribed", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(extractor, 0);
                 extractor.GetType().GetField("subscribeFlag", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(extractor, false);
-                await tester.RemoveSubscription("DataChangeListener");
+                await tester.RemoveSubscription(SubscriptionName.DataPoints);
             }
 
 
@@ -775,7 +776,7 @@ namespace Test.Integration
             await extractor.RunExtractor(true);
             Assert.All(extractor.State.NodeStates, state => { Assert.True(state.ShouldSubscribe); });
             await extractor.WaitForSubscriptions();
-            Assert.Equal(4u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith("DataChangeListener", StringComparison.InvariantCulture)).MonitoredItemCount);
+            Assert.Equal(4u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith(SubscriptionName.DataPoints.Name(), StringComparison.InvariantCulture)).MonitoredItemCount);
             await TestUtils.WaitForCondition(() => CommonTestUtils.TestMetricValue("opcua_frontfill_data_count", 1), 5);
 
             // Test disable subscriptions
@@ -788,7 +789,7 @@ namespace Test.Integration
             state = extractor.State.GetNodeState(ids.IntVar);
             Assert.False(state.ShouldSubscribe);
             await extractor.WaitForSubscriptions();
-            Assert.DoesNotContain(session.Subscriptions, sub => sub.DisplayName.StartsWith("DataChangeListener", StringComparison.InvariantCulture));
+            Assert.DoesNotContain(session.Subscriptions, sub => sub.DisplayName.StartsWith(SubscriptionName.DataPoints.Name(), StringComparison.InvariantCulture));
             await TestUtils.WaitForCondition(() => CommonTestUtils.TestMetricValue("opcua_frontfill_data_count", 2), 5);
 
 
@@ -815,7 +816,7 @@ namespace Test.Integration
             state = extractor.State.GetNodeState(ids.IntVar);
             Assert.True(state.ShouldSubscribe);
             await extractor.WaitForSubscriptions();
-            Assert.Equal(3u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith("DataChangeListener", StringComparison.InvariantCulture)).MonitoredItemCount);
+            Assert.Equal(3u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith(SubscriptionName.DataPoints.Name(), StringComparison.InvariantCulture)).MonitoredItemCount);
             await TestUtils.WaitForCondition(() => CommonTestUtils.TestMetricValue("opcua_frontfill_data_count", 3), 5);
         }
 

--- a/Test/Integration/EventTests.cs
+++ b/Test/Integration/EventTests.cs
@@ -211,7 +211,7 @@ namespace Test.Integration
             await extractor.RunExtractor(true);
             Assert.All(extractor.State.EmitterStates, state => { Assert.True(state.ShouldSubscribe); });
             await extractor.WaitForSubscriptions();
-            Assert.Equal(3u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith(SubscriptionName.Events.ToString(), StringComparison.InvariantCulture)).MonitoredItemCount);
+            Assert.Equal(3u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith(SubscriptionName.Events.Name(), StringComparison.InvariantCulture)).MonitoredItemCount);
             await TestUtils.WaitForCondition(() => CommonTestUtils.TestMetricValue("opcua_frontfill_events_count", 1), 5);
 
             // Test disable subscriptions
@@ -223,7 +223,7 @@ namespace Test.Integration
             state = extractor.State.GetEmitterState(ObjectIds.Server);
             Assert.False(state.ShouldSubscribe);
             await extractor.WaitForSubscriptions();
-            Assert.DoesNotContain(session.Subscriptions, sub => sub.DisplayName.StartsWith(SubscriptionName.Events.ToString(), StringComparison.InvariantCulture));
+            Assert.DoesNotContain(session.Subscriptions, sub => sub.DisplayName.StartsWith(SubscriptionName.Events.Name(), StringComparison.InvariantCulture));
             await TestUtils.WaitForCondition(() => CommonTestUtils.TestMetricValue("opcua_frontfill_events_count", 2), 5);
 
             // Test disable specific subscriptions
@@ -248,7 +248,7 @@ namespace Test.Integration
             state = extractor.State.GetEmitterState(ObjectIds.Server);
             Assert.True(state.ShouldSubscribe);
             await extractor.WaitForSubscriptions();
-            Assert.Equal(2u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith(SubscriptionName.Events.ToString(), StringComparison.InvariantCulture)).MonitoredItemCount);
+            Assert.Equal(2u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith(SubscriptionName.Events.Name(), StringComparison.InvariantCulture)).MonitoredItemCount);
             await TestUtils.WaitForCondition(() => CommonTestUtils.TestMetricValue("opcua_frontfill_events_count", 3), 5);
         }
         #endregion

--- a/Test/Integration/EventTests.cs
+++ b/Test/Integration/EventTests.cs
@@ -2,6 +2,7 @@
 using Cognite.Extractor.Testing;
 using Cognite.OpcUa;
 using Cognite.OpcUa.Config;
+using Cognite.OpcUa.Subscriptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
@@ -194,7 +195,7 @@ namespace Test.Integration
                 extractor.State.Clear();
                 extractor.GetType().GetField("subscribed", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(extractor, 0);
                 extractor.GetType().GetField("subscribeFlag", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(extractor, false);
-                await tester.RemoveSubscription("EventListener");
+                await tester.RemoveSubscription(SubscriptionName.Events);
             }
 
             tester.Config.Extraction.RootNode = CommonTestUtils.ToProtoNodeId(ids.Root, tester.Client);
@@ -210,7 +211,7 @@ namespace Test.Integration
             await extractor.RunExtractor(true);
             Assert.All(extractor.State.EmitterStates, state => { Assert.True(state.ShouldSubscribe); });
             await extractor.WaitForSubscriptions();
-            Assert.Equal(3u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith("EventListener", StringComparison.InvariantCulture)).MonitoredItemCount);
+            Assert.Equal(3u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith(SubscriptionName.Events.ToString(), StringComparison.InvariantCulture)).MonitoredItemCount);
             await TestUtils.WaitForCondition(() => CommonTestUtils.TestMetricValue("opcua_frontfill_events_count", 1), 5);
 
             // Test disable subscriptions
@@ -222,7 +223,7 @@ namespace Test.Integration
             state = extractor.State.GetEmitterState(ObjectIds.Server);
             Assert.False(state.ShouldSubscribe);
             await extractor.WaitForSubscriptions();
-            Assert.DoesNotContain(session.Subscriptions, sub => sub.DisplayName.StartsWith("EventListener", StringComparison.InvariantCulture));
+            Assert.DoesNotContain(session.Subscriptions, sub => sub.DisplayName.StartsWith(SubscriptionName.Events.ToString(), StringComparison.InvariantCulture));
             await TestUtils.WaitForCondition(() => CommonTestUtils.TestMetricValue("opcua_frontfill_events_count", 2), 5);
 
             // Test disable specific subscriptions
@@ -247,7 +248,7 @@ namespace Test.Integration
             state = extractor.State.GetEmitterState(ObjectIds.Server);
             Assert.True(state.ShouldSubscribe);
             await extractor.WaitForSubscriptions();
-            Assert.Equal(2u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith("EventListener", StringComparison.InvariantCulture)).MonitoredItemCount);
+            Assert.Equal(2u, session.Subscriptions.First(sub => sub.DisplayName.StartsWith(SubscriptionName.Events.ToString(), StringComparison.InvariantCulture)).MonitoredItemCount);
             await TestUtils.WaitForCondition(() => CommonTestUtils.TestMetricValue("opcua_frontfill_events_count", 3), 5);
         }
         #endregion

--- a/Test/Integration/RebrowseTriggerManagerTests.cs
+++ b/Test/Integration/RebrowseTriggerManagerTests.cs
@@ -1,6 +1,7 @@
 using Cognite.Extractor.Testing;
 using Cognite.OpcUa;
 using Cognite.OpcUa.Config;
+using Cognite.OpcUa.Subscriptions;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -37,7 +38,7 @@ namespace Test.Integration
             await extractor.WaitForSubscriptions();
 
             // Assert
-            Assert.True(tester.TryGetSubscription(RebrowseTriggerManager.SubscriptionName, out var _));
+            Assert.True(tester.TryGetSubscription(SubscriptionName.RebrowseTriggers, out var _));
 
             await BaseExtractorTestFixture.TerminateRunTask(runTask, extractor);
         }
@@ -56,7 +57,7 @@ namespace Test.Integration
             await extractor.WaitForSubscriptions();
 
             // Assert
-            Assert.False(tester.TryGetSubscription(RebrowseTriggerManager.SubscriptionName, out var _));
+            Assert.False(tester.TryGetSubscription(SubscriptionName.RebrowseTriggers, out var _));
 
             await BaseExtractorTestFixture.TerminateRunTask(runTask, extractor);
         }

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config\" />
+    <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -7,6 +7,7 @@ using Cognite.OpcUa.History;
 using Cognite.OpcUa.Nodes;
 using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.Pushers;
+using Cognite.OpcUa.Subscriptions;
 using Cognite.OpcUa.Types;
 using CogniteSdk;
 using Com.Cognite.V1.Timeseries.Proto;
@@ -1271,7 +1272,7 @@ namespace Test.Unit
             Assert.Empty(handler.Assets);
 
             await extractor.WaitForSubscriptions();
-            await tester.RemoveSubscription("DataChangeListener");
+            await tester.RemoveSubscription(SubscriptionName.DataPoints);
 
             extractor.State.Clear();
 
@@ -1349,7 +1350,7 @@ namespace Test.Unit
             Assert.Empty(handler.Assets);
 
             await extractor.WaitForSubscriptions();
-            await tester.RemoveSubscription("EventListener");
+            await tester.RemoveSubscription(SubscriptionName.Events);
 
             extractor.State.Clear();
 
@@ -1423,7 +1424,7 @@ namespace Test.Unit
             Assert.Empty(handler.Assets);
 
             await extractor.WaitForSubscriptions();
-            await tester.RemoveSubscription("EventListener");
+            await tester.RemoveSubscription(SubscriptionName.Events);
 
             extractor.State.Clear();
 
@@ -1461,7 +1462,7 @@ namespace Test.Unit
 
             (handler, pusher) = tester.GetCDFPusher();
             using var extractor = tester.BuildExtractor(true, null, pusher);
- 
+
             var update = new UpdateConfig();
             var dt = new UADataType(DataTypeIds.Double);
             var node = new UAObject(tester.Server.Ids.Base.Root, "BaseRoot", null, null, NodeId.Null, null);
@@ -1469,14 +1470,14 @@ namespace Test.Unit
             variable.FullAttributes.DataType = dt;
             var rel = new UAReference(extractor.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes), true, node, variable);
 
-            var result = await pusher.PushNodes(new[] { node }, new [] { variable }, new[] { rel }, update, tester.Source.Token);
+            var result = await pusher.PushNodes(new[] { node }, new[] { variable }, new[] { rel }, update, tester.Source.Token);
 
             Assert.True(result.Objects);
             Assert.True(result.RawObjects);
 
             Assert.True(result.Variables);
             Assert.True(result.RawVariables);
- 
+
             Assert.True(result.References);
             Assert.True(result.RawReferences);
 

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -90,7 +90,7 @@ namespace Test.Unit
             await Provider.DisposeAsync();
         }
 
-        public async Task RemoveSubscription(string name)
+        public async Task RemoveSubscription(SubscriptionName name)
         {
             if (TryGetSubscription(name, out var subscription) && subscription!.Created)
             {
@@ -109,10 +109,10 @@ namespace Test.Unit
             }
         }
 
-        public bool TryGetSubscription(string name, out Subscription subscription)
+        public bool TryGetSubscription(SubscriptionName name, out Subscription subscription)
         {
             subscription = Client.SessionManager?.Session?.Subscriptions?.FirstOrDefault(sub =>
-                sub.DisplayName.StartsWith(name, StringComparison.InvariantCulture));
+                sub.DisplayName.StartsWith(name.ToString(), StringComparison.InvariantCulture));
             return subscription != null;
         }
     }
@@ -1032,7 +1032,7 @@ namespace Test.Unit
             }
             finally
             {
-                await tester.RemoveSubscription("DataChangeListener");
+                await tester.RemoveSubscription(SubscriptionName.DataPoints);
                 foreach (var node in nodes)
                 {
                     tester.Server.UpdateNode(node.SourceId, null);
@@ -1136,7 +1136,7 @@ namespace Test.Unit
             }
             finally
             {
-                await tester.RemoveSubscription("DataChangeListener");
+                await tester.RemoveSubscription(SubscriptionName.DataPoints);
                 tester.Server.WipeHistory(tester.Server.Ids.Custom.Array, new double[] { 0, 0, 0, 0 });
                 tester.Server.WipeHistory(tester.Server.Ids.Custom.MysteryVar, null);
                 tester.Server.WipeHistory(tester.Server.Ids.Base.StringVar, null);
@@ -1193,7 +1193,7 @@ namespace Test.Unit
             {
                 tester.Config.Source.SubscriptionChunk = 1000;
                 tester.Config.Events.Enabled = false;
-                await tester.RemoveSubscription("EventListener");
+                await tester.RemoveSubscription(SubscriptionName.Events);
                 tester.Server.WipeEventHistory();
             }
         }
@@ -1235,7 +1235,7 @@ namespace Test.Unit
                 tester.Config.Source.SubscriptionChunk = 1000;
                 tester.Config.Events.Enabled = false;
                 tester.Config.Events.EventIds = null;
-                await tester.RemoveSubscription("EventListener");
+                await tester.RemoveSubscription(SubscriptionName.Events);
                 tester.Server.WipeEventHistory();
             }
 
@@ -1272,7 +1272,7 @@ namespace Test.Unit
             finally
             {
                 tester.Server.SetEventConfig(false, true, false);
-                await tester.RemoveSubscription("AuditListener");
+                await tester.RemoveSubscription(SubscriptionName.Audit);
             }
         }
         #endregion
@@ -1379,7 +1379,7 @@ namespace Test.Unit
 
             await TestUtils.WaitForCondition(() => CommonTestUtils.GetMetricValue("opcua_node_CurrentSessionCount") >= 1, 20);
 
-            await tester.RemoveSubscription("NodeMetrics");
+            await tester.RemoveSubscription(SubscriptionName.NodeMetrics);
             tester.Server.SetDiagnosticsEnabled(false);
             tester.Config.Metrics.Nodes = null;
         }
@@ -1413,7 +1413,7 @@ namespace Test.Unit
 
             tester.Server.UpdateNode(ids.DoubleVar1, 0);
             tester.Server.UpdateNode(ids.DoubleVar2, 0);
-            await tester.RemoveSubscription("NodeMetrics");
+            await tester.RemoveSubscription(SubscriptionName.NodeMetrics);
             tester.Config.Metrics.Nodes = null;
         }
         #endregion

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -112,7 +112,7 @@ namespace Test.Unit
         public bool TryGetSubscription(SubscriptionName name, out Subscription subscription)
         {
             subscription = Client.SessionManager?.Session?.Subscriptions?.FirstOrDefault(sub =>
-                sub.DisplayName.StartsWith(name.ToString(), StringComparison.InvariantCulture));
+                sub.DisplayName.StartsWith(name.Name(), StringComparison.InvariantCulture));
             return subscription != null;
         }
     }

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -170,7 +170,6 @@ namespace Test.Utils
             var newServices = new ServiceCollection();
             foreach (var service in Services)
             {
-
                 newServices.Add(service);
             }
             CommonTestUtils.AddDummyProvider("test", CDFMockHandler.MockMode.None, true, newServices);
@@ -300,7 +299,7 @@ namespace Test.Utils
         public bool TryGetSubscription(SubscriptionName name, out Subscription subscription)
         {
             subscription = Client.SessionManager?.Session?.Subscriptions?.FirstOrDefault(sub =>
-                sub.DisplayName.StartsWith(name.ToString(), StringComparison.InvariantCulture));
+                sub.DisplayName.StartsWith(name.Name(), StringComparison.InvariantCulture));
             return subscription != null;
         }
     }

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -251,6 +251,9 @@ namespace Test.Utils
             var startTask = Start();
             var resultTask = await Task.WhenAny(startTask, Task.Delay(20000));
             Assert.Equal(startTask, resultTask);
+            if (startTask.Exception != null) {
+                throw startTask.Exception;
+            }
         }
 
         public virtual async Task DisposeAsync()

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -19,6 +19,7 @@ using Xunit;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Linq;
 using Opc.Ua.Client;
+using Cognite.OpcUa.Subscriptions;
 
 namespace Test.Utils
 {
@@ -120,10 +121,10 @@ namespace Test.Utils
             if (clear)
             {
                 Client.ClearNodeOverrides();
-                RemoveSubscription("EventListener").Wait();
-                RemoveSubscription("DataChangeListener").Wait();
-                RemoveSubscription("AuditListener").Wait();
-                RemoveSubscription(RebrowseTriggerManager.SubscriptionName).Wait();
+                RemoveSubscription(SubscriptionName.Events).Wait();
+                RemoveSubscription(SubscriptionName.DataPoints).Wait();
+                RemoveSubscription(SubscriptionName.Audit).Wait();
+                RemoveSubscription(SubscriptionName.RebrowseTriggers).Wait();
                 Client.Browser.IgnoreFilters = null;
             }
             var ext = new UAExtractor(Config, Provider, pushers, Client, stateStore);
@@ -167,8 +168,9 @@ namespace Test.Utils
         public (CDFMockHandler, CDFPusher) GetCDFPusher()
         {
             var newServices = new ServiceCollection();
-            foreach (var service in Services) {
-                
+            foreach (var service in Services)
+            {
+
                 newServices.Add(service);
             }
             CommonTestUtils.AddDummyProvider("test", CDFMockHandler.MockMode.None, true, newServices);
@@ -251,7 +253,8 @@ namespace Test.Utils
             var startTask = Start();
             var resultTask = await Task.WhenAny(startTask, Task.Delay(20000));
             Assert.Equal(startTask, resultTask);
-            if (startTask.Exception != null) {
+            if (startTask.Exception != null)
+            {
                 throw startTask.Exception;
             }
         }
@@ -275,7 +278,7 @@ namespace Test.Utils
             }
         }
 
-        public async Task RemoveSubscription(string name)
+        public async Task RemoveSubscription(SubscriptionName name)
         {
             if (TryGetSubscription(name, out var subscription) && subscription!.Created)
             {
@@ -294,10 +297,10 @@ namespace Test.Utils
             }
         }
 
-        public bool TryGetSubscription(string name, out Subscription subscription)
+        public bool TryGetSubscription(SubscriptionName name, out Subscription subscription)
         {
             subscription = Client.SessionManager?.Session?.Subscriptions?.FirstOrDefault(sub =>
-                sub.DisplayName.StartsWith(name, StringComparison.InvariantCulture));
+                sub.DisplayName.StartsWith(name.ToString(), StringComparison.InvariantCulture));
             return subscription != null;
         }
     }


### PR DESCRIPTION
This adds a cache containing the state of each subscription, and when it was last updated. It is effectively a very overkill solution for making subscription recreation wait a bit before they run, to help prevent subscriptions from being queued for deletion, then recover after being fully created.

The solution is a bit much, but it's relatively tidy, and it should work. This is pretty much impossible to test.