### PR TITLE
Properly reset max node parallelism if it changes

### DIFF
--- a/Extractor/Browse/Browser.cs
+++ b/Extractor/Browse/Browser.cs
@@ -37,7 +37,7 @@ namespace Cognite.OpcUa.Browse
         private readonly ContinuationPointThrottlingConfig throttling;
         private readonly TaskThrottler throttler;
 
-        private readonly BlockingResourceCounter continuationPoints;
+        private BlockingResourceCounter continuationPoints;
 
         public IEnumerable<NodeFilter>? IgnoreFilters { get; set; }
 
@@ -49,6 +49,13 @@ namespace Cognite.OpcUa.Browse
             throttling = config.Source.BrowseThrottling;
             throttler = new TaskThrottler(throttling.MaxParallelism, false, throttling.MaxPerMinute, TimeSpan.FromMinutes(1));
             continuationPoints = new BlockingResourceCounter(throttling.MaxNodeParallelism <= 0 ? 100_000 : throttling.MaxNodeParallelism);
+        }
+
+        public void MaxNodeParallelismChanged()
+        {
+            continuationPoints = new BlockingResourceCounter(
+                config.Source.BrowseThrottling.MaxNodeParallelism > 0 ? config.Source.BrowseThrottling.MaxNodeParallelism : 100_000
+            );
         }
 
         /// <summary>

--- a/Extractor/Browse/Browser.cs
+++ b/Extractor/Browse/Browser.cs
@@ -37,7 +37,7 @@ namespace Cognite.OpcUa.Browse
         private readonly ContinuationPointThrottlingConfig throttling;
         private readonly TaskThrottler throttler;
 
-        private BlockingResourceCounter continuationPoints;
+        private readonly BlockingResourceCounter continuationPoints;
 
         public IEnumerable<NodeFilter>? IgnoreFilters { get; set; }
 
@@ -53,7 +53,7 @@ namespace Cognite.OpcUa.Browse
 
         public void MaxNodeParallelismChanged()
         {
-            continuationPoints = new BlockingResourceCounter(
+            continuationPoints.SetCapacity(
                 config.Source.BrowseThrottling.MaxNodeParallelism > 0 ? config.Source.BrowseThrottling.MaxNodeParallelism : 100_000
             );
         }

--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AdysTech.InfluxDB.Client.Net.Core" Version="0.25.0" />
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.15.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.16.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.4.371.60" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.4.371.96" />

--- a/Extractor/History/HistoryReader.cs
+++ b/Extractor/History/HistoryReader.cs
@@ -35,7 +35,7 @@ namespace Cognite.OpcUa.History
         private CancellationTokenSource source;
         // private ILogger log = Log.Logger.ForContext<HistoryReader>();
         private readonly TaskThrottler throttler;
-        private readonly BlockingResourceCounter continuationPoints;
+        private BlockingResourceCounter continuationPoints;
 
         private readonly OperationWaiter waiter;
 
@@ -65,6 +65,13 @@ namespace Cognite.OpcUa.History
             using var op = waiter.GetInstance();
 
             await scheduler.RunAsync();
+        }
+
+        public void MaxNodeParallelismChanged()
+        {
+            continuationPoints = new BlockingResourceCounter(
+                config.Throttling.MaxNodeParallelism > 0 ? config.Throttling.MaxNodeParallelism : 1_000
+            );
         }
 
         /// <summary>

--- a/Extractor/History/HistoryReader.cs
+++ b/Extractor/History/HistoryReader.cs
@@ -35,7 +35,7 @@ namespace Cognite.OpcUa.History
         private CancellationTokenSource source;
         // private ILogger log = Log.Logger.ForContext<HistoryReader>();
         private readonly TaskThrottler throttler;
-        private BlockingResourceCounter continuationPoints;
+        private readonly BlockingResourceCounter continuationPoints;
 
         private readonly OperationWaiter waiter;
 
@@ -69,9 +69,7 @@ namespace Cognite.OpcUa.History
 
         public void MaxNodeParallelismChanged()
         {
-            continuationPoints = new BlockingResourceCounter(
-                config.Throttling.MaxNodeParallelism > 0 ? config.Throttling.MaxNodeParallelism : 1_000
-            );
+            continuationPoints.SetCapacity(config.Throttling.MaxNodeParallelism > 0 ? config.Throttling.MaxNodeParallelism : 1_000);
         }
 
         /// <summary>

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -860,7 +860,18 @@ namespace Cognite.OpcUa
             BuildTransformations();
 
             var helper = new ServerInfoHelper(Provider.GetRequiredService<ILogger<ServerInfoHelper>>(), uaClient);
+            var oldHistoryPar = Config.History.Throttling.MaxNodeParallelism;
+            var oldBrowsePar = Config.Source.BrowseThrottling.MaxNodeParallelism;
             await helper.LimitConfigValues(Config, Source.Token);
+
+            if (historyReader != null && oldHistoryPar != Config.History.Throttling.MaxNodeParallelism)
+            {
+                historyReader.MaxNodeParallelismChanged();
+            }
+            if (oldBrowsePar != Config.Source.BrowseThrottling.MaxNodeParallelism)
+            {
+                uaClient.Browser.MaxNodeParallelismChanged();
+            }
         }
 
         /// <summary>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cognite.Extractor.Testing" Version="1.15.0" />
+    <PackageReference Include="Cognite.Extractor.Testing" Version="1.16.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/schema/cognite_config.schema.json
+++ b/schema/cognite_config.schema.json
@@ -3,7 +3,11 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configuration for pushing data to Cognite Data Fusion (CDF)",
-    "allOf": [{ "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.12.2/schema/cognite_config.schema.json" }],
+    "allOf": [
+        {
+            "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.16.0/schema/cognite_config.schema.json"
+        }
+    ],
     "unevaluatedProperties": false,
     "properties": {
         "data-set": {
@@ -38,7 +42,9 @@
                     "type": "object",
                     "description": "Details of CDF raw (database and table).",
                     "unevaluatedProperties": false,
-                    "required": ["database"],
+                    "required": [
+                        "database"
+                    ],
                     "properties": {
                         "database": {
                             "type": "string",
@@ -81,7 +87,14 @@
                     "unevaluatedProperties": false,
                     "description": "configuration for flexible data models in CDF",
                     "type": "object",
-                    "required": ["enabled", "exclude-no-referenced", "types-to-map", "skip-simple-types", "skip-types-on-equal-count", "ignore-mandatory"],
+                    "required": [
+                        "enabled",
+                        "exclude-no-referenced",
+                        "types-to-map",
+                        "skip-simple-types",
+                        "skip-types-on-equal-count",
+                        "ignore-mandatory"
+                    ],
                     "properties": {
                         "space": {
                             "type": "string",
@@ -98,7 +111,11 @@
                         "types-to-map": {
                             "type": "string",
                             "description": "Types to map to fdm",
-                            "enum": ["referenced", "custom", "all"]
+                            "enum": [
+                                "referenced",
+                                "custom",
+                                "all"
+                            ]
                         },
                         "skip-simple-types": {
                             "type": "boolean",
@@ -145,7 +162,11 @@
                     "patternProperties": {
                         ".*": {
                             "type": "string",
-                            "enum": [ "description", "name", "parentId" ]
+                            "enum": [
+                                "description",
+                                "name",
+                                "parentId"
+                            ]
                         }
                     }
                 },
@@ -155,7 +176,12 @@
                     "patternProperties": {
                         ".*": {
                             "type": "string",
-                            "enum": [ "description", "name", "parentId", "unit" ]
+                            "enum": [
+                                "description",
+                                "name",
+                                "parentId",
+                                "unit"
+                            ]
                         }
                     }
                 }
@@ -165,7 +191,10 @@
             "type": "object",
             "description": "Read from CDF instead of OPC-UA when starting, to speed up start on slow servers. Requires `extraction-data-types.expand-node-ids` and `append-internal-values` to be set to `true`. This should generaly be enabled along with `skip-metadata` or `raw-metadata`. If `browse-on-empty` is set to `true` and `raw-metadata` is configured with the same database and tables the extractor will read into raw on first run, then use raw as source for later runs. The Raw database can be deleted to reset on next read.",
             "unevaluatedProperties": false,
-            "required": [ "enable", "database" ],
+            "required": [
+                "enable",
+                "database"
+            ],
             "properties": {
                 "enable": {
                     "type": "boolean",
@@ -190,7 +219,10 @@
             }
         },
         "non-finite-replacement": {
-            "type": [ "number", "null" ],
+            "type": [
+                "number",
+                "null"
+            ],
             "description": "Replacement for NaN values. Deprecated in favor of `nan-replacement`",
             "deprecated": true
         },

--- a/schema/full_config.schema.json
+++ b/schema/full_config.schema.json
@@ -67,7 +67,7 @@
             }
         },
         "high-availability": {
-            "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.4.2/schema/high_availability.schema.json",
+            "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.16.0/schema/high_availability.schema.json",
             "unevaluatedProperties": false
         }
     }

--- a/schema/logger_config.schema.json
+++ b/schema/logger_config.schema.json
@@ -2,13 +2,24 @@
     "$id": "logger_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Configure logging to console or file",
-    "allOf": [{ "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.12.2/schema/logger_config.schema.json" }],
+    "allOf": [
+        {
+            "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.16.0/schema/logger_config.schema.json"
+        }
+    ],
     "unevaluatedProperties": false,
     "type": "object",
     "properties": {
         "ua-trace-level": {
             "type": "string",
-            "enum": ["verbose", "debug", "information", "warning", "error", "fatal"],
+            "enum": [
+                "verbose",
+                "debug",
+                "information",
+                "warning",
+                "error",
+                "fatal"
+            ],
             "description": "Optionally capture OPC-UA trace at this level or higher."
         },
         "ua-session-tracing": {

--- a/schema/metrics_config.schema.json
+++ b/schema/metrics_config.schema.json
@@ -2,7 +2,11 @@
     "$id": "metrics_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Configure logging to console or file",
-    "allOf": [{ "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.12.2/schema/metrics_config.schema.json" }],
+    "allOf": [
+        {
+            "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.16.0/schema/metrics_config.schema.json"
+        }
+    ],
     "unevaluatedProperties": false,
     "type": "object",
     "properties": {

--- a/schema/state_storage_config.schema.json
+++ b/schema/state_storage_config.schema.json
@@ -4,7 +4,11 @@
     "type": "object",
     "description": "Configuration for storing the range of extracted datapoints and events to a persistent store",
     "unevaluatedProperties": false,
-    "allOf": [{ "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.12.2/schema/state_store_config.schema.json" }],
+    "allOf": [
+        {
+            "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.16.0/schema/state_store_config.schema.json"
+        }
+    ],
     "properties": {
         "interval": {
             "type": "string",

--- a/schema/ua_retries_config.schema.json
+++ b/schema/ua_retries_config.schema.json
@@ -3,7 +3,11 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configuration for retries on OPC-UA service calls",
-    "allOf": [{ "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.12.2/schema/retry_config.schema.json" }],
+    "allOf": [
+        {
+            "$ref": "https://raw.githubusercontent.com/cognitedata/dotnet-extractor-utils/v1.16.0/schema/retry_config.schema.json"
+        }
+    ],
     "unevaluatedProperties": false,
     "properties": {
         "retry-status-codes": {


### PR DESCRIPTION
This happens because the history reader and browser are built before we limit config based on the server. This solution isn't perfect, but it's fine.