### PR TITLE
Separate session context from session

### DIFF
--- a/ConfigurationTool/Checks/DataTypes.cs
+++ b/ConfigurationTool/Checks/DataTypes.cs
@@ -156,7 +156,7 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public async Task IdentifyDataTypeSettings(CancellationToken token)
         {
-            var roots = Config.Extraction.GetRootNodes(Context!, log);
+            var roots = Config.Extraction.GetRootNodes(Context, log);
 
             int oldArraySize = Config.Extraction.DataTypes.MaxArraySize;
             int arrayLimit = Config.Extraction.DataTypes.MaxArraySize == 0 ? 10 : Config.Extraction.DataTypes.MaxArraySize;

--- a/ConfigurationTool/Checks/DataTypes.cs
+++ b/ConfigurationTool/Checks/DataTypes.cs
@@ -156,7 +156,7 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public async Task IdentifyDataTypeSettings(CancellationToken token)
         {
-            var roots = Config.Extraction.GetRootNodes(this, log);
+            var roots = Config.Extraction.GetRootNodes(Context!, log);
 
             int oldArraySize = Config.Extraction.DataTypes.MaxArraySize;
             int arrayLimit = Config.Extraction.DataTypes.MaxArraySize == 0 ? 10 : Config.Extraction.DataTypes.MaxArraySize;

--- a/ConfigurationTool/Checks/Events.cs
+++ b/ConfigurationTool/Checks/Events.cs
@@ -149,7 +149,7 @@ namespace Cognite.OpcUa.Config
                         states.Take(baseConfig.Source.SubscriptionChunk),
                         BuildEventFilter(TypeManager.EventFields));
 
-                await ToolUtil.RunWithTimeout(task.Run(log, SessionManager!, Config, SubscriptionManager!, token), 120);
+                await ToolUtil.RunWithTimeout(task.Run(log, SessionManager, Config, SubscriptionManager!, token), 120);
             }
             catch (Exception ex)
             {

--- a/ConfigurationTool/Checks/Subscriptions.cs
+++ b/ConfigurationTool/Checks/Subscriptions.cs
@@ -106,7 +106,7 @@ namespace Cognite.OpcUa.Config
                         ToolUtil.GetSimpleListWriterHandler(dps, states.ToDictionary(state => state.SourceId), this, log, true),
                         states.Take(chunkSize));
 
-                    await ToolUtil.RunWithTimeout(task.Run(log, SessionManager!, Config, SubscriptionManager!, token), 120);
+                    await ToolUtil.RunWithTimeout(task.Run(log, SessionManager, Config, SubscriptionManager!, token), 120);
                     baseConfig.Source.SubscriptionChunk = chunkSize;
                     failed = false;
                     break;

--- a/ConfigurationTool/UAServerExplorer.cs
+++ b/ConfigurationTool/UAServerExplorer.cs
@@ -96,7 +96,7 @@ namespace Cognite.OpcUa.Config
             if (nodesRead) return;
             nodeList.Clear();
             log.LogInformation("Mapping out node hierarchy");
-            var roots = Config.Extraction.GetRootNodes(this, log);
+            var roots = Config.Extraction.GetRootNodes(Context!, log);
             try
             {
                 await Browser.BrowseNodeHierarchy(roots, ToolUtil.GetSimpleListWriterCallback(nodeList, this, TypeManager, log), token,

--- a/ConfigurationTool/UAServerExplorer.cs
+++ b/ConfigurationTool/UAServerExplorer.cs
@@ -96,7 +96,7 @@ namespace Cognite.OpcUa.Config
             if (nodesRead) return;
             nodeList.Clear();
             log.LogInformation("Mapping out node hierarchy");
-            var roots = Config.Extraction.GetRootNodes(Context!, log);
+            var roots = Config.Extraction.GetRootNodes(Context, log);
             try
             {
                 await Browser.BrowseNodeHierarchy(roots, ToolUtil.GetSimpleListWriterCallback(nodeList, this, TypeManager, log), token,

--- a/Extractor/Config/Common.cs
+++ b/Extractor/Config/Common.cs
@@ -48,9 +48,9 @@ namespace Cognite.OpcUa.Config
         /// Identifier of the NodeId, on the form i=123 or s=string, etc.
         /// </summary>
         public string? NodeId { get; set; }
-        public NodeId ToNodeId(UAClient client)
+        public NodeId ToNodeId(SessionContext context)
         {
-            var node = client.ToNodeId(NodeId, NamespaceUri);
+            var node = context.ToNodeId(NodeId, NamespaceUri);
             return node;
         }
     }

--- a/Extractor/Config/EventConfig.cs
+++ b/Extractor/Config/EventConfig.cs
@@ -102,7 +102,7 @@ namespace Cognite.OpcUa.Config
             var whitelist = new HashSet<NodeId>();
             foreach (var proto in EventIds)
             {
-                var id = proto.ToNodeId(context!);
+                var id = proto.ToNodeId(context);
                 if (id.IsNullNodeId)
                 {
                     logger.LogWarning("Failed to convert event id {Namespace} {Id} to NodeId", proto.NamespaceUri, proto.NodeId);
@@ -121,7 +121,7 @@ namespace Cognite.OpcUa.Config
             var ids = new HashSet<NodeId>();
             foreach (var proto in EmitterIds)
             {
-                var id = proto.ToNodeId(context!);
+                var id = proto.ToNodeId(context);
                 if (id.IsNullNodeId)
                 {
                     logger.LogWarning("Failed to convert emitter id {Namespace} {Id} to NodeId", proto.NamespaceUri, proto.NodeId);

--- a/Extractor/Config/EventConfig.cs
+++ b/Extractor/Config/EventConfig.cs
@@ -96,13 +96,13 @@ namespace Cognite.OpcUa.Config
         public Dictionary<string, string> DestinationNameMap { get => destinationNameMap; set => destinationNameMap = value ?? destinationNameMap; }
         private Dictionary<string, string> destinationNameMap = new Dictionary<string, string>();
 
-        public HashSet<NodeId>? GetWhitelist(UAClient client, ILogger logger)
+        public HashSet<NodeId>? GetWhitelist(SessionContext context, ILogger logger)
         {
             if (EventIds == null || !EventIds.Any()) return null;
             var whitelist = new HashSet<NodeId>();
             foreach (var proto in EventIds)
             {
-                var id = proto.ToNodeId(client);
+                var id = proto.ToNodeId(context!);
                 if (id.IsNullNodeId)
                 {
                     logger.LogWarning("Failed to convert event id {Namespace} {Id} to NodeId", proto.NamespaceUri, proto.NodeId);
@@ -115,13 +115,13 @@ namespace Cognite.OpcUa.Config
             return whitelist;
         }
 
-        public HashSet<NodeId> GetEmitterIds(UAClient client, ILogger logger)
+        public HashSet<NodeId> GetEmitterIds(SessionContext context, ILogger logger)
         {
             if (EmitterIds == null || !EmitterIds.Any()) return new HashSet<NodeId>();
             var ids = new HashSet<NodeId>();
             foreach (var proto in EmitterIds)
             {
-                var id = proto.ToNodeId(client);
+                var id = proto.ToNodeId(context!);
                 if (id.IsNullNodeId)
                 {
                     logger.LogWarning("Failed to convert emitter id {Namespace} {Id} to NodeId", proto.NamespaceUri, proto.NodeId);
@@ -134,13 +134,13 @@ namespace Cognite.OpcUa.Config
             return ids;
         }
 
-        public HashSet<NodeId> GetHistorizingEmitterIds(UAClient client, ILogger logger)
+        public HashSet<NodeId> GetHistorizingEmitterIds(SessionContext context, ILogger logger)
         {
             if (HistorizingEmitterIds == null || !HistorizingEmitterIds.Any()) return new HashSet<NodeId>();
             var ids = new HashSet<NodeId>();
             foreach (var proto in HistorizingEmitterIds)
             {
-                var id = proto.ToNodeId(client);
+                var id = proto.ToNodeId(context);
                 if (id.IsNullNodeId)
                 {
                     logger.LogWarning("Failed to convert historizing emitter id {Namespace} {Id} to NodeId", proto.NamespaceUri, proto.NodeId);

--- a/Extractor/Config/ExtractionConfig.cs
+++ b/Extractor/Config/ExtractionConfig.cs
@@ -147,12 +147,12 @@ namespace Cognite.OpcUa.Config
         /// It is possible to have multiple of each filter type.
         /// </summary>
         public IEnumerable<RawNodeTransformation>? Transformations { get; set; }
-        public IEnumerable<NodeId> GetRootNodes(UAClient client, ILogger logger)
+        public IEnumerable<NodeId> GetRootNodes(SessionContext context, ILogger logger)
         {
             var roots = new List<NodeId>();
             if (RootNode != null)
             {
-                var id = RootNode.ToNodeId(client);
+                var id = RootNode.ToNodeId(context);
                 if (id.IsNullNodeId)
                 {
                     logger.LogWarning("Failed to convert configured root node {Namespace} {Id} to NodeId", RootNode.NamespaceUri, RootNode.NodeId);
@@ -166,7 +166,7 @@ namespace Cognite.OpcUa.Config
             {
                 foreach (var root in RootNodes)
                 {
-                    var id = root.ToNodeId(client);
+                    var id = root.ToNodeId(context);
                     if (id.IsNullNodeId)
                     {
                         logger.LogWarning("Failed to convert configured root node {Namespace} {Id} to NodeId", root.NamespaceUri, root.NodeId);
@@ -287,12 +287,15 @@ namespace Cognite.OpcUa.Config
         public bool CreateReferencedNodes { get; set; }
 
         [YamlIgnore]
-        public HierarchicalReferenceMode Mode { get
+        public HierarchicalReferenceMode Mode
+        {
+            get
             {
                 if (!Enabled || !Hierarchical) return HierarchicalReferenceMode.Disabled;
                 if (!InverseHierarchical) return HierarchicalReferenceMode.Forward;
                 return HierarchicalReferenceMode.Both;
-            } }
+            }
+        }
     }
     public class NodeTypeConfig
     {

--- a/Extractor/Deletes.cs
+++ b/Extractor/Deletes.cs
@@ -102,9 +102,9 @@ namespace Cognite.OpcUa
             if (!result.CanBeUsedForDeletes) return new DeletedNodes();
 
             var time = DateTime.UtcNow.AddSeconds(-1);
-            var newVariables = result.DestinationVariables.Select(v => v.GetUniqueId(client)!).ToDictionary(
+            var newVariables = result.DestinationVariables.Select(v => v.GetUniqueId(client.Context!)!).ToDictionary(
                 i => i, i => new NodeExistsState(i, time));
-            var newObjects = result.DestinationObjects.Select(o => o.GetUniqueId(client)!).ToDictionary(i => i, i => new NodeExistsState(i, time));
+            var newObjects = result.DestinationObjects.Select(o => o.GetUniqueId(client.Context!)!).ToDictionary(i => i, i => new NodeExistsState(i, time));
             var newReferences = result.DestinationReferences.Select(r => client.GetRelationshipId(r)!).ToDictionary(i => i, i => new NodeExistsState(i, time));
 
             var res = await Task.WhenAll(

--- a/Extractor/Deletes.cs
+++ b/Extractor/Deletes.cs
@@ -102,9 +102,9 @@ namespace Cognite.OpcUa
             if (!result.CanBeUsedForDeletes) return new DeletedNodes();
 
             var time = DateTime.UtcNow.AddSeconds(-1);
-            var newVariables = result.DestinationVariables.Select(v => v.GetUniqueId(client.Context!)!).ToDictionary(
+            var newVariables = result.DestinationVariables.Select(v => v.GetUniqueId(client.Context)!).ToDictionary(
                 i => i, i => new NodeExistsState(i, time));
-            var newObjects = result.DestinationObjects.Select(o => o.GetUniqueId(client.Context!)!).ToDictionary(i => i, i => new NodeExistsState(i, time));
+            var newObjects = result.DestinationObjects.Select(o => o.GetUniqueId(client.Context)!).ToDictionary(i => i, i => new NodeExistsState(i, time));
             var newReferences = result.DestinationReferences.Select(r => client.GetRelationshipId(r)!).ToDictionary(i => i, i => new NodeExistsState(i, time));
 
             var res = await Task.WhenAll(

--- a/Extractor/NodeMetricsManager.cs
+++ b/Extractor/NodeMetricsManager.cs
@@ -112,7 +112,7 @@ namespace Cognite.OpcUa
             {
                 foreach (var proto in config.OtherMetrics)
                 {
-                    nodes.Add(proto.ToNodeId(client));
+                    nodes.Add(proto.ToNodeId(client.Context!));
                 }
             }
 

--- a/Extractor/NodeMetricsManager.cs
+++ b/Extractor/NodeMetricsManager.cs
@@ -112,7 +112,7 @@ namespace Cognite.OpcUa
             {
                 foreach (var proto in config.OtherMetrics)
                 {
-                    nodes.Add(proto.ToNodeId(client.Context!));
+                    nodes.Add(proto.ToNodeId(client.Context));
                 }
             }
 

--- a/Extractor/NodeSources/NodeHierarchyBuilder.cs
+++ b/Extractor/NodeSources/NodeHierarchyBuilder.cs
@@ -236,7 +236,7 @@ namespace Cognite.OpcUa.NodeSources
 
         private void AddManagedNode(TypeUpdateConfig update, BaseUANode node)
         {
-            extractor.State.RegisterNode(node.Id, node.GetUniqueId(client));
+            extractor.State.RegisterNode(node.Id, node.GetUniqueId(client.Context));
             extractor.State.AddActiveNode(
                 node,
                 config.Extraction.Update.Objects,
@@ -512,7 +512,7 @@ namespace Cognite.OpcUa.NodeSources
                 {
                     foreach (var child in variable.CreateTimeseries())
                     {
-                        var uniqueId = child.GetUniqueId(extractor);
+                        var uniqueId = child.GetUniqueId(extractor.Context);
                         if (state != null) extractor.State.SetNodeState(state, uniqueId);
                         extractor.State.RegisterNode(node.Id, uniqueId);
                     }

--- a/Extractor/Nodes/BaseUANode.cs
+++ b/Extractor/Nodes/BaseUANode.cs
@@ -177,10 +177,8 @@ namespace Cognite.OpcUa.Nodes
             }
         }
 
-        public virtual string? GetUniqueId(SessionContext? context)
+        public virtual string? GetUniqueId(SessionContext context)
         {
-            if (context == null) throw new InvalidOperationException("Attempt to get unique ID without initialized client");
-
             return context.GetUniqueId(Id);
         }
 
@@ -477,7 +475,7 @@ namespace Cognite.OpcUa.Nodes
             Dictionary<string, string>? metaMap,
             AssetCreate asset)
         {
-            var id = GetUniqueId(client.Context!);
+            var id = GetUniqueId(client.Context);
             asset.Description = Attributes.Description;
             asset.ExternalId = id;
             asset.Name = string.IsNullOrEmpty(Name) ? id : Name;
@@ -570,7 +568,7 @@ namespace Cognite.OpcUa.Nodes
             Dictionary<string, string>? extras = null;
             if (getExtras)
             {
-                extras = GetExtraMetadata(config, client.Context!, client.StringConverter);
+                extras = GetExtraMetadata(config, client.Context, client.StringConverter);
             }
             return BuildMetadataBase(extras, client);
         }

--- a/Extractor/Nodes/BaseUANode.cs
+++ b/Extractor/Nodes/BaseUANode.cs
@@ -177,9 +177,11 @@ namespace Cognite.OpcUa.Nodes
             }
         }
 
-        public virtual string? GetUniqueId(IUAClientAccess client)
+        public virtual string? GetUniqueId(SessionContext? context)
         {
-            return client.GetUniqueId(Id);
+            if (context == null) throw new InvalidOperationException("Attempt to get unique ID without initialized client");
+
+            return context.GetUniqueId(Id);
         }
 
         public virtual bool AllowValueRead(ILogger logger, DataTypeConfig config, bool ignoreDimension)
@@ -399,7 +401,7 @@ namespace Cognite.OpcUa.Nodes
             return true;
         }
 
-        public virtual Dictionary<string, string>? GetExtraMetadata(FullConfig config, IUAClientAccess client)
+        public virtual Dictionary<string, string>? GetExtraMetadata(FullConfig config, SessionContext context, StringConverter converter)
         {
             return null;
         }
@@ -475,7 +477,7 @@ namespace Cognite.OpcUa.Nodes
             Dictionary<string, string>? metaMap,
             AssetCreate asset)
         {
-            var id = GetUniqueId(client);
+            var id = GetUniqueId(client.Context!);
             asset.Description = Attributes.Description;
             asset.ExternalId = id;
             asset.Name = string.IsNullOrEmpty(Name) ? id : Name;
@@ -568,7 +570,7 @@ namespace Cognite.OpcUa.Nodes
             Dictionary<string, string>? extras = null;
             if (getExtras)
             {
-                extras = GetExtraMetadata(config, client);
+                extras = GetExtraMetadata(config, client.Context!, client.StringConverter);
             }
             return BuildMetadataBase(extras, client);
         }

--- a/Extractor/Nodes/UAObject.cs
+++ b/Extractor/Nodes/UAObject.cs
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
 using Cognite.OpcUa.Config;
 using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.TypeCollectors;
+using Cognite.OpcUa.Types;
 using Opc.Ua;
 using System.Collections.Generic;
 using System.Globalization;
@@ -105,7 +106,7 @@ namespace Cognite.OpcUa.Nodes
 
         public override NodeId? TypeDefinition => FullAttributes.TypeDefinition?.Id;
 
-        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, IUAClientAccess client)
+        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, SessionContext context, StringConverter converter)
         {
             if (config.Extraction.NodeTypes.Metadata && FullAttributes.TypeDefinition?.Name != null)
             {

--- a/Extractor/Nodes/UAVariable.cs
+++ b/Extractor/Nodes/UAVariable.cs
@@ -290,7 +290,7 @@ namespace Cognite.OpcUa.Nodes
             return (Id, -1);
         }
 
-        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, IUAClientAccess client)
+        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, SessionContext context, StringConverter converter)
         {
             Dictionary<string, string>? fields = null;
             if (config.Extraction.NodeTypes.Metadata && FullAttributes.TypeDefinition?.Name != null)
@@ -317,7 +317,7 @@ namespace Cognite.OpcUa.Nodes
                 }
                 else
                 {
-                    fields["dataType"] = dt.Name ?? dt.GetUniqueId(client) ?? "null";
+                    fields["dataType"] = dt.Name ?? dt.GetUniqueId(context) ?? "null";
                 }
             }
             return fields;
@@ -439,7 +439,7 @@ namespace Cognite.OpcUa.Nodes
             long? dataSetId,
             Dictionary<string, string>? metaMap)
         {
-            string? externalId = GetUniqueId(client);
+            string? externalId = GetUniqueId(client.Context);
             var writePoco = new StatelessTimeSeriesCreate
             {
                 Description = FullAttributes.Description,
@@ -474,7 +474,7 @@ namespace Cognite.OpcUa.Nodes
             IDictionary<NodeId, long>? nodeToAssetIds,
             Dictionary<string, string>? metaMap)
         {
-            string? externalId = GetUniqueId(client);
+            string? externalId = GetUniqueId(client.Context);
             var writePoco = new TimeSeriesCreate
             {
                 Description = FullAttributes.Description,
@@ -507,7 +507,7 @@ namespace Cognite.OpcUa.Nodes
 
         public TimeSeriesCreate ToMinimalTimeseries(IUAClientAccess client, long? dataSetId)
         {
-            string? externalId = GetUniqueId(client);
+            string? externalId = GetUniqueId(client.Context);
 
             return new TimeSeriesCreate
             {
@@ -532,9 +532,11 @@ namespace Cognite.OpcUa.Nodes
             TSParent = parent;
         }
 
-        public override string? GetUniqueId(IUAClientAccess client)
+        public override string? GetUniqueId(SessionContext? context)
         {
-            return client.GetUniqueId(Id, Index);
+            if (context == null) throw new InvalidOperationException("Attempt to get unique ID without initialized client");
+
+            return context.GetUniqueId(Id, Index);
         }
 
         public override (NodeId, int) DestinationId()

--- a/Extractor/Nodes/UAVariable.cs
+++ b/Extractor/Nodes/UAVariable.cs
@@ -532,10 +532,8 @@ namespace Cognite.OpcUa.Nodes
             TSParent = parent;
         }
 
-        public override string? GetUniqueId(SessionContext? context)
+        public override string? GetUniqueId(SessionContext context)
         {
-            if (context == null) throw new InvalidOperationException("Attempt to get unique ID without initialized client");
-
             return context.GetUniqueId(Id, Index);
         }
 

--- a/Extractor/Nodes/UAVariableType.cs
+++ b/Extractor/Nodes/UAVariableType.cs
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
 using Cognite.OpcUa.Config;
 using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.TypeCollectors;
+using Cognite.OpcUa.Types;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using System;
@@ -131,7 +132,7 @@ namespace Cognite.OpcUa.Nodes
                 && FullAttributes.DataType.AllowValueRead(this, FullAttributes.ArrayDimensions, FullAttributes.ValueRank, logger, config, ignoreDimension);
         }
 
-        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, IUAClientAccess client)
+        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, SessionContext context, StringConverter converter)
         {
             Dictionary<string, string>? fields = new Dictionary<string, string>();
             var dt = FullAttributes.DataType;
@@ -150,10 +151,10 @@ namespace Cognite.OpcUa.Nodes
                 }
                 else
                 {
-                    fields["dataType"] = dt.Name ?? dt.GetUniqueId(client) ?? "null";
+                    fields["dataType"] = dt.Name ?? dt.GetUniqueId(context) ?? "null";
                 }
             }
-            fields["Value"] = client.StringConverter.ConvertToString(FullAttributes.Value, dt.EnumValues);
+            fields["Value"] = converter.ConvertToString(FullAttributes.Value, dt.EnumValues);
 
             return fields;
         }

--- a/Extractor/Pushers/FDM/InstanceBuilder.cs
+++ b/Extractor/Pushers/FDM/InstanceBuilder.cs
@@ -157,7 +157,7 @@ namespace Cognite.OpcUa.Pushers.FDM
                     {
                         if (variable.IsArray)
                         {
-                            value = new RawPropertyValue<string[]>(variable.ArrayChildren.Select(v => v.GetUniqueId(client)!).ToArray());
+                            value = new RawPropertyValue<string[]>(variable.ArrayChildren.Select(v => v.GetUniqueId(client.Context)!).ToArray());
                         }
                         else
                         {

--- a/Extractor/Pushers/MqttPusher.cs
+++ b/Extractor/Pushers/MqttPusher.cs
@@ -320,7 +320,7 @@ namespace Cognite.OpcUa.Pushers
                     states = objects
                        .SelectNonNull(node => Extractor.GetUniqueId(node.Id))
                        .Where(node => !existingNodes.Contains(node))
-                       .Concat(variables.SelectNonNull(variable => variable.GetUniqueId(Extractor)))
+                       .Concat(variables.SelectNonNull(variable => variable.GetUniqueId(Extractor.Context)))
                        .Concat(relationships.SelectNonNull(rel => rel.ExternalId))
                        .Select(id => new ExistingState(id))
                        .ToDictionary(state => state.Id);
@@ -360,13 +360,13 @@ namespace Cognite.OpcUa.Pushers
                 {
                     variables = variables
                         .Where(variable => !variable.Id.IsNullNodeId
-                            && !existingNodes.Contains(variable.GetUniqueId(Extractor)!)).ToList();
+                            && !existingNodes.Contains(variable.GetUniqueId(Extractor.Context)!)).ToList();
                 }
                 else
                 {
                     foreach (var node in variables)
                     {
-                        string? id = node.GetUniqueId(Extractor);
+                        string? id = node.GetUniqueId(Extractor.Context);
                         node.Changed = id != null && existingNodes.Contains(id);
                     }
                 }
@@ -407,7 +407,7 @@ namespace Cognite.OpcUa.Pushers
 
             var newStates = objects
                     .SelectNonNull(node => Extractor.GetUniqueId(node.Id))
-                    .Concat(variables.SelectNonNull(variable => variable.GetUniqueId(Extractor)))
+                    .Concat(variables.SelectNonNull(variable => variable.GetUniqueId(Extractor.Context)))
                     .Concat(relationships.SelectNonNull(rel => rel.ExternalId))
                     .Select(id => new ExistingState(id) { Existing = true, LastTimeModified = DateTime.UtcNow })
                     .ToList();

--- a/Extractor/SessionContext.cs
+++ b/Extractor/SessionContext.cs
@@ -33,17 +33,12 @@ namespace Cognite.OpcUa
         {
             MessageContext = session.MessageContext;
             SystemContext = session.SystemContext;
-            NamespaceTable = session.NamespaceUris;
+            NamespaceTable = session.NamespaceUris ?? new NamespaceTable(new[] {
+                "http://opcfoundation.org/UA/"
+            });
             this.config = config;
             this.log = log;
-
-            if (config.Extraction.NodeMap != null)
-            {
-                foreach (var kvp in config.Extraction.NodeMap)
-                {
-                    nodeOverrides[kvp.Value.ToNodeId(this)] = kvp.Key;
-                }
-            }
+            InitNodeOverrides();
         }
 
         public SessionContext(FullConfig config, ILogger log)
@@ -55,10 +50,23 @@ namespace Cognite.OpcUa
             SystemContext = new DummySystemContext(NamespaceTable);
             this.config = config;
             this.log = log;
+            InitNodeOverrides();
+        }
+
+        private void InitNodeOverrides()
+        {
+            if (config.Extraction.NodeMap != null)
+            {
+                foreach (var kvp in config.Extraction.NodeMap)
+                {
+                    nodeOverrides[kvp.Value.ToNodeId(this)] = kvp.Key;
+                }
+            }
         }
 
         public void AddExternalNamespaces(string[] table)
         {
+            if (table == null) return;
             foreach (var ns in table)
             {
                 NamespaceTable.GetIndexOrAppend(ns);

--- a/Extractor/SessionContext.cs
+++ b/Extractor/SessionContext.cs
@@ -29,18 +29,6 @@ namespace Cognite.OpcUa
         private readonly Dictionary<NodeId, string> nodeOverrides = new();
         private readonly Dictionary<ushort, string> nsPrefixMap = new();
 
-        public SessionContext(ISession session, FullConfig config, ILogger log)
-        {
-            MessageContext = session.MessageContext;
-            SystemContext = session.SystemContext;
-            NamespaceTable = session.NamespaceUris ?? new NamespaceTable(new[] {
-                "http://opcfoundation.org/UA/"
-            });
-            this.config = config;
-            this.log = log;
-            InitNodeOverrides();
-        }
-
         public SessionContext(FullConfig config, ILogger log)
         {
             NamespaceTable = new NamespaceTable(new[] {
@@ -73,6 +61,13 @@ namespace Cognite.OpcUa
             }
         }
 
+        public void UpdateFromSession(ISession session)
+        {
+            MessageContext = session.MessageContext;
+            SystemContext = session.SystemContext;
+            NamespaceTable = session.NamespaceUris;
+        }
+
         /// <summary>
         /// Converts an ExpandedNodeId into a NodeId using the Session
         /// </summary>
@@ -82,16 +77,6 @@ namespace Cognite.OpcUa
         {
             if (nodeid == null || nodeid.IsNull || NamespaceTable == null) return NodeId.Null;
             return ExpandedNodeId.ToNodeId(nodeid, NamespaceTable);
-        }
-
-        public void OverrideMessageContext(IServiceMessageContext context)
-        {
-            MessageContext = context;
-        }
-
-        public void OverrideNamespaceTable(NamespaceTable namespaceTable)
-        {
-            NamespaceTable = namespaceTable;
         }
 
         public NodeId ToNodeId(string? identifier, string? namespaceUri)

--- a/Extractor/SessionContext.cs
+++ b/Extractor/SessionContext.cs
@@ -38,7 +38,6 @@ namespace Cognite.OpcUa
             SystemContext = new DummySystemContext(NamespaceTable);
             this.config = config;
             this.log = log;
-            InitNodeOverrides();
         }
 
         private void InitNodeOverrides()
@@ -59,6 +58,7 @@ namespace Cognite.OpcUa
             {
                 NamespaceTable.GetIndexOrAppend(ns);
             }
+            InitNodeOverrides();
         }
 
         public void UpdateFromSession(ISession session)
@@ -66,6 +66,7 @@ namespace Cognite.OpcUa
             MessageContext = session.MessageContext;
             SystemContext = session.SystemContext;
             NamespaceTable = session.NamespaceUris;
+            InitNodeOverrides();
         }
 
         /// <summary>

--- a/Extractor/SessionContext.cs
+++ b/Extractor/SessionContext.cs
@@ -1,0 +1,269 @@
+using Cognite.OpcUa.Config;
+using Cognite.OpcUa.NodeSources;
+using Cognite.OpcUa.Types;
+using Microsoft.Extensions.Logging;
+using Opc.Ua;
+using Opc.Ua.Client;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Cognite.OpcUa
+{
+    /// <summary>
+    /// OPC-UA server context detached from the server itself.
+    /// Having this be separate makes it easier to keep running the extractor
+    /// even when connection to the server is lost.
+    /// </summary>
+    public class SessionContext
+    {
+        public IServiceMessageContext MessageContext { get; private set; }
+        public ISystemContext SystemContext { get; private set; }
+        public NamespaceTable NamespaceTable { get; private set; }
+
+        private readonly FullConfig config;
+        private readonly ILogger log;
+
+        private readonly Dictionary<NodeId, string> nodeOverrides = new();
+        private readonly Dictionary<ushort, string> nsPrefixMap = new();
+
+        public SessionContext(ISession session, FullConfig config, ILogger log)
+        {
+            MessageContext = session.MessageContext;
+            SystemContext = session.SystemContext;
+            NamespaceTable = session.NamespaceUris;
+            this.config = config;
+            this.log = log;
+
+            if (config.Extraction.NodeMap != null)
+            {
+                foreach (var kvp in config.Extraction.NodeMap)
+                {
+                    nodeOverrides[kvp.Value.ToNodeId(this)] = kvp.Key;
+                }
+            }
+        }
+
+        public SessionContext(FullConfig config, ILogger log)
+        {
+            NamespaceTable = new NamespaceTable(new[] {
+                "http://opcfoundation.org/UA/"
+            });
+            MessageContext = new DummyMessageContext(NamespaceTable);
+            SystemContext = new DummySystemContext(NamespaceTable);
+            this.config = config;
+            this.log = log;
+        }
+
+        public void AddExternalNamespaces(string[] table)
+        {
+            foreach (var ns in table)
+            {
+                NamespaceTable.GetIndexOrAppend(ns);
+            }
+        }
+
+        /// <summary>
+        /// Converts an ExpandedNodeId into a NodeId using the Session
+        /// </summary>
+        /// <param name="nodeid"></param>
+        /// <returns>Resulting NodeId</returns>
+        public NodeId ToNodeId(ExpandedNodeId nodeid)
+        {
+            if (nodeid == null || nodeid.IsNull || NamespaceTable == null) return NodeId.Null;
+            return ExpandedNodeId.ToNodeId(nodeid, NamespaceTable);
+        }
+
+        public void OverrideMessageContext(IServiceMessageContext context)
+        {
+            MessageContext = context;
+        }
+
+        public void OverrideNamespaceTable(NamespaceTable namespaceTable)
+        {
+            NamespaceTable = namespaceTable;
+        }
+
+        public NodeId ToNodeId(string? identifier, string? namespaceUri)
+        {
+            if (identifier == null || namespaceUri == null || NamespaceTable == null) return NodeId.Null;
+            int idx = NamespaceTable.GetIndex(namespaceUri);
+            if (idx < 0)
+            {
+                log.LogInformation("Namespace {NS} not found in {Table}", namespaceUri, NamespaceTable.ToArray());
+                if (config.Extraction.NamespaceMap.ContainsValue(namespaceUri))
+                {
+                    string readNs = config.Extraction.NamespaceMap.First(kvp => kvp.Value == namespaceUri).Key;
+                    idx = NamespaceTable.GetIndex(readNs);
+                    if (idx < 0) return NodeId.Null;
+                }
+                else
+                {
+                    return NodeId.Null;
+                }
+            }
+
+            string nsString = "ns=" + idx;
+            return new NodeId(nsString + ";" + identifier);
+        }
+
+        /// <summary>
+        /// Returns consistent unique string representation of a <see cref="NodeId"/> given its namespaceUri
+        /// </summary>
+        /// <remarks>
+        /// NodeId is, according to spec, unique in combination with its namespaceUri. We use this to generate a consistent, unique string
+        /// to be used for mapping assets and timeseries in CDF to opcua nodes.
+        /// To avoid having to send the entire namespaceUri to CDF, we allow mapping Uris to prefixes in the config file.
+        /// </remarks>
+        /// <param name="id">Nodeid to be converted</param>
+        /// <returns>Unique string representation</returns>
+        public string? GetUniqueId(ExpandedNodeId id, int index = -1)
+        {
+            var nodeId = ToNodeId(id);
+            if (nodeId.IsNullNodeId) return null;
+            if (nodeOverrides.TryGetValue(nodeId, out var nodeOverride))
+            {
+                if (index <= -1) return nodeOverride;
+                return $"{nodeOverride}[{index}]";
+            }
+
+            // ExternalIds shorter than 32 chars are unlikely, this will generally avoid at least 1 re-allocation of the buffer,
+            // and usually boost performance.
+            var buffer = new StringBuilder(config.Extraction.IdPrefix, 32);
+
+            if (!nsPrefixMap.TryGetValue(nodeId.NamespaceIndex, out var prefix))
+            {
+                var namespaceUri = id.NamespaceUri ?? NamespaceTable!.GetString(nodeId.NamespaceIndex);
+                string newPrefix;
+                if (namespaceUri is not null)
+                {
+                    if (config.Extraction.NamespaceMap.TryGetValue(namespaceUri, out string prefixNode))
+                    {
+                        newPrefix = prefixNode;
+                    }
+                    else
+                    {
+                        newPrefix = namespaceUri + ":";
+                    }
+                }
+                else
+                {
+                    log.LogWarning("NodeID received with null NamespaceUri, and index not in NamespaceTable. This is likely a bug in the server. {Id}, {Index}",
+                        nodeId, nodeId.NamespaceIndex);
+                    newPrefix = $"UNKNOWN_NS_{nodeId.NamespaceIndex}";
+                }
+                nsPrefixMap[nodeId.NamespaceIndex] = prefix = newPrefix;
+            }
+
+            buffer.Append(prefix);
+            // Use 0 as namespace-index. This means that the namespace is not appended, as the string representation
+            // of a base namespace nodeId does not include the namespace-index, which fits our use-case.
+            NodeId.Format(buffer, nodeId.Identifier, nodeId.IdType, 0);
+
+            TrimEnd(buffer);
+
+            if (index > -1)
+            {
+                // Modifying buffer.Length effectively removes the last few elements, but more efficiently than modifying strings,
+                // StringBuilder is just a char array.
+                // 255 is max length, Log10(Max(1, index)) + 3 is the length of the index suffix ("[123]").
+                buffer.Length = Math.Min(buffer.Length, 255 - ((int)Math.Log10(Math.Max(1, index)) + 3));
+                buffer.AppendFormat(CultureInfo.InvariantCulture, "[{0}]", index);
+            }
+            else
+            {
+                buffer.Length = Math.Min(buffer.Length, 255);
+            }
+            return buffer.ToString();
+        }
+        /// <summary>
+        /// Used to trim the whitespace off the end of a StringBuilder
+        /// </summary> 
+        private static void TrimEnd(StringBuilder sb)
+        {
+            if (sb == null || sb.Length == 0) return;
+
+            int i = sb.Length - 1;
+            for (; i >= 0; i--)
+                if (!char.IsWhiteSpace(sb[i]))
+                    break;
+
+            if (i < sb.Length - 1)
+                sb.Length = i + 1;
+
+            return;
+        }
+
+        /// <summary>
+        /// Append NodeId and namespace to the given StringBuilder.
+        /// </summary>
+        /// <param name="buffer">Builder to append to</param>
+        /// <param name="nodeId">NodeId to append</param>
+        private void AppendNodeId(StringBuilder buffer, NodeId nodeId)
+        {
+            if (nodeOverrides.TryGetValue(nodeId, out var nodeOverride))
+            {
+                buffer.Append(nodeOverride);
+                return;
+            }
+
+            if (!nsPrefixMap.TryGetValue(nodeId.NamespaceIndex, out var prefix))
+            {
+                var namespaceUri = NamespaceTable!.GetString(nodeId.NamespaceIndex);
+                string newPrefix = config.Extraction.NamespaceMap.TryGetValue(namespaceUri, out string prefixNode) ? prefixNode : (namespaceUri + ":");
+                nsPrefixMap[nodeId.NamespaceIndex] = prefix = newPrefix;
+            }
+
+            buffer.Append(prefix);
+
+            NodeId.Format(buffer, nodeId.Identifier, nodeId.IdType, 0);
+
+            TrimEnd(buffer);
+        }
+
+        /// <summary>
+        /// Get string representation of NodeId on the form i=123 or s=string, etc.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        private string GetNodeIdString(NodeId id)
+        {
+            var buffer = new StringBuilder();
+            AppendNodeId(buffer, id);
+            return buffer.ToString();
+        }
+
+        /// <summary>
+        /// Get the unique reference id, on the form [prefix][reference-name];[sourceId];[targetId]
+        /// </summary>
+        /// <param name="reference">Reference to get id for</param>
+        /// <returns>String reference id</returns>
+        public string GetRelationshipId(UAReference reference)
+        {
+            var buffer = new StringBuilder(config.Extraction.IdPrefix, 64);
+            buffer.Append(reference.Type.GetName(!reference.IsForward));
+            buffer.Append(';');
+            AppendNodeId(buffer, reference.Source.Id);
+            buffer.Append(';');
+            AppendNodeId(buffer, reference.Target.Id);
+
+            if (buffer.Length > 255)
+            {
+                // This is an edge-case. If the id overflows, it is most sensible to cut from the
+                // start of the id, as long ids are likely (from experience) to be similar to
+                // system.subsystem.sensor.measurement...
+                // so cutting from the start is less likely to cause conflicts
+                var overflow = (int)Math.Ceiling((buffer.Length - 255) / 2.0);
+                buffer = new StringBuilder(config.Extraction.IdPrefix, 255);
+                buffer.Append(reference.Type.GetName(!reference.IsForward));
+                buffer.Append(';');
+                buffer.Append(GetNodeIdString(reference.Source.Id).AsSpan(overflow));
+                buffer.Append(';');
+                buffer.Append(GetNodeIdString(reference.Target.Id).AsSpan(overflow));
+            }
+            return buffer.ToString();
+        }
+    }
+}

--- a/Extractor/TypeCollectors/TypeManager.cs
+++ b/Extractor/TypeCollectors/TypeManager.cs
@@ -72,7 +72,7 @@ namespace Cognite.OpcUa.TypeCollectors
             {
                 foreach (var type in config.Extraction.DataTypes.IgnoreDataTypes)
                 {
-                    var id = type.ToNodeId(client.Context!);
+                    var id = type.ToNodeId(client.Context);
                     if (id == null || id.IsNullNodeId)
                     {
                         log.LogWarning("Invalid ignore datatype nodeId: {NameSpace}: {Identifier}", type.NamespaceUri, type.NodeId);
@@ -87,7 +87,7 @@ namespace Cognite.OpcUa.TypeCollectors
                 foreach (var type in config.Extraction.DataTypes.CustomNumericTypes)
                 {
                     if (type.NodeId == null) continue;
-                    var id = type.NodeId.ToNodeId(client.Context!);
+                    var id = type.NodeId.ToNodeId(client.Context);
                     if (id == null || id.IsNullNodeId)
                     {
                         log.LogWarning("Invalid datatype nodeId: {NameSpace}: {Identifier}", type.NodeId.NamespaceUri, type.NodeId.NodeId);
@@ -245,7 +245,7 @@ namespace Cognite.OpcUa.TypeCollectors
             }
             var excludeProperties = new HashSet<string>(config.Events.ExcludeProperties);
             var baseExcludeProperties = new HashSet<string>(config.Events.BaseExcludeProperties);
-            var whitelist = config.Events.GetWhitelist(client.Context!, log);
+            var whitelist = config.Events.GetWhitelist(client.Context, log);
 
             foreach (var type in NodeMap.Values.OfType<UAObjectType>())
             {

--- a/Extractor/TypeCollectors/TypeManager.cs
+++ b/Extractor/TypeCollectors/TypeManager.cs
@@ -72,7 +72,7 @@ namespace Cognite.OpcUa.TypeCollectors
             {
                 foreach (var type in config.Extraction.DataTypes.IgnoreDataTypes)
                 {
-                    var id = type.ToNodeId(client);
+                    var id = type.ToNodeId(client.Context!);
                     if (id == null || id.IsNullNodeId)
                     {
                         log.LogWarning("Invalid ignore datatype nodeId: {NameSpace}: {Identifier}", type.NamespaceUri, type.NodeId);
@@ -87,7 +87,7 @@ namespace Cognite.OpcUa.TypeCollectors
                 foreach (var type in config.Extraction.DataTypes.CustomNumericTypes)
                 {
                     if (type.NodeId == null) continue;
-                    var id = type.NodeId.ToNodeId(client);
+                    var id = type.NodeId.ToNodeId(client.Context!);
                     if (id == null || id.IsNullNodeId)
                     {
                         log.LogWarning("Invalid datatype nodeId: {NameSpace}: {Identifier}", type.NodeId.NamespaceUri, type.NodeId.NodeId);
@@ -245,7 +245,7 @@ namespace Cognite.OpcUa.TypeCollectors
             }
             var excludeProperties = new HashSet<string>(config.Events.ExcludeProperties);
             var baseExcludeProperties = new HashSet<string>(config.Events.BaseExcludeProperties);
-            var whitelist = config.Events.GetWhitelist(client, log);
+            var whitelist = config.Events.GetWhitelist(client.Context!, log);
 
             foreach (var type in NodeMap.Values.OfType<UAObjectType>())
             {
@@ -342,7 +342,8 @@ namespace Cognite.OpcUa.TypeCollectors
         }
         public UADataType GetDataType(NodeId nodeId)
         {
-            return GetType<UADataType>(nodeId, x => {
+            return GetType<UADataType>(nodeId, x =>
+            {
                 UADataType dt;
                 if (customDataTypes.TryGetValue(x, out var protoDataType))
                 {

--- a/Extractor/Types/UAPropertySerializer.cs
+++ b/Extractor/Types/UAPropertySerializer.cs
@@ -175,7 +175,7 @@ namespace Cognite.OpcUa.Types
             else if (value is DataValue dv) return ConvertToString(dv.WrappedValue, enumValues, null, mode);
             else if (value is ExpandedNodeId expandedNodeId)
             {
-                if (context != null && uaClient != null && uaClient.Context != null)
+                if (context != null && uaClient != null)
                 {
                     returnStr = context.NodeIdToString(uaClient.Context.ToNodeId(expandedNodeId));
                 }
@@ -339,7 +339,7 @@ namespace Cognite.OpcUa.Types
         private readonly NodeIdConverter? nodeIdConverter;
         public void AddConverters(JsonSerializerOptions options, ConverterType type)
         {
-            if (config == null || uaClient == null || nodeIdConverter == null || uaClient.Context == null)
+            if (config == null || uaClient == null || nodeIdConverter == null)
                 throw new InvalidOperationException("Config and UAClient must be supplied to create converters");
             options.Converters.Add(converters.GetOrAdd(type, key => new NodeSerializer(this, config, uaClient.Context, key, log)));
             options.Converters.Add(nodeIdConverter);

--- a/Extractor/Types/UAPropertySerializer.cs
+++ b/Extractor/Types/UAPropertySerializer.cs
@@ -175,9 +175,9 @@ namespace Cognite.OpcUa.Types
             else if (value is DataValue dv) return ConvertToString(dv.WrappedValue, enumValues, null, mode);
             else if (value is ExpandedNodeId expandedNodeId)
             {
-                if (context != null && uaClient != null)
+                if (context != null && uaClient != null && uaClient.Context != null)
                 {
-                    returnStr = context.NodeIdToString(uaClient.ToNodeId(expandedNodeId));
+                    returnStr = context.NodeIdToString(uaClient.Context.ToNodeId(expandedNodeId));
                 }
                 else
                 {
@@ -250,7 +250,8 @@ namespace Cognite.OpcUa.Types
             else if (IsNumber(value)) return value.ToString();
             else returnStr = value.ToString();
 
-            switch (mode) {
+            switch (mode)
+            {
                 case StringConverterMode.Simple:
                     return returnStr;
                 case StringConverterMode.Json:
@@ -338,9 +339,9 @@ namespace Cognite.OpcUa.Types
         private readonly NodeIdConverter? nodeIdConverter;
         public void AddConverters(JsonSerializerOptions options, ConverterType type)
         {
-            if (config == null || uaClient == null || nodeIdConverter == null)
+            if (config == null || uaClient == null || nodeIdConverter == null || uaClient.Context == null)
                 throw new InvalidOperationException("Config and UAClient must be supplied to create converters");
-            options.Converters.Add(converters.GetOrAdd(type, key => new NodeSerializer(this, config, uaClient, key, log)));
+            options.Converters.Add(converters.GetOrAdd(type, key => new NodeSerializer(this, config, uaClient.Context, key, log)));
             options.Converters.Add(nodeIdConverter);
         }
     }
@@ -355,14 +356,14 @@ namespace Cognite.OpcUa.Types
     {
         private readonly StringConverter converter;
         private readonly FullConfig config;
-        private readonly UAClient uaClient;
+        private readonly SessionContext context;
         public ConverterType Type { get; }
         private readonly ILogger log;
-        public NodeSerializer(StringConverter converter, FullConfig config, UAClient uaClient, ConverterType type, ILogger log)
+        public NodeSerializer(StringConverter converter, FullConfig config, SessionContext context, ConverterType type, ILogger log)
         {
             this.converter = converter;
             this.config = config;
-            this.uaClient = uaClient;
+            this.context = context;
             Type = type;
             this.log = log;
         }
@@ -393,7 +394,7 @@ namespace Cognite.OpcUa.Types
 
             if (getExtras)
             {
-                extras = node.GetExtraMetadata(config, uaClient);
+                extras = node.GetExtraMetadata(config, context, converter);
                 if (extras != null) extras.Remove("Value");
             }
             // If we should treat this as a key/value pair, or write it as an object
@@ -450,7 +451,7 @@ namespace Cognite.OpcUa.Types
 
         private void WriteBaseValues(Utf8JsonWriter writer, BaseUANode node)
         {
-            var id = uaClient.GetUniqueId(node.Id);
+            var id = context.GetUniqueId(node.Id);
             writer.WriteString("externalId", id);
             writer.WriteString("name", string.IsNullOrEmpty(node.Name) ? id : node.Name);
             writer.WriteString("description", node.Attributes.Description);
@@ -458,13 +459,13 @@ namespace Cognite.OpcUa.Types
             WriteProperties(writer, node, true, node.NodeClass == NodeClass.VariableType);
             if (Type == ConverterType.Variable && node is UAVariable variable)
             {
-                writer.WriteString("assetExternalId", uaClient.GetUniqueId(node.ParentId));
+                writer.WriteString("assetExternalId", context.GetUniqueId(node.ParentId));
                 writer.WriteBoolean("isString", variable.FullAttributes.DataType?.IsString ?? false);
                 writer.WriteBoolean("isStep", variable.FullAttributes.DataType?.IsStep ?? false);
             }
             else
             {
-                writer.WriteString("parentExternalId", uaClient.GetUniqueId(node.ParentId));
+                writer.WriteString("parentExternalId", context.GetUniqueId(node.ParentId));
             }
         }
         private void WriteNodeIds(Utf8JsonWriter writer, BaseUANode node, JsonSerializerOptions options)

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -229,8 +229,6 @@ namespace Cognite.OpcUa
         {
             if (Callbacks == null) throw new InvalidOperationException("Attempted to start UAClient without setting callbacks");
 
-            // A restarted Session might mean a restarted server, so all server-relevant data must be cleared.
-            // This includes any stored NodeId, which may refer to an outdated namespaceIndex
             var appConfig = await LoadAppConfig();
 
             SessionManager.Initialize(appConfig, liveToken, timeout);

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -56,11 +56,8 @@ namespace Cognite.OpcUa
         public IClientCallbacks Callbacks { get; set; } = null!;
 
         private readonly SemaphoreSlim subscriptionSem = new SemaphoreSlim(1);
-        private readonly Dictionary<NodeId, string> nodeOverrides = new Dictionary<NodeId, string>();
         public bool Started { get; private set; }
         private CancellationToken liveToken;
-
-        private readonly Dictionary<ushort, string> nsPrefixMap = new Dictionary<ushort, string>();
 
         private static readonly Counter attributeRequests = Metrics
             .CreateCounter("opcua_attribute_requests", "Number of attributes fetched from the server");
@@ -85,6 +82,8 @@ namespace Cognite.OpcUa
 
         public StringConverter StringConverter { get; }
         public Browser Browser { get; }
+
+        public SessionContext? Context => SessionManager?.Context;
 
         /// <summary>
         /// Constructor, does not start the client.
@@ -234,13 +233,11 @@ namespace Cognite.OpcUa
 
             // A restarted Session might mean a restarted server, so all server-relevant data must be cleared.
             // This includes any stored NodeId, which may refer to an outdated namespaceIndex
-            nodeOverrides?.Clear();
-
             await LoadAppConfig();
 
             if (SessionManager == null)
             {
-                SessionManager = new SessionManager(Config.Source, this, AppConfig!, log, liveToken, timeout);
+                SessionManager = new SessionManager(Config, this, AppConfig!, log, liveToken, timeout);
             }
             else
             {
@@ -323,23 +320,6 @@ namespace Cognite.OpcUa
             if (node == null) throw new ExtractorFailureException($"Root node {desc.NodeId} is unexpected node class: {desc.NodeClass}");
             await ReadNodeData(new[] { node }, token, "the server node");
             return node;
-        }
-        /// <summary>
-        /// Add externalId override for a single node
-        /// </summary>
-        /// <param name="nodeId">Id of node to be overridden</param>
-        /// <param name="externalId">ExternalId to be used</param>
-        public void AddNodeOverride(NodeId nodeId, string externalId)
-        {
-            if (nodeId == null || nodeId == NodeId.Null) return;
-            nodeOverrides[nodeId] = externalId;
-        }
-        /// <summary>
-        /// Remove all externalId overrides
-        /// </summary>
-        public void ClearNodeOverrides()
-        {
-            nodeOverrides.Clear();
         }
 
         private List<BrowseNode> HandleBrowseResult(List<BrowseNode> nodes, BrowseResultCollection results,
@@ -812,17 +792,17 @@ namespace Cognite.OpcUa
 
         #region Events
 
-        private ISystemContext? dummyContext;
         /// <summary>
         /// Return systemContext. Can be used by SDK-tools for converting events.
         /// </summary>
-        public ISystemContext? SystemContext => Session?.SystemContext ?? dummyContext;
+        public ISystemContext? SystemContext => SessionManager?.Context?.SystemContext;
 
-        private IServiceMessageContext? dummyMessageContext;
+        public NamespaceTable? NamespaceTable => SessionManager?.Context?.NamespaceTable;
+
         /// <summary>
         /// Return MessageContext, used for serialization
         /// </summary>
-        public IServiceMessageContext? MessageContext => Session?.MessageContext ?? dummyMessageContext;
+        public IServiceMessageContext? MessageContext => SessionManager?.Context?.MessageContext;
         /// <summary>
         /// Constructs a filter from the given list of permitted eventids, the already constructed field map and an optional receivedAfter property.
         /// </summary>
@@ -887,66 +867,13 @@ namespace Cognite.OpcUa
 
         #region Utils
 
-        public NamespaceTable? ExternalNamespaceUris { get; set; }
-
         public void AddExternalNamespaces(string[] table)
         {
-            if (ExternalNamespaceUris == null)
-            {
-                ExternalNamespaceUris = new NamespaceTable(new[]
-                {
-                    "http://opcfoundation.org/UA/"
-                });
-                dummyContext = new DummySystemContext(ExternalNamespaceUris);
-                dummyMessageContext = new DummyMessageContext(ExternalNamespaceUris);
-            }
-            if (table == null) return;
-            foreach (var ns in table)
-            {
-                ExternalNamespaceUris.GetIndexOrAppend(ns);
-            }
+            if (SessionManager == null) throw new InvalidOperationException("External namespaces must be added to initialized client");
+
+            SessionManager.RegisterExternalNamespaces(table);
         }
 
-
-        public NamespaceTable? NamespaceTable => Session?.NamespaceUris ?? ExternalNamespaceUris;
-        /// <summary>
-        /// Converts an ExpandedNodeId into a NodeId using the Session
-        /// </summary>
-        /// <param name="nodeid"></param>
-        /// <returns>Resulting NodeId</returns>
-        public NodeId ToNodeId(ExpandedNodeId nodeid)
-        {
-            if (nodeid == null || nodeid.IsNull || NamespaceTable == null) return NodeId.Null;
-            return ExpandedNodeId.ToNodeId(nodeid, NamespaceTable);
-        }
-        /// <summary>
-        /// Converts identifier string and namespaceUri into NodeId. Identifier will be on form i=123 or s=abc etc.
-        /// </summary>
-        /// <param name="identifier">Full identifier on form i=123 or s=abc etc.</param>
-        /// <param name="namespaceUri">Full namespaceUri</param>
-        /// <returns>Resulting NodeId</returns>
-        public NodeId ToNodeId(string? identifier, string? namespaceUri)
-        {
-            if (identifier == null || namespaceUri == null || NamespaceTable == null) return NodeId.Null;
-            int idx = NamespaceTable.GetIndex(namespaceUri);
-            if (idx < 0)
-            {
-                log.LogInformation("Namespace {NS} not found in {Table}", namespaceUri, NamespaceTable.ToArray());
-                if (Config.Extraction.NamespaceMap.ContainsValue(namespaceUri))
-                {
-                    string readNs = Config.Extraction.NamespaceMap.First(kvp => kvp.Value == namespaceUri).Key;
-                    idx = NamespaceTable.GetIndex(readNs);
-                    if (idx < 0) return NodeId.Null;
-                }
-                else
-                {
-                    return NodeId.Null;
-                }
-            }
-
-            string nsString = "ns=" + idx;
-            return new NodeId(nsString + ";" + identifier);
-        }
         /// <summary>
         /// Convert a datavalue into a double representation, testing for edge cases.
         /// </summary>
@@ -978,161 +905,25 @@ namespace Cognite.OpcUa
             }
         }
 
-        /// <summary>
-        /// Returns consistent unique string representation of a <see cref="NodeId"/> given its namespaceUri
-        /// </summary>
-        /// <remarks>
-        /// NodeId is, according to spec, unique in combination with its namespaceUri. We use this to generate a consistent, unique string
-        /// to be used for mapping assets and timeseries in CDF to opcua nodes.
-        /// To avoid having to send the entire namespaceUri to CDF, we allow mapping Uris to prefixes in the config file.
-        /// </remarks>
-        /// <param name="id">Nodeid to be converted</param>
-        /// <returns>Unique string representation</returns>
         public string? GetUniqueId(ExpandedNodeId id, int index = -1)
         {
-            var nodeId = ToNodeId(id);
-            if (nodeId.IsNullNodeId) return null;
-            if (nodeOverrides.TryGetValue(nodeId, out var nodeOverride))
-            {
-                if (index <= -1) return nodeOverride;
-                return $"{nodeOverride}[{index}]";
-            }
+            if (SessionManager?.Context == null) throw new InvalidOperationException("Attempt to get unique ID without session context");
 
-            // ExternalIds shorter than 32 chars are unlikely, this will generally avoid at least 1 re-allocation of the buffer,
-            // and usually boost performance.
-            var buffer = new StringBuilder(Config.Extraction.IdPrefix, 32);
-
-            if (!nsPrefixMap.TryGetValue(nodeId.NamespaceIndex, out var prefix))
-            {
-                var namespaceUri = id.NamespaceUri ?? NamespaceTable!.GetString(nodeId.NamespaceIndex);
-                string newPrefix;
-                if (namespaceUri is not null)
-                {
-                    if (Config.Extraction.NamespaceMap.TryGetValue(namespaceUri, out string prefixNode))
-                    {
-                        newPrefix = prefixNode;
-                    }
-                    else
-                    {
-                        newPrefix = namespaceUri + ":";
-                    }
-                }
-                else
-                {
-                    log.LogWarning("NodeID received with null NamespaceUri, and index not in NamespaceTable. This is likely a bug in the server. {Id}, {Index}",
-                        nodeId, nodeId.NamespaceIndex);
-                    newPrefix = $"UNKNOWN_NS_{nodeId.NamespaceIndex}";
-                }
-                nsPrefixMap[nodeId.NamespaceIndex] = prefix = newPrefix;
-            }
-
-            buffer.Append(prefix);
-            // Use 0 as namespace-index. This means that the namespace is not appended, as the string representation
-            // of a base namespace nodeId does not include the namespace-index, which fits our use-case.
-            NodeId.Format(buffer, nodeId.Identifier, nodeId.IdType, 0);
-
-            TrimEnd(buffer);
-
-            if (index > -1)
-            {
-                // Modifying buffer.Length effectively removes the last few elements, but more efficiently than modifying strings,
-                // StringBuilder is just a char array.
-                // 255 is max length, Log10(Max(1, index)) + 3 is the length of the index suffix ("[123]").
-                buffer.Length = Math.Min(buffer.Length, 255 - ((int)Math.Log10(Math.Max(1, index)) + 3));
-                buffer.AppendFormat(CultureInfo.InvariantCulture, "[{0}]", index);
-            }
-            else
-            {
-                buffer.Length = Math.Min(buffer.Length, 255);
-            }
-            return buffer.ToString();
-        }
-        /// <summary>
-        /// Used to trim the whitespace off the end of a StringBuilder
-        /// </summary> 
-        private static void TrimEnd(StringBuilder sb)
-        {
-            if (sb == null || sb.Length == 0) return;
-
-            int i = sb.Length - 1;
-            for (; i >= 0; i--)
-                if (!char.IsWhiteSpace(sb[i]))
-                    break;
-
-            if (i < sb.Length - 1)
-                sb.Length = i + 1;
-
-            return;
+            return SessionManager.Context.GetUniqueId(id, index);
         }
 
-        /// <summary>
-        /// Append NodeId and namespace to the given StringBuilder.
-        /// </summary>
-        /// <param name="buffer">Builder to append to</param>
-        /// <param name="nodeId">NodeId to append</param>
-        private void AppendNodeId(StringBuilder buffer, NodeId nodeId)
-        {
-            if (nodeOverrides.TryGetValue(nodeId, out var nodeOverride))
-            {
-                buffer.Append(nodeOverride);
-                return;
-            }
-
-            if (!nsPrefixMap.TryGetValue(nodeId.NamespaceIndex, out var prefix))
-            {
-                var namespaceUri = NamespaceTable!.GetString(nodeId.NamespaceIndex);
-                string newPrefix = Config.Extraction.NamespaceMap.TryGetValue(namespaceUri, out string prefixNode) ? prefixNode : (namespaceUri + ":");
-                nsPrefixMap[nodeId.NamespaceIndex] = prefix = newPrefix;
-            }
-
-            buffer.Append(prefix);
-
-            NodeId.Format(buffer, nodeId.Identifier, nodeId.IdType, 0);
-
-            TrimEnd(buffer);
-        }
-
-        /// <summary>
-        /// Get string representation of NodeId on the form i=123 or s=string, etc.
-        /// </summary>
-        /// <param name="id"></param>
-        /// <returns></returns>
-        private string GetNodeIdString(NodeId id)
-        {
-            var buffer = new StringBuilder();
-            AppendNodeId(buffer, id);
-            return buffer.ToString();
-        }
-
-        /// <summary>
-        /// Get the unique reference id, on the form [prefix][reference-name];[sourceId];[targetId]
-        /// </summary>
-        /// <param name="reference">Reference to get id for</param>
-        /// <returns>String reference id</returns>
         public string GetRelationshipId(UAReference reference)
         {
-            var buffer = new StringBuilder(Config.Extraction.IdPrefix, 64);
-            buffer.Append(reference.Type.GetName(!reference.IsForward));
-            buffer.Append(';');
-            AppendNodeId(buffer, reference.Source.Id);
-            buffer.Append(';');
-            AppendNodeId(buffer, reference.Target.Id);
+            if (SessionManager?.Context == null) throw new InvalidOperationException("Attempt to get relationship ID without session context");
 
-            if (buffer.Length > 255)
-            {
-                // This is an edge-case. If the id overflows, it is most sensible to cut from the
-                // start of the id, as long ids are likely (from experience) to be similar to
-                // system.subsystem.sensor.measurement...
-                // so cutting from the start is less likely to cause conflicts
-                var overflow = (int)Math.Ceiling((buffer.Length - 255) / 2.0);
-                buffer = new StringBuilder(Config.Extraction.IdPrefix, 255);
-                buffer.Append(reference.Type.GetName(!reference.IsForward));
-                buffer.Append(';');
-                buffer.Append(GetNodeIdString(reference.Source.Id).AsSpan(overflow));
-                buffer.Append(';');
-                buffer.Append(GetNodeIdString(reference.Target.Id).AsSpan(overflow));
-            }
-            return buffer.ToString();
+            return SessionManager.Context.GetRelationshipId(reference);
+        }
+
+        public NodeId ToNodeId(ExpandedNodeId id)
+        {
+            if (SessionManager?.Context == null) throw new InvalidOperationException("Attempt to convert node ID without session context");
+
+            return SessionManager.Context.ToNodeId(id);
         }
 
         public void Dispose()

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -66,7 +66,7 @@ namespace Cognite.OpcUa
         public NamespaceTable? NamespaceTable => uaClient.NamespaceTable;
 
         public TypeManager TypeManager => uaClient.TypeManager;
-        public SessionContext? Context => uaClient.Context;
+        public SessionContext Context => uaClient.Context;
 
         private NodeSetNodeSource? nodeSetSource;
 
@@ -105,7 +105,6 @@ namespace Cognite.OpcUa
 
         public bool AllowUpdateState =>
             !Config.Source.Redundancy.MonitorServiceLevel
-            || uaClient.SessionManager != null
             && uaClient.SessionManager.CurrentServiceLevel >= Config.Source.Redundancy.ServiceLevelThreshold;
 
         /// <summary>
@@ -723,7 +722,7 @@ namespace Cognite.OpcUa
                 await rebrowseTriggerManager.EnableCustomServerSubscriptions(Source.Token);
             }
 
-            if (Config.Source.Redundancy.MonitorServiceLevel && uaClient.SessionManager != null)
+            if (Config.Source.Redundancy.MonitorServiceLevel)
             {
                 uaClient.SessionManager.EnsureServiceLevelSubscription();
             }
@@ -811,8 +810,6 @@ namespace Cognite.OpcUa
         /// </summary>
         private async Task ConfigureExtractor()
         {
-            if (uaClient.Context == null) throw new InvalidOperationException("Missing client context");
-
             RootNodes = Config.Extraction.GetRootNodes(uaClient.Context, log);
 
             foreach (var state in State.NodeStates)
@@ -1292,6 +1289,6 @@ namespace Cognite.OpcUa
         StringConverter StringConverter { get; }
         string GetRelationshipId(UAReference reference);
         NamespaceTable? NamespaceTable { get; }
-        public SessionContext? Context { get; }
+        public SessionContext Context { get; }
     }
 }

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -105,7 +105,7 @@ namespace Cognite.OpcUa
 
         public bool AllowUpdateState =>
             !Config.Source.Redundancy.MonitorServiceLevel
-            && uaClient.SessionManager.CurrentServiceLevel >= Config.Source.Redundancy.ServiceLevelThreshold;
+            || uaClient.SessionManager.CurrentServiceLevel >= Config.Source.Redundancy.ServiceLevelThreshold;
 
         /// <summary>
         /// Construct extractor with list of pushers

--- a/Test/Integration/NodeExtractionTests.cs
+++ b/Test/Integration/NodeExtractionTests.cs
@@ -614,18 +614,18 @@ namespace Test.Integration
             Assert.Equal(16, pusher.PushedVariables.Count);
 
             var node = pusher.PushedNodes[ids.Root];
-            var metadata = node.GetExtraMetadata(tester.Config, extractor);
+            var metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
             Assert.Single(metadata);
             Assert.Equal("BaseObjectType", metadata["TypeDefinition"]);
 
             node = pusher.PushedNodes[ids.Array];
-            metadata = node.GetExtraMetadata(tester.Config, extractor);
+            metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
             Assert.Equal(2, metadata.Count);
             Assert.Equal("BaseDataVariableType", metadata["TypeDefinition"]);
             Assert.Equal("Double", metadata["dataType"]);
 
             node = pusher.PushedNodes[ids.EnumVar3];
-            metadata = node.GetExtraMetadata(tester.Config, extractor);
+            metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
             Assert.Equal(4, metadata.Count);
             Assert.Equal("BaseDataVariableType", metadata["TypeDefinition"]);
             Assert.Equal("CustomEnumType2", metadata["dataType"]);
@@ -633,7 +633,7 @@ namespace Test.Integration
             Assert.Equal("VEnum2", metadata["123"]);
 
             var vb = pusher.PushedVariables[(ids.EnumVar3, 1)];
-            metadata = node.GetExtraMetadata(tester.Config, extractor);
+            metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
             Assert.Equal(4, metadata.Count);
             Assert.Equal("BaseDataVariableType", metadata["TypeDefinition"]);
             Assert.Equal("CustomEnumType2", metadata["dataType"]);
@@ -641,7 +641,7 @@ namespace Test.Integration
             Assert.Equal("VEnum2", metadata["123"]);
 
             vb = pusher.PushedVariables[(ids.MysteryVar, -1)];
-            metadata = vb.GetExtraMetadata(tester.Config, extractor);
+            metadata = vb.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
             Assert.Equal(2, metadata.Count);
             Assert.Equal("BaseDataVariableType", metadata["TypeDefinition"]);
             Assert.Equal("MysteryType", metadata["dataType"]);

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -1103,7 +1103,7 @@ namespace Test.Unit
             var converter = tester.Client.StringConverter;
             converter.AddConverters(options, type);
 
-            var id = node.GetUniqueId(extractor);
+            var id = node.GetUniqueId(extractor.Context);
 
             var json = JsonSerializer.Serialize(node, options);
 

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -1281,24 +1281,24 @@ namespace Test.Unit
         public void TestExpandedNodeIdConversion()
         {
             var nodeId = new ExpandedNodeId("string-ns", tester.Client.NamespaceTable.GetString(2));
-            Assert.Equal(new NodeId("string-ns", 2), tester.Client.ToNodeId(nodeId));
+            Assert.Equal(new NodeId("string-ns", 2), tester.Client.Context.ToNodeId(nodeId));
             nodeId = new ExpandedNodeId(new byte[] { 12, 12, 6 }, 1);
-            Assert.Equal(new NodeId(new byte[] { 12, 12, 6 }, 1), tester.Client.ToNodeId(nodeId));
+            Assert.Equal(new NodeId(new byte[] { 12, 12, 6 }, 1), tester.Client.Context.ToNodeId(nodeId));
             nodeId = new ExpandedNodeId("other-server", "opc.tcp://some-other-server.test", 1);
-            Assert.Null(tester.Client.ToNodeId(nodeId));
+            Assert.Null(tester.Client.Context.ToNodeId(nodeId));
         }
         [Fact]
         public void TestNodeIdConversion()
         {
-            var nodeId = tester.Client.ToNodeId("i=123", tester.Client.NamespaceTable.GetString(2));
+            var nodeId = tester.Client.Context.ToNodeId("i=123", tester.Client.NamespaceTable.GetString(2));
             Assert.Equal(new NodeId(123u, 2), nodeId);
-            nodeId = tester.Client.ToNodeId("s=abc", tester.Client.NamespaceTable.GetString(1));
+            nodeId = tester.Client.Context.ToNodeId("s=abc", tester.Client.NamespaceTable.GetString(1));
             Assert.Equal(new NodeId("abc", 1), nodeId);
-            nodeId = tester.Client.ToNodeId("s=abcd", "some-namespaces-that-doesnt-exist");
+            nodeId = tester.Client.Context.ToNodeId("s=abcd", "some-namespaces-that-doesnt-exist");
             Assert.Equal(NodeId.Null, nodeId);
-            nodeId = tester.Client.ToNodeId("s=bcd", "tl:");
+            nodeId = tester.Client.Context.ToNodeId("s=bcd", "tl:");
             Assert.Equal(new NodeId("bcd", 2), nodeId);
-            Assert.Equal(NodeId.Null, tester.Client.ToNodeId("i=123", null));
+            Assert.Equal(NodeId.Null, tester.Client.Context.ToNodeId("i=123", null));
         }
         [Fact]
         public static void TestConvertToDouble()
@@ -1326,10 +1326,14 @@ namespace Test.Unit
             Assert.Equal("gp.tl:s=", tester.Client.GetUniqueId(new NodeId(new string(' ', 400), 2)));
             Assert.Equal("gp.tl:s=[123]", tester.Client.GetUniqueId(new NodeId(new string(' ', 400), 2), 123));
 
-            tester.Client.AddNodeOverride(new NodeId(1234, 2), "override");
+
+            var overrides = tester.Client.Context.GetType().GetField("nodeOverrides",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .GetValue(tester.Client.Context) as Dictionary<NodeId, string>;
+            overrides.Add(new NodeId(1234, 2), "override");
             Assert.Equal("override", tester.Client.GetUniqueId(new NodeId(1234, 2)));
             Assert.Equal("override[123]", tester.Client.GetUniqueId(new NodeId(1234, 2), 123));
-            tester.Client.ClearNodeOverrides();
+            overrides.Clear();
         }
 
         [Fact]

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -111,7 +111,7 @@ namespace Test.Unit
 
         public bool TryGetSubscription(SubscriptionName name, out Subscription subscription)
         {
-            subscription = Client.SessionManager?.Session?.Subscriptions?.FirstOrDefault(sub =>
+            subscription = Client.SessionManager.Session?.Subscriptions?.FirstOrDefault(sub =>
                 sub.DisplayName.StartsWith(name.Name(), StringComparison.InvariantCulture));
             return subscription != null;
         }

--- a/Test/Unit/UAExtractorTest.cs
+++ b/Test/Unit/UAExtractorTest.cs
@@ -201,21 +201,18 @@ namespace Test.Unit
             Assert.Equal("value", fields["Value"]);
         }
         [Fact]
-        public async Task TestNodeMapping()
+        public void TestNodeMapping()
         {
             tester.Config.Extraction.NodeMap = new Dictionary<string, ProtoNodeId>
             {
                 { "Test1", new NodeId("test").ToProtoNodeId(tester.Client) },
                 { "Test2", new NodeId("test2", 2).ToProtoNodeId(tester.Client) }
             };
-            using var extractor = tester.BuildExtractor();
+            var ctx = new SessionContext(tester.Client.SessionManager.Session, tester.Config, tester.Log);
 
-            // Run the configure extractor method...
-            await extractor.RunExtractor(true);
-
-            Assert.Equal("Test1", extractor.GetUniqueId(new NodeId("test")));
-            Assert.Equal("Test2", tester.Client.GetUniqueId(new NodeId("test2", 2)));
-            Assert.Equal("Test1[0]", extractor.GetUniqueId(new NodeId("test"), 0));
+            Assert.Equal("Test1", ctx.GetUniqueId(new NodeId("test")));
+            Assert.Equal("Test2", ctx.GetUniqueId(new NodeId("test2", 2)));
+            Assert.Equal("Test1[0]", ctx.GetUniqueId(new NodeId("test"), 0));
         }
 
         [Fact]

--- a/Test/Unit/UAExtractorTest.cs
+++ b/Test/Unit/UAExtractorTest.cs
@@ -178,14 +178,14 @@ namespace Test.Unit
             tester.Config.Extraction.DataTypes.DataTypeMetadata = true;
             var variable = new UAVariable(new NodeId("test"), "test", null, null, NodeId.Null, null);
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
-            var fields = variable.GetExtraMetadata(tester.Config, extractor);
+            var fields = variable.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
             Assert.Single(fields);
             Assert.Equal("Double", fields["dataType"]);
 
             tester.Config.Extraction.NodeTypes.Metadata = true;
             var node = new UAObject(new NodeId("test"), "test", null, null, NodeId.Null, new UAObjectType(new NodeId("type")));
             node.FullAttributes.TypeDefinition.Attributes.DisplayName = "SomeType";
-            fields = node.GetExtraMetadata(tester.Config, extractor);
+            fields = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
             Assert.Single(fields);
             Assert.Equal("SomeType", fields["TypeDefinition"]);
 
@@ -196,7 +196,7 @@ namespace Test.Unit
             var type = new UAVariableType(new NodeId("test"), "test", null, null, NodeId.Null);
             type.FullAttributes.DataType = new UADataType(DataTypeIds.String);
             type.FullAttributes.Value = new Variant("value");
-            fields = type.GetExtraMetadata(tester.Config, extractor);
+            fields = type.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
             Assert.Single(fields);
             Assert.Equal("value", fields["Value"]);
         }

--- a/Test/Unit/UAExtractorTest.cs
+++ b/Test/Unit/UAExtractorTest.cs
@@ -208,7 +208,8 @@ namespace Test.Unit
                 { "Test1", new NodeId("test").ToProtoNodeId(tester.Client) },
                 { "Test2", new NodeId("test2", 2).ToProtoNodeId(tester.Client) }
             };
-            var ctx = new SessionContext(tester.Client.SessionManager.Session, tester.Config, tester.Log);
+            var ctx = new SessionContext(tester.Config, tester.Log);
+            ctx.UpdateFromSession(tester.Client.SessionManager.Session);
 
             Assert.Equal("Test1", ctx.GetUniqueId(new NodeId("test")));
             Assert.Equal("Test2", ctx.GetUniqueId(new NodeId("test2", 2)));

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -297,7 +297,7 @@ namespace Test.Utils
 
         public bool TryGetSubscription(SubscriptionName name, out Subscription subscription)
         {
-            subscription = Client.SessionManager?.Session?.Subscriptions?.FirstOrDefault(sub =>
+            subscription = Client.SessionManager.Session?.Subscriptions?.FirstOrDefault(sub =>
                 sub.DisplayName.StartsWith(name.Name(), StringComparison.InvariantCulture));
             return subscription != null;
         }

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -120,7 +120,6 @@ namespace Test.Utils
         {
             if (clear)
             {
-                Client.ClearNodeOverrides();
                 RemoveSubscription(SubscriptionName.Events).Wait();
                 RemoveSubscription(SubscriptionName.DataPoints).Wait();
                 RemoveSubscription(SubscriptionName.Audit).Wait();

--- a/Test/Utils/DummyPusher.cs
+++ b/Test/Utils/DummyPusher.cs
@@ -115,7 +115,7 @@ namespace Test.Utils
                         {
                             DataPoints[variable.DestinationId()] = new List<UADataPoint>();
                         }
-                        UniqueToNodeId[variable.GetUniqueId(Extractor)] = variable.DestinationId();
+                        UniqueToNodeId[variable.GetUniqueId(Extractor.Context)] = variable.DestinationId();
                         PushedVariables[variable.DestinationId()] = variable;
                     }
                 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -60,6 +60,12 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.21.2":
+    description: Reliability improvements
+    changelog:
+      fixed:
+        - Fixed bug causing extractor to crash if connection failed while creating extractor.
+        - Fixed issue causing extractor to fail to load data from CDF if connection to the server was lost.
   "2.21.1":
     description: Retry on more status codes
     changelog:


### PR DESCRIPTION
This is a bit tricky, but it might allow the extractor to keep working even when connection to the server is lost. It should generally be fine to continue going with the _previous_ session context. If the setup is such that this won't work, the extractor should be configured to restart hard on connection loss. Most servers will work fine with this.