### PR TITLE
Remove proto nodeId fallback

### DIFF
--- a/ConfigurationTool/Checks/DataTypes.cs
+++ b/ConfigurationTool/Checks/DataTypes.cs
@@ -156,7 +156,7 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public async Task IdentifyDataTypeSettings(CancellationToken token)
         {
-            var roots = Config.Extraction.GetRootNodes(Context, log);
+            var roots = Config.Extraction.GetRootNodes(Context);
 
             int oldArraySize = Config.Extraction.DataTypes.MaxArraySize;
             int arrayLimit = Config.Extraction.DataTypes.MaxArraySize == 0 ? 10 : Config.Extraction.DataTypes.MaxArraySize;

--- a/ConfigurationTool/UAServerExplorer.cs
+++ b/ConfigurationTool/UAServerExplorer.cs
@@ -96,7 +96,7 @@ namespace Cognite.OpcUa.Config
             if (nodesRead) return;
             nodeList.Clear();
             log.LogInformation("Mapping out node hierarchy");
-            var roots = Config.Extraction.GetRootNodes(Context, log);
+            var roots = Config.Extraction.GetRootNodes(Context);
             try
             {
                 await Browser.BrowseNodeHierarchy(roots, ToolUtil.GetSimpleListWriterCallback(nodeList, this, TypeManager, log), token,

--- a/Extractor/Config/EventConfig.cs
+++ b/Extractor/Config/EventConfig.cs
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. */
 
+using Cognite.Extractor.Common;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using System.Collections.Generic;
@@ -105,12 +106,10 @@ namespace Cognite.OpcUa.Config
                 var id = proto.ToNodeId(context);
                 if (id.IsNullNodeId)
                 {
-                    logger.LogWarning("Failed to convert event id {Namespace} {Id} to NodeId", proto.NamespaceUri, proto.NodeId);
+                    throw new ConfigurationException($"Failed to convert event id {proto.NamespaceUri} {proto.NodeId} to NodeId");
                 }
-                else
-                {
-                    whitelist.Add(id);
-                }
+
+                whitelist.Add(id);
             }
             return whitelist;
         }
@@ -124,12 +123,10 @@ namespace Cognite.OpcUa.Config
                 var id = proto.ToNodeId(context);
                 if (id.IsNullNodeId)
                 {
-                    logger.LogWarning("Failed to convert emitter id {Namespace} {Id} to NodeId", proto.NamespaceUri, proto.NodeId);
+                    throw new ConfigurationException($"Failed to convert emitter id {proto.NamespaceUri} {proto.NodeId} to NodeId");
                 }
-                else
-                {
-                    ids.Add(id);
-                }
+
+                ids.Add(id);
             }
             return ids;
         }
@@ -143,12 +140,9 @@ namespace Cognite.OpcUa.Config
                 var id = proto.ToNodeId(context);
                 if (id.IsNullNodeId)
                 {
-                    logger.LogWarning("Failed to convert historizing emitter id {Namespace} {Id} to NodeId", proto.NamespaceUri, proto.NodeId);
+                    throw new ConfigurationException($"Failed to convert historizing emitter id {proto.NamespaceUri} {proto.NodeId} to NodeId");
                 }
-                else
-                {
-                    ids.Add(id);
-                }
+                ids.Add(id);
             }
             return ids;
         }

--- a/Extractor/Config/ExtractionConfig.cs
+++ b/Extractor/Config/ExtractionConfig.cs
@@ -151,7 +151,7 @@ namespace Cognite.OpcUa.Config
         {
             var roots = new List<NodeId>();
             var protoRoots = RootNodes ?? Enumerable.Empty<ProtoNodeId>();
-            if (RootNode != null)
+            if (RootNode != null && RootNode.NamespaceUri != null && RootNode.NodeId != null)
             {
                 protoRoots = protoRoots.Prepend(RootNode);
             }

--- a/Extractor/Config/ExtractionConfig.cs
+++ b/Extractor/Config/ExtractionConfig.cs
@@ -147,35 +147,22 @@ namespace Cognite.OpcUa.Config
         /// It is possible to have multiple of each filter type.
         /// </summary>
         public IEnumerable<RawNodeTransformation>? Transformations { get; set; }
-        public IEnumerable<NodeId> GetRootNodes(SessionContext context, ILogger logger)
+        public IEnumerable<NodeId> GetRootNodes(SessionContext context)
         {
             var roots = new List<NodeId>();
+            var protoRoots = RootNodes ?? Enumerable.Empty<ProtoNodeId>();
             if (RootNode != null)
             {
-                var id = RootNode.ToNodeId(context);
+                protoRoots = protoRoots.Prepend(RootNode);
+            }
+            foreach (var root in protoRoots)
+            {
+                var id = root.ToNodeId(context);
                 if (id.IsNullNodeId)
                 {
-                    logger.LogWarning("Failed to convert configured root node {Namespace} {Id} to NodeId", RootNode.NamespaceUri, RootNode.NodeId);
+                    throw new ConfigurationException($"Failed to convert configured root node {root.NamespaceUri} {root.NodeId} to NodeId");
                 }
-                else
-                {
-                    roots.Add(id);
-                }
-            }
-            if (RootNodes != null)
-            {
-                foreach (var root in RootNodes)
-                {
-                    var id = root.ToNodeId(context);
-                    if (id.IsNullNodeId)
-                    {
-                        logger.LogWarning("Failed to convert configured root node {Namespace} {Id} to NodeId", root.NamespaceUri, root.NodeId);
-                    }
-                    else
-                    {
-                        roots.Add(id);
-                    }
-                }
+                roots.Add(id);
             }
             if (!roots.Any())
             {

--- a/Extractor/SessionContext.cs
+++ b/Extractor/SessionContext.cs
@@ -1,3 +1,4 @@
+using Cognite.Extractor.Common;
 using Cognite.OpcUa.Config;
 using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.Types;
@@ -46,7 +47,10 @@ namespace Cognite.OpcUa
             {
                 foreach (var kvp in config.Extraction.NodeMap)
                 {
-                    nodeOverrides[kvp.Value.ToNodeId(this)] = kvp.Key;
+                    var nodeId = kvp.Value.ToNodeId(this);
+                    if (nodeId.IsNullNodeId) throw new ConfigurationException($"Failed to convert nodeId override {kvp.Value.NamespaceUri} {kvp.Value.NodeId} to NodeId");
+
+                    nodeOverrides[nodeId] = kvp.Key;
                 }
             }
         }

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -810,7 +810,7 @@ namespace Cognite.OpcUa
         /// </summary>
         private async Task ConfigureExtractor()
         {
-            RootNodes = Config.Extraction.GetRootNodes(uaClient.Context, log);
+            RootNodes = Config.Extraction.GetRootNodes(uaClient.Context);
 
             foreach (var state in State.NodeStates)
             {


### PR DESCRIPTION
Avoid falling back to invalid values when converting ProtoNodeId to NodeIds, this causes inconsistent behavior. Better to just fail if this happens.