### PR TITLE
Make reconnect better

### DIFF
--- a/Extractor/ExtractorUtils.cs
+++ b/Extractor/ExtractorUtils.cs
@@ -523,8 +523,13 @@ namespace Cognite.OpcUa
         public uint StatusCode { get; }
         public ServiceResultException? InnerServiceException { get; }
 
+        private static string GetSymbolicId(uint sc)
+        {
+            return Opc.Ua.StatusCode.LookupSymbolicId(sc);
+        }
+
         public SilentServiceException(string msg, ServiceResultException ex, ExtractorUtils.SourceOp op)
-            : base($"{msg}: code {ex?.StatusCode ?? StatusCodes.BadUnexpectedError}, operation {op}", ex)
+            : base($"{msg}: code {GetSymbolicId(ex?.StatusCode ?? StatusCodes.BadUnexpectedError)}, operation {op}", ex)
         {
             Operation = op;
             StatusCode = ex?.StatusCode ?? StatusCodes.BadUnexpectedError;


### PR DESCRIPTION
This might really help a lot. Essentially, any time we lose connection to the server, prefer reconnecting to the old server before trying any new server, or closing the connection.

We can check the error returned from attempting a reconnect to determine whether we should continue trying to reconnect. ForceRestart changes semantics as well, a little, it will probably be much less useful going forward.

This is more or less impossible to test in CICD, because it pretty much requires simulating network loss, which is really hard to do without being netadmin. I've done some testing locally, but even that is tricky.