### PR TITLE
Fix .NET 8 warnings and bump OPC-UA SDK

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,3 +46,6 @@ dotnet_diagnostic.IDE0090.severity = none
 
 # CA1851: Possible multiple enumerations. Nice in theory, but this one is a bit overzealous.
 dotnet_diagnostic.CA1851.severity = none
+
+# CA1861: Prefer static readonly fields over constant array arguments. Not really that important where this pops up, and there are tons of false positives.
+dotnet_diagnostic.CA1861.severity = none

--- a/Extractor/Browse/BrowseScheduler.cs
+++ b/Extractor/Browse/BrowseScheduler.cs
@@ -86,7 +86,7 @@ namespace Cognite.OpcUa
             baseParams = options.InitialParams;
 
             filters = options.Filters;
-            if (baseParams.Nodes.Any())
+            if (baseParams.Nodes.Count != 0)
             {
                 foreach (var node in baseParams.Nodes)
                 {
@@ -212,7 +212,7 @@ namespace Cognite.OpcUa
             }
             await base.RunAsync();
             LogBrowseResult();
-            if (exceptions.Any())
+            if (exceptions.Count != 0)
             {
                 throw new AggregateException(exceptions);
             }

--- a/Extractor/Browse/Browser.cs
+++ b/Extractor/Browse/Browser.cs
@@ -160,7 +160,7 @@ namespace Cognite.OpcUa.Browse
                     .Select(r => uaClient.ToNodeId(r.NodeId))
                     .ToList();
 
-                if (toBrowseForTypeDef.Any())
+                if (toBrowseForTypeDef.Count != 0)
                 {
                     var nodes = toBrowseForTypeDef.Select(id => new BrowseNode(id)).ToDictionary(node => node.Id);
 
@@ -230,7 +230,7 @@ namespace Cognite.OpcUa.Browse
             string purpose = "")
         {
             var result = new Dictionary<NodeId, ReferenceDescriptionCollection>();
-            if (baseParams == null || baseParams.Nodes == null || !baseParams.Nodes.Any()) return result;
+            if (baseParams == null || baseParams.Nodes == null || baseParams.Nodes.Count == 0) return result;
             var options = new DirectoryBrowseParams
             {
                 Callback = GetDictWriteCallback(result),

--- a/Extractor/Config/ExtractionConfig.cs
+++ b/Extractor/Config/ExtractionConfig.cs
@@ -164,7 +164,7 @@ namespace Cognite.OpcUa.Config
                 }
                 roots.Add(id);
             }
-            if (!roots.Any())
+            if (roots.Count == 0)
             {
                 roots.Add(ObjectIds.ObjectsFolder);
             }

--- a/Extractor/Deletes.cs
+++ b/Extractor/Deletes.cs
@@ -111,7 +111,7 @@ namespace Cognite.OpcUa
 
             var time = DateTime.UtcNow;
             var deletedStates = oldStates.Where(s => !states.ContainsKey(s.Key)).Select(kvp => kvp.Value).ToList();
-            if (deletedStates.Any())
+            if (deletedStates.Count != 0)
             {
                 logger.LogInformation("Found {Del} stored nodes in {Tab} that no longer exist and will be marked as deleted", deletedStates.Count, tableName);
                 if (!config.DryRun) await stateStore.DeleteExtractionState(deletedStates.Select(d =>

--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -15,11 +15,11 @@
     <PackageReference Include="AdysTech.InfluxDB.Client.Net.Core" Version="0.25.0" />
     <PackageReference Include="Cognite.ExtractorUtils" Version="1.17.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.4.371.60" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.4.371.96" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.4.371.60-beta" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.4.372.106" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.4.372.106" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.4.372.106-beta" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="MQTTnet" Version="3.1.2" />
+    <PackageReference Include="MQTTnet" Version="4.3.3.952" />
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.25.1" />
   </ItemGroup>

--- a/Extractor/ExtractorUtils.cs
+++ b/Extractor/ExtractorUtils.cs
@@ -138,7 +138,7 @@ namespace Cognite.OpcUa
                 {
                     LogException(log, exc, message, silentMessage);
                 }
-                if (!flat.InnerExceptions.Any())
+                if (flat.InnerExceptions.Count == 0)
                 {
                     log.LogError(e, "{Message} - {ErrMessage}", message, e.Message);
                 }
@@ -195,7 +195,7 @@ namespace Cognite.OpcUa
         {
             var exceptions = new List<Exception>();
             var flat = ex.Flatten();
-            if (flat.InnerExceptions != null && flat.InnerExceptions.Any())
+            if (flat.InnerExceptions != null && flat.InnerExceptions.Count != 0)
             {
                 foreach (var e in flat.InnerExceptions)
                 {

--- a/Extractor/FailureBuffer.cs
+++ b/Extractor/FailureBuffer.cs
@@ -252,7 +252,7 @@ namespace Cognite.OpcUa
         {
             bool success = true;
 
-            if (UseInflux() && nodeBufferStates.Any() && !fullConfig.DryRun)
+            if (UseInflux() && nodeBufferStates.Count != 0 && !fullConfig.DryRun)
             {
                 try
                 {
@@ -373,7 +373,7 @@ namespace Cognite.OpcUa
         {
             bool success = true;
 
-            if (UseInflux() && eventBufferStates.Any() && !fullConfig.DryRun)
+            if (UseInflux() && eventBufferStates.Count != 0 && !fullConfig.DryRun)
             {
                 try
                 {
@@ -444,7 +444,7 @@ namespace Cognite.OpcUa
                         .SelectMany(group => group).ToList();
 
                     log.LogInformation("Read {Count} datapoints from file", points.Count);
-                    if (!points.Any() && final) break;
+                    if (points.Count == 0 && final) break;
 
                     var results = await Task.WhenAll(pushers.Select(pusher => pusher.PushDataPoints(points, token)));
 
@@ -513,7 +513,7 @@ namespace Cognite.OpcUa
                         .ToList();
 
                     log.LogInformation("Read {Count} events from file", events.Count);
-                    if (!events.Any() && final) break;
+                    if (events.Count == 0 && final) break;
 
                     var results = await Task.WhenAll(pushers.Select(pusher => pusher.PushEvents(events, token)));
 

--- a/Extractor/History/HistoryScheduler.cs
+++ b/Extractor/History/HistoryScheduler.cs
@@ -373,7 +373,7 @@ namespace Cognite.OpcUa.History
 
         private static void LogHistoryTermination(ILogger log, List<HistoryReadNode> toTerminate, HistoryReadType type)
         {
-            if (!toTerminate.Any()) return;
+            if (toTerminate.Count == 0) return;
             string name = GetResourceName(type);
             var builder = new StringBuilder();
             foreach (var node in toTerminate)
@@ -436,7 +436,7 @@ namespace Cognite.OpcUa.History
                 metrics.NumItems.Inc(node.LastRead);
             }
 
-            if (failed.Any())
+            if (failed.Count != 0)
             {
                 log.LogError("HistoryRead {Type} failed for {Nodes}", type, string.Join(", ", failed.Select(f => $"{f.id}: {f.status}")));
             }
@@ -505,14 +505,14 @@ namespace Cognite.OpcUa.History
             var last = DateTime.MinValue;
             var first = DateTime.MaxValue;
 
-            if (dataPoints.Any())
+            if (dataPoints.Count != 0)
             {
                 (first, last) = dataPoints.MinMax(dp => dp.SourceTimestamp);
             }
 
             if (config.IgnoreContinuationPoints)
             {
-                node.Completed = !dataPoints.Any()
+                node.Completed = dataPoints.Count == 0
                     || Frontfill && first == last && last == node.State.SourceExtractedRange.Last
                     || !Frontfill && first == last && last == node.State.SourceExtractedRange.First
                     || !Frontfill && last <= historyStartTime;

--- a/Extractor/History/VariableExtractionState.cs
+++ b/Extractor/History/VariableExtractionState.cs
@@ -110,7 +110,7 @@ namespace Cognite.OpcUa.History
         /// <returns>The contents of the buffer once called.</returns>
         public IEnumerable<UADataPoint> FlushBuffer()
         {
-            if (IsFrontfilling || buffer == null || !buffer.Any()) return Array.Empty<UADataPoint>();
+            if (IsFrontfilling || buffer == null || buffer.Count == 0) return Array.Empty<UADataPoint>();
             lock (Mutex)
             {
                 var result = buffer.Where(pt => pt.Timestamp > SourceExtractedRange.Last).ToList();

--- a/Extractor/Looper.cs
+++ b/Extractor/Looper.cs
@@ -128,13 +128,13 @@ namespace Cognite.OpcUa
 
         private async Task CheckFailingPushers(CancellationToken token)
         {
-            if (!failingPushers.Any()) return;
+            if (failingPushers.Count == 0) return;
 
             var result = await Task.WhenAll(failingPushers.Select(pusher => pusher.TestConnection(config, token)));
             var recovered = result.Select((res, idx) => (result: res, pusher: failingPushers.ElementAt(idx)))
                 .Where(x => x.result == true).ToList();
 
-            if (recovered.Any())
+            if (recovered.Count != 0)
             {
                 log.LogInformation("Pushers {Names} recovered", string.Join(", ", recovered.Select(val => val.pusher.GetType())));
             }

--- a/Extractor/NodeMetricsManager.cs
+++ b/Extractor/NodeMetricsManager.cs
@@ -151,7 +151,7 @@ namespace Cognite.OpcUa
                 metrics[nodes[i]] = state;
             }
 
-            if (!metrics.Any()) return;
+            if (metrics.Count == 0) return;
 
             if (client.SubscriptionManager == null) throw new InvalidOperationException("Client not initialized");
 

--- a/Extractor/NodeSources/CDFNodeSourceWithFallback.cs
+++ b/Extractor/NodeSources/CDFNodeSourceWithFallback.cs
@@ -29,7 +29,7 @@ namespace Cognite.OpcUa.NodeSources
         public async Task<NodeLoadResult> LoadNodes(IEnumerable<NodeId> nodesToBrowse, uint nodeClassMask, HierarchicalReferenceMode hierarchicalReferences, string purpose, CancellationToken token)
         {
             var res = await cdfSource.LoadNodes(nodesToBrowse, nodeClassMask, hierarchicalReferences, purpose, token);
-            if (!res.Nodes.Any())
+            if (res.Nodes.Count == 0)
             {
                 usingFallback = true;
                 return await fallbackSource.LoadNodes(nodesToBrowse, nodeClassMask, hierarchicalReferences, purpose, token);

--- a/Extractor/NodeSources/NodeHierarchyBuilder.cs
+++ b/Extractor/NodeSources/NodeHierarchyBuilder.cs
@@ -226,7 +226,7 @@ namespace Cognite.OpcUa.NodeSources
                 FinalReferences.Add(reference);
             }
 
-            if (FinalReferences.Any())
+            if (FinalReferences.Count != 0)
             {
                 logger.LogInformation("Mapped {Count} references", FinalReferences.Count);
             }
@@ -375,7 +375,7 @@ namespace Cognite.OpcUa.NodeSources
                 }
                 toReadValues.Add(node);
             }
-            if (!toReadValues.Any()) return;
+            if (toReadValues.Count == 0) return;
 
             if (config.Source.EndpointUrl == null)
             {

--- a/Extractor/NodeSources/NodeSetNodeSource.cs
+++ b/Extractor/NodeSources/NodeSetNodeSource.cs
@@ -354,7 +354,7 @@ namespace Cognite.OpcUa.NodeSources
                 }
             }
 
-            while (nextIds.Any())
+            while (nextIds.Count != 0)
             {
                 var refs = new List<(IReference Node, NodeId ParentId)>();
 

--- a/Extractor/NodeSources/UANodeSource.cs
+++ b/Extractor/NodeSources/UANodeSource.cs
@@ -73,7 +73,7 @@ namespace Cognite.OpcUa.NodeSources
 
             await client.Browser.BrowseNodeHierarchy(nodesToBrowse, HandleNode, token, purpose, nodeClassMask);
 
-            if (nodeMap.Any()) await client.ReadNodeData(nodeMap, token, purpose);
+            if (nodeMap.Count != 0) await client.ReadNodeData(nodeMap, token, purpose);
 
             return TakeResults(false);
         }
@@ -87,7 +87,7 @@ namespace Cognite.OpcUa.NodeSources
         {
             await LoadNonHierarchicalReferencesInternal(knownNodes, getTypeReferences, initUnknownNodes, purpose, token);
 
-            if (nodeMap.Any()) await client.ReadNodeData(nodeMap, token, "new non-hierarchical instances");
+            if (nodeMap.Count != 0) await client.ReadNodeData(nodeMap, token, "new non-hierarchical instances");
 
             logger.LogDebug("Is mandatory in nodemap? {Yes}", nodeMap.FirstOrDefault(n => n.Id == ObjectIds.ModellingRule_Mandatory));
 

--- a/Extractor/Nodes/UAVariable.cs
+++ b/Extractor/Nodes/UAVariable.cs
@@ -407,7 +407,7 @@ namespace Cognite.OpcUa.Nodes
             Action<string> parentIdHandler,
             StringConverter converter)
         {
-            if (Properties == null || !Properties.Any() || metaMap == null || !metaMap.Any()) return;
+            if (Properties == null || !Properties.Any() || metaMap == null || metaMap.Count == 0) return;
             foreach (var prop in Properties)
             {
                 if (prop is not UAVariable propVar) continue;

--- a/Extractor/Pushers/FDM/FDMWriter.cs
+++ b/Extractor/Pushers/FDM/FDMWriter.cs
@@ -194,7 +194,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             var viewsToInsert = types.Views.Values.ToList();
             if (config.Cognite!.MetadataTargets!.DataModels!.SkipSimpleTypes)
             {
-                viewsToInsert = viewsToInsert.Where(v => v.Properties.Any() || types.ViewIsReferenced.GetValueOrDefault(v.ExternalId)).ToList();
+                viewsToInsert = viewsToInsert.Where(v => v.Properties.Count != 0 || types.ViewIsReferenced.GetValueOrDefault(v.ExternalId)).ToList();
             }
 
             log.LogInformation("Building {Count} containers, and {Count2} views", types.Containers.Count, viewsToInsert.Count);
@@ -221,7 +221,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             }
             catch { }
 
-            if (!viewsToInsert.Any())
+            if (viewsToInsert.Count == 0)
             {
                 log.LogDebug("No views have changed, not updating");
                 return;
@@ -540,7 +540,7 @@ namespace Cognite.OpcUa.Pushers.FDM
         private async Task<IEnumerable<InstanceIdentifier>> GetAllReferencingEdges(IEnumerable<NodeId> nodes, NodeIdContext context, CancellationToken token)
         {
             var chunks = nodes.Select(n => context.NodeIdToString(n)).ChunkBy(1000).ToList();
-            if (!chunks.Any()) return Enumerable.Empty<InstanceIdentifier>();
+            if (chunks.Count == 0) return Enumerable.Empty<InstanceIdentifier>();
 
             var edgeIds = new IEnumerable<InstanceIdentifier>[chunks.Count];
             var generators = chunks

--- a/Extractor/Pushers/FDM/InstanceBuilder.cs
+++ b/Extractor/Pushers/FDM/InstanceBuilder.cs
@@ -256,7 +256,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             var currentType = type;
             while (currentType != null)
             {
-                if (!currentType.Children.Any())
+                if (currentType.Children.Count == 0)
                 {
                     currentType = currentType.Parent;
                     continue;
@@ -264,7 +264,7 @@ namespace Cognite.OpcUa.Pushers.FDM
 
                 var props = new Dictionary<string, IDMSValue?>();
                 CollectProperties(node, currentType.Children, Enumerable.Empty<string>(), props, knownProperties, currentType, true);
-                if (props.Any())
+                if (props.Count != 0)
                 {
                     data.Add(new InstanceData<Dictionary<string, IDMSValue?>>
                     {
@@ -426,7 +426,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             NodeClass = (int)node.NodeClass;
             DisplayName = node.Attributes.DisplayName;
             Description = node.Attributes.Description;
-            if (knownProperties.Any())
+            if (knownProperties.Count != 0)
             {
                 NodeMeta = knownProperties;
             }

--- a/Extractor/Pushers/FDM/TypeHierarchyBuilder.cs
+++ b/Extractor/Pushers/FDM/TypeHierarchyBuilder.cs
@@ -60,7 +60,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             Types.Add(type.Node.Id, type);
 
             // Only create a container if the node has properties
-            bool shouldCreateContainer = type.Properties.Values.Any();
+            bool shouldCreateContainer = type.Properties.Values.Count != 0;
 
             ViewCreate view;
             if (shouldCreateContainer)

--- a/Extractor/Pushers/InfluxPusher.cs
+++ b/Extractor/Pushers/InfluxPusher.cs
@@ -259,17 +259,17 @@ namespace Cognite.OpcUa
                 var last = await client.QueryMultiSeriesAsync(config.Database,
                     $"SELECT last(value) FROM \"{id}\"");
 
-                if (last.Any() && last.First().HasEntries)
+                if (last.Count != 0 && last.First().HasEntries)
                 {
                     DateTime ts = last.First().Entries[0].Time;
                     ranges[id] = new TimeRange(ts, ts);
                 }
 
-                if (backfillEnabled && last.Any() && last.First().HasEntries)
+                if (backfillEnabled && last.Count != 0 && last.First().HasEntries)
                 {
                     var first = await client.QueryMultiSeriesAsync(config.Database,
                         $"SELECT first(value) FROM \"{id}\"");
-                    if (first.Any() && first.First().HasEntries)
+                    if (first.Count != 0 && first.First().HasEntries)
                     {
                         DateTime ts = first.First().Entries[0].Time;
                         ranges[id] = new TimeRange(ts, ranges[id].Last);
@@ -351,7 +351,7 @@ namespace Cognite.OpcUa
                 var last = await client.QueryMultiSeriesAsync(config.Database,
                     $"SELECT last(value) FROM \"{id}\"");
 
-                if (last.Any() && last.First().HasEntries)
+                if (last.Count != 0 && last.First().HasEntries)
                 {
                     DateTime ts = last.First().Entries[0].Time;
                     lock (mutex)
@@ -362,10 +362,10 @@ namespace Cognite.OpcUa
 
                 if (backfillEnabled)
                 {
-                    if (!last.Any()) return;
+                    if (last.Count == 0) return;
                     var first = await client.QueryMultiSeriesAsync(config.Database,
                         $"SELECT first(value) FROM \"{id}\"");
-                    if (first.Any() && first.First().HasEntries)
+                    if (first.Count != 0 && first.First().HasEntries)
                     {
                         DateTime ts = first.First().Entries[0].Time;
                         lock (mutex)
@@ -599,7 +599,7 @@ namespace Cognite.OpcUa
 
             foreach (var series in results)
             {
-                if (!series.Any()) continue;
+                if (series.Count == 0) continue;
                 var current = series.First();
                 string id = current.SeriesName;
                 if (!states.TryGetValue(id, out var state)) continue;

--- a/Extractor/Pushers/PusherUtils.cs
+++ b/Extractor/Pushers/PusherUtils.cs
@@ -88,7 +88,7 @@ namespace Cognite.OpcUa.Pushers
 
         private static bool ShouldSetNewMetadata(FullConfig config, Dictionary<string, string> newMetadata, Dictionary<string, string>? oldMetadata)
         {
-            if (newMetadata.Any())
+            if (newMetadata.Count != 0)
             {
                 if (oldMetadata == null) return true;
                 if (!newMetadata.All(kvp => oldMetadata.TryGetValue(kvp.Key, out var oldVal) && kvp.Value == oldVal)) return true;

--- a/Extractor/Pushers/Writers/BaseTimeseriesWriter.cs
+++ b/Extractor/Pushers/Writers/BaseTimeseriesWriter.cs
@@ -64,7 +64,7 @@ namespace Cognite.OpcUa.Pushers.Writers
                     .Where(kvp => kvp.Value.Source != NodeSource.CDF)
                     .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-                if (update.AnyUpdate && toPushMeta.Any())
+                if (update.AnyUpdate && toPushMeta.Count != 0)
                 {
                     await UpdateTimeseries(extractor, toPushMeta, timeseries, nodeToAssetIds, update, result, token);
                 }
@@ -135,7 +135,7 @@ namespace Cognite.OpcUa.Pushers.Writers
                     foundBadTimeseries.Add(ts.ExternalId);
                 }
             }
-            if (foundBadTimeseries.Any())
+            if (foundBadTimeseries.Count != 0)
             {
                 logger.LogDebug(
                     "Found mismatched timeseries when ensuring: {TimeSeries}",

--- a/Extractor/Pushers/Writers/CDFWriter.cs
+++ b/Extractor/Pushers/Writers/CDFWriter.cs
@@ -105,7 +105,7 @@ namespace Cognite.OpcUa.Pushers.Writers
             }
 
             // Raw assets and timeseries
-            if (assetMap.Any() && raw != null)
+            if (assetMap.Count != 0 && raw != null)
             {
                 tasks.Add(Task.Run(async () =>
                 {
@@ -113,7 +113,7 @@ namespace Cognite.OpcUa.Pushers.Writers
                 }));
             }
 
-            if (timeseriesMap.Any() && raw != null)
+            if (timeseriesMap.Count != 0 && raw != null)
             {
                 tasks.Add(Task.Run(async () =>
                 {

--- a/Extractor/Pushers/Writers/CleanWriter.cs
+++ b/Extractor/Pushers/Writers/CleanWriter.cs
@@ -192,7 +192,7 @@ namespace Cognite.OpcUa.Pushers.Writers
                     }
                 }
             }
-            if (updates.Any())
+            if (updates.Count != 0)
             {
                 var res = await destination.UpdateAssetsAsync(updates, RetryMode.OnError, SanitationMode.Clean, token);
 
@@ -234,7 +234,7 @@ namespace Cognite.OpcUa.Pushers.Writers
                             }
                         }
                     }
-                    if (!existing.Any())
+                    if (existing.Count == 0)
                         throw;
 
                     relationships = relationships

--- a/Extractor/Pushers/Writers/TimeseriesWriter.cs
+++ b/Extractor/Pushers/Writers/TimeseriesWriter.cs
@@ -85,7 +85,7 @@ namespace Cognite.OpcUa.Pushers.Writers
                 }
             }
 
-            if (updates.Any())
+            if (updates.Count != 0)
             {
                 var res = await destination.UpdateTimeSeriesAsync(updates, RetryMode.OnError, SanitationMode.Clean, token);
 

--- a/Extractor/RebrowseTriggerManager.cs
+++ b/Extractor/RebrowseTriggerManager.cs
@@ -160,7 +160,7 @@ namespace Cognite.OpcUa
                 );
             }
 
-            if (nodes.Any())
+            if (nodes.Count != 0)
             {
                 await CheckLastStateTriggered(nodes.Values.ToList(), token);
                 CreateSubscriptions(nodes, token);

--- a/Extractor/Streamer.cs
+++ b/Extractor/Streamer.cs
@@ -177,7 +177,7 @@ namespace Cognite.OpcUa
                 return false;
             }
             var reconnectedPushers = passingPushers.Where(pusher => pusher.DataFailing).ToList();
-            if (reconnectedPushers.Any())
+            if (reconnectedPushers.Count != 0)
             {
                 log.LogInformation("{Count} failing pushers were able to push data, reconnecting", reconnectedPushers.Count);
 
@@ -269,7 +269,7 @@ namespace Cognite.OpcUa
                 return false;
             }
             var reconnectedPushers = passingPushers.Where(pusher => pusher.EventsFailing).ToList();
-            if (reconnectedPushers.Any())
+            if (reconnectedPushers.Count != 0)
             {
                 log.LogInformation("{Count} failing pushers were able to push events, reconnecting", reconnectedPushers.Count);
 

--- a/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
+++ b/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
@@ -88,7 +88,7 @@ namespace Cognite.OpcUa.Subscriptions
         {
             var hasSubscription = subscription.MonitoredItems.Select(s => s.ResolvedNodeId).ToHashSet();
             var toAdd = Items.Where(i => !hasSubscription.Contains(i.Key)).ToList();
-            if (toAdd.Any())
+            if (toAdd.Count != 0)
             {
                 logger.LogInformation("Adding {Count} new monitored items to subscription {Name}", toAdd.Count, SubscriptionName.Name());
 

--- a/Extractor/TypeCollectors/TypeManager.cs
+++ b/Extractor/TypeCollectors/TypeManager.cs
@@ -181,7 +181,7 @@ namespace Cognite.OpcUa.TypeCollectors
                 loadReferences = true;
             }
 
-            if (!rootNodes.Any()) return;
+            if (rootNodes.Count == 0) return;
 
 
             var result = await source.LoadNodes(rootNodes, mask, referenceMode, "the type hierarchy", token);
@@ -293,7 +293,7 @@ namespace Cognite.OpcUa.TypeCollectors
             {
                 if (!type.IsEventType()) continue;
                 if (ignoreFilter != null && ignoreFilter.IsMatch(type.Name)) continue;
-                if (whitelist != null && whitelist.Any())
+                if (whitelist != null && whitelist.Count != 0)
                 {
                     if (!whitelist.Contains(type.Id)) continue;
                 }

--- a/Extractor/Types/UAEvent.cs
+++ b/Extractor/Types/UAEvent.cs
@@ -89,7 +89,7 @@ namespace Cognite.OpcUa.Types
                 builder.AppendFormat(CultureInfo.InvariantCulture, "SourceNode: {0}", SourceNode);
                 builder.AppendLine();
             }
-            if (MetaData != null && MetaData.Any())
+            if (MetaData != null && MetaData.Count != 0)
             {
                 builder.Append("MetaData: {");
                 builder.AppendLine();
@@ -262,7 +262,7 @@ namespace Cognite.OpcUa.Types
                 }
             }
 
-            if (finalMetaData.Any())
+            if (finalMetaData.Count != 0)
             {
                 evt.Metadata = finalMetaData;
             }

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -363,7 +363,7 @@ namespace Cognite.OpcUa
 
             using var operation = waiter.GetInstance();
 
-            if (toBrowse.Any())
+            if (toBrowse.Count != 0)
             {
                 var results = await RetryUtil.RetryResultAsync("browse", async () => await GetReferencesChunk(browseParams, toBrowse, token), Config.Source.Retries, Config.Source.Retries.ShouldRetryException, log, token);
 
@@ -371,7 +371,7 @@ namespace Cognite.OpcUa
                 if (readToCompletion) toBrowseNext.AddRange(next);
             }
 
-            while (toBrowseNext.Any())
+            while (toBrowseNext.Count != 0)
             {
                 var results = await RetryUtil.RetryResultAsync("browse next", async () => await GetNextReferencesChunk(toBrowseNext, token), Config.Source.Retries, Config.Source.Retries.ShouldRetryException, log, token);
 
@@ -458,7 +458,7 @@ namespace Cognite.OpcUa
         {
             if (Session == null) throw new ServiceCallFailureException("Session is not connected", ServiceCallFailure.SessionMissing);
             var toAbort = nodes.Where(node => node.ContinuationPoint != null).ToList();
-            if (!toAbort.Any()) return;
+            if (toAbort.Count == 0) return;
             var cps = new ByteStringCollection(nodes.Select(node => node.ContinuationPoint));
             try
             {
@@ -804,7 +804,7 @@ namespace Cognite.OpcUa
              */
             var whereClause = new ContentFilter();
 
-            if (eventFields.Keys.Any() && ((Config.Events.EventIds?.Any() ?? false) || !Config.Events.AllEvents))
+            if (eventFields.Keys.Count != 0 && ((Config.Events.EventIds?.Any() ?? false) || !Config.Events.AllEvents))
             {
                 log.LogDebug("Limit event results to the following ids: {Ids}", string.Join(", ", eventFields.Keys));
                 var eventListOperand = new SimpleAttributeOperand

--- a/MQTTCDFBridge/MQTTCDFBridge.csproj
+++ b/MQTTCDFBridge/MQTTCDFBridge.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Cognite.ExtractorUtils" Version="1.17.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="MQTTnet" Version="3.1.2" />
+    <PackageReference Include="MQTTnet" Version="4.3.3.952" />
     <PackageReference Include="Google.Protobuf" Version="3.25.1" />
   </ItemGroup>
 </Project>

--- a/Server/DebugMasterNodeManager.cs
+++ b/Server/DebugMasterNodeManager.cs
@@ -58,7 +58,7 @@ namespace Server
             out DataValueCollection values,
             out DiagnosticInfoCollection diagnosticInfos)
         {
-            if (nodesToRead == null) throw new ArgumentNullException(nameof(nodesToRead));
+            ArgumentNullException.ThrowIfNull(nodesToRead);
 
             callbacks.OnRead(context, nodesToRead);
 
@@ -75,8 +75,8 @@ namespace Server
             IList<MonitoringFilterResult> filterResults,
             IList<IMonitoredItem> monitoredItems)
         {
-            if (itemsToCreate == null) throw new ArgumentNullException(nameof(itemsToCreate));
-            if (errors == null) throw new ArgumentNullException(nameof(errors));
+            ArgumentNullException.ThrowIfNull(itemsToCreate);
+            ArgumentNullException.ThrowIfNull(errors);
 
             callbacks.OnCreateMonitoredItems(context, subscriptionId, itemsToCreate);
 
@@ -92,7 +92,7 @@ namespace Server
             out HistoryReadResultCollection results,
             out DiagnosticInfoCollection diagnosticInfos)
         {
-            if (nodesToRead == null) throw new ArgumentNullException(nameof(nodesToRead));
+            ArgumentNullException.ThrowIfNull(nodesToRead);
 
             callbacks.OnHistoryRead(context, historyReadDetails, nodesToRead);
 
@@ -107,8 +107,8 @@ namespace Server
             out BrowseResultCollection results,
             out DiagnosticInfoCollection diagnosticInfos)
         {
-            if (context == null) throw new ArgumentNullException(nameof(context));
-            if (nodesToBrowse == null) throw new ArgumentNullException(nameof(nodesToBrowse));
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(nodesToBrowse);
 
             callbacks.OnBrowse(context, nodesToBrowse);
 

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Cognite.ExtractorUtils" Version="1.17.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
-    <PackageReference Include="MQTTnet" Version="3.1.2" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.4.371.96" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.4.371.60-beta" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.4.371.60" />
+    <PackageReference Include="MQTTnet" Version="4.3.3.952" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.4.372.106" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.4.372.106-beta" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.4.372.106" />
   </ItemGroup>
 </Project>

--- a/Server/ServerController.cs
+++ b/Server/ServerController.cs
@@ -130,7 +130,7 @@ namespace Server
 
         public async Task UpdateNodeMultiple(NodeId id, int count, Func<int, object> generator, int delayms = 50)
         {
-            if (generator == null) throw new ArgumentNullException(nameof(generator));
+            ArgumentNullException.ThrowIfNull(generator);
             for (int i = 0; i < count; i++)
             {
                 Server.UpdateNode(id, generator(i));

--- a/Server/TestServer.cs
+++ b/Server/TestServer.cs
@@ -24,6 +24,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Server
 {
@@ -35,6 +37,16 @@ namespace Server
         }
 
         public void Validate(X509Certificate2Collection certificates)
+        {
+            throw ServiceResultException.Create(StatusCodes.BadCertificateInvalid, "Bad certificate");
+        }
+
+        public Task ValidateAsync(X509Certificate2 certificate, CancellationToken ct)
+        {
+            throw ServiceResultException.Create(StatusCodes.BadCertificateInvalid, "Bad certificate");
+        }
+
+        public Task ValidateAsync(X509Certificate2Collection certificateChain, CancellationToken ct)
         {
             throw ServiceResultException.Create(StatusCodes.BadCertificateInvalid, "Bad certificate");
         }
@@ -102,7 +114,7 @@ namespace Server
 
         protected override void OnServerStarting(ApplicationConfiguration configuration)
         {
-            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            ArgumentNullException.ThrowIfNull(configuration);
             configuration.ServerConfiguration.ReverseConnect = new ReverseConnectServerConfiguration
             {
                 ConnectInterval = 1000,
@@ -147,7 +159,7 @@ namespace Server
 
         protected override void OnServerStarted(IServerInternal server)
         {
-            if (server == null) throw new ArgumentNullException(nameof(server));
+            ArgumentNullException.ThrowIfNull(server);
 
             base.OnServerStarted(server);
 
@@ -313,7 +325,7 @@ namespace Server
         }
         public void MutateNode(NodeId id, Action<NodeState> mutation)
         {
-            if (mutation == null) throw new ArgumentNullException(nameof(mutation));
+            ArgumentNullException.ThrowIfNull(mutation);
             custom.MutateNode(id, mutation);
         }
         public void ReContextualize(NodeId id, NodeId oldParentId, NodeId newParentId, NodeId referenceType)

--- a/Test/CommonTestUtils.cs
+++ b/Test/CommonTestUtils.cs
@@ -211,11 +211,11 @@ namespace Test
             CustomNodeReference ids,
             bool raw)
         {
-            if (assets == null) throw new ArgumentNullException(nameof(assets));
-            if (timeseries == null) throw new ArgumentNullException(nameof(timeseries));
+            ArgumentNullException.ThrowIfNull(assets);
+            ArgumentNullException.ThrowIfNull(timeseries);
             if (upd == null) upd = new UpdateConfig();
-            if (client == null) throw new ArgumentNullException(nameof(client));
-            if (ids == null) throw new ArgumentNullException(nameof(ids));
+            ArgumentNullException.ThrowIfNull(client);
+            ArgumentNullException.ThrowIfNull(ids);
             Assert.Equal(6, assets.Count);
             Assert.Equal(16, timeseries.Count);
 
@@ -262,13 +262,13 @@ namespace Test
 
             if (!upd.Objects.Metadata)
             {
-                Assert.True(obj1Meta == null || !obj1Meta.Any());
+                Assert.True(obj1Meta == null || obj1Meta.Count == 0);
                 Assert.Equal(2, obj2Meta.Count);
                 Assert.Equal("1234", obj2Meta["NumericProp"]);
             }
             if (!upd.Variables.Metadata)
             {
-                Assert.True(stringyMeta == null || !stringyMeta.Any());
+                Assert.True(stringyMeta == null || stringyMeta.Count == 0);
                 Assert.Equal(2, mysteryMeta.Count);
                 Assert.Equal("(0, 100)", mysteryMeta["EURange"]);
             }
@@ -283,11 +283,11 @@ namespace Test
             CustomNodeReference ids,
             bool raw)
         {
-            if (assets == null) throw new ArgumentNullException(nameof(assets));
-            if (timeseries == null) throw new ArgumentNullException(nameof(timeseries));
+            ArgumentNullException.ThrowIfNull(assets);
+            ArgumentNullException.ThrowIfNull(timeseries);
             if (upd == null) upd = new UpdateConfig();
-            if (client == null) throw new ArgumentNullException(nameof(client));
-            if (ids == null) throw new ArgumentNullException(nameof(ids));
+            ArgumentNullException.ThrowIfNull(client);
+            ArgumentNullException.ThrowIfNull(ids);
             Assert.Equal(6, assets.Count);
             Assert.Equal(16, timeseries.Count);
 
@@ -348,12 +348,14 @@ namespace Test
             }
         }
 
+        private static readonly JsonSerializerOptions jsonOptions = new JsonSerializerOptions
+        {
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+
         public static string JsonElementToString(JsonElement elem)
         {
-            return System.Text.Json.JsonSerializer.Serialize(elem, new JsonSerializerOptions
-            {
-                Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-            });
+            return System.Text.Json.JsonSerializer.Serialize(elem, jsonOptions);
         }
 
         public static ProtoNodeId ToProtoNodeId(this NodeId id, UAClient client)

--- a/Test/CommonTestUtils.cs
+++ b/Test/CommonTestUtils.cs
@@ -372,7 +372,7 @@ namespace Test
         }
         public static UAVariable GetSimpleVariable(string name, UADataType dt, int dim = 0, NodeId id = null)
         {
-            var variable = new UAVariable(id ?? new NodeId(name), name, null, null, NodeId.Null, null);
+            var variable = new UAVariable(id ?? new NodeId(name, 0), name, null, null, NodeId.Null, null);
             variable.FullAttributes.DataType = dt;
             variable.FullAttributes.ValueRank = ValueRanks.Scalar;
             if (dim > 0)

--- a/Test/Integration/DataPointTests.cs
+++ b/Test/Integration/DataPointTests.cs
@@ -70,7 +70,7 @@ namespace Test.Integration
 
             await extractor.WaitForSubscriptions();
 
-            await TestUtils.WaitForCondition(() => pusher.DataPoints.Any(kvp => kvp.Value.Any()), 5);
+            await TestUtils.WaitForCondition(() => pusher.DataPoints.Any(kvp => kvp.Value.Count != 0), 5);
             foreach (var kvp in pusher.DataPoints)
             {
                 kvp.Value.Clear();
@@ -92,8 +92,8 @@ namespace Test.Integration
             // enum array
             tester.Server.UpdateNode(ids.EnumVar3, new[] { 123, 321, 321, 321 });
 
-            await TestUtils.WaitForCondition(() => pusher.DataPoints.Count(kvp => kvp.Value.Any()) == 13,
-                5, () => $"Expected to get values in 13 timeseries, but got {pusher.DataPoints.Count(kvp => kvp.Value.Any())}");
+            await TestUtils.WaitForCondition(() => pusher.DataPoints.Count(kvp => kvp.Value.Count != 0) == 13,
+                5, () => $"Expected to get values in 13 timeseries, but got {pusher.DataPoints.Count(kvp => kvp.Value.Count != 0)}");
 
             void TestDataPoints((NodeId, int) id, object expected)
             {
@@ -149,7 +149,7 @@ namespace Test.Integration
 
             try
             {
-                await TestUtils.WaitForCondition(() => pusher.DataPoints.Any(kvp => kvp.Value.Any()), 5);
+                await TestUtils.WaitForCondition(() => pusher.DataPoints.Any(kvp => kvp.Value.Count != 0), 5);
             }
             finally
             {
@@ -164,8 +164,8 @@ namespace Test.Integration
             // enum array
             tester.Server.UpdateNode(ids.EnumVar3, new[] { 123, 321, 321, 321 });
 
-            await TestUtils.WaitForCondition(() => pusher.DataPoints.Count(kvp => kvp.Value.Any()) == 5,
-                5, () => $"Expected to get values in 5 timeseries, but got {pusher.DataPoints.Count(kvp => kvp.Value.Any())}");
+            await TestUtils.WaitForCondition(() => pusher.DataPoints.Count(kvp => kvp.Value.Count != 0) == 5,
+                5, () => $"Expected to get values in 5 timeseries, but got {pusher.DataPoints.Count(kvp => kvp.Value.Count != 0)}");
 
             void TestDataPoints((NodeId, int) id, object expected)
             {
@@ -215,7 +215,7 @@ namespace Test.Integration
 
             await extractor.WaitForSubscriptions();
 
-            await TestUtils.WaitForCondition(() => pusher.DataPoints.Any(kvp => kvp.Value.Any()), 5);
+            await TestUtils.WaitForCondition(() => pusher.DataPoints.Any(kvp => kvp.Value.Count != 0), 5);
             foreach (var kvp in pusher.DataPoints)
             {
                 kvp.Value.Clear();
@@ -231,8 +231,8 @@ namespace Test.Integration
             tester.Server.UpdateNode(ids.RankImpreciseNoDim, new[] { 1, 2, 3, 4 });
             tester.Server.UpdateNode(ids.NullType, 1);
 
-            await TestUtils.WaitForCondition(() => pusher.DataPoints.Count(kvp => kvp.Value.Any()) == 8,
-                5, () => $"Expected to get values in 8 timeseries, but got {pusher.DataPoints.Count(kvp => kvp.Value.Any())}");
+            await TestUtils.WaitForCondition(() => pusher.DataPoints.Count(kvp => kvp.Value.Count != 0) == 8,
+                5, () => $"Expected to get values in 8 timeseries, but got {pusher.DataPoints.Count(kvp => kvp.Value.Count != 0)}");
 
             void TestDataPoints((NodeId, int) id, object expected)
             {
@@ -969,7 +969,7 @@ namespace Test.Integration
                 && extractor.State.NodeStates.All(state => !state.IsFrontfilling), 5,
                 () => $"Pusher is dataFailing: {pusher.DataFailing}");
 
-            Assert.True(pusher.DataPoints.All(dps => !dps.Value.Any()));
+            Assert.True(pusher.DataPoints.All(dps => dps.Value.Count == 0));
 
             tester.Server.UpdateNode(ids.DoubleVar1, 1000);
             tester.Server.UpdateNode(ids.DoubleVar2, 1);

--- a/Test/Integration/EventTests.cs
+++ b/Test/Integration/EventTests.cs
@@ -576,7 +576,7 @@ namespace Test.Integration
                 && extractor.State.EmitterStates.All(state => !state.IsFrontfilling), 5,
                 () => $"Pusher is dataFailing: {pusher.DataFailing}");
 
-            Assert.True(pusher.DataPoints.All(dps => !dps.Value.Any()));
+            Assert.True(pusher.DataPoints.All(dps => dps.Value.Count == 0));
 
             tester.Server.TriggerEvents(100);
 

--- a/Test/Integration/LauncherTests.cs
+++ b/Test/Integration/LauncherTests.cs
@@ -130,7 +130,7 @@ version: 1
             };
             await Program.Main(args);
 
-            var file = File.ReadAllText("config-output-test-1.yml");
+            var file = await File.ReadAllTextAsync("config-output-test-1.yml");
             Assert.Equal(
                 GetConfigToolOutput().Replace("\r\n", "\n", StringComparison.InvariantCulture),
                 file.Replace("\r\n", "\n", StringComparison.InvariantCulture));
@@ -155,7 +155,7 @@ version: 1
 
                 await extractor.WaitForSubscriptions();
 
-                await TestUtils.WaitForCondition(() => pusher.PushedNodes.Any(), 10);
+                await TestUtils.WaitForCondition(() => pusher.PushedNodes.Count != 0, 10);
                 Assert.Equal(167, pusher.PushedNodes.Count);
                 Assert.Equal(2006, pusher.PushedVariables.Count);
             }
@@ -176,7 +176,7 @@ version: 1
                 "config-test-1.yml",
                 "--exit"
             };
-            File.WriteAllText("config-test-1.yml", GetConfigToolOutput());
+            await File.WriteAllTextAsync("config-test-1.yml", GetConfigToolOutput());
 
             var task = Program.Main(args);
 
@@ -186,7 +186,7 @@ version: 1
 
                 await extractor.WaitForSubscriptions();
 
-                await TestUtils.WaitForCondition(() => pusher.PushedNodes.Any(), 10);
+                await TestUtils.WaitForCondition(() => pusher.PushedNodes.Count != 0, 10);
                 Assert.Equal(172, pusher.PushedNodes.Count);
                 Assert.Equal(2032, pusher.PushedVariables.Count);
             }
@@ -212,7 +212,7 @@ version: 1
                 "config",
                 "--exit"
             };
-            File.WriteAllText("config-test-1.yml", GetConfigToolOutput());
+            await File.WriteAllTextAsync("config-test-1.yml", GetConfigToolOutput());
 
             var task = Program.Main(args);
 
@@ -222,7 +222,7 @@ version: 1
 
                 await extractor.WaitForSubscriptions();
 
-                await TestUtils.WaitForCondition(() => pusher.PushedNodes.Any(), 10);
+                await TestUtils.WaitForCondition(() => pusher.PushedNodes.Count != 0, 10);
                 Assert.Equal(172, pusher.PushedNodes.Count);
                 Assert.Equal(2032, pusher.PushedVariables.Count);
             }

--- a/Test/Integration/NodeExtractionTests.cs
+++ b/Test/Integration/NodeExtractionTests.cs
@@ -3,6 +3,7 @@ using Cognite.OpcUa;
 using Cognite.OpcUa.Config;
 using Cognite.OpcUa.Nodes;
 using Cognite.OpcUa.Types;
+using CogniteSdk;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
@@ -703,6 +704,10 @@ namespace Test.Integration
             using var extractor = tester.BuildExtractor(true, null, pusher);
             await RunReferenceExtraction(extractor);
 
+            foreach (var rf in pusher.PushedReferences)
+            {
+                tester.Log.LogDebug("{S}", rf);
+            }
             Assert.Equal(18, pusher.PushedReferences.Count);
             Assert.Equal(14, pusher.PushedReferences.Count(rel => rel.IsForward));
 
@@ -893,7 +898,7 @@ namespace Test.Integration
 
             var runTask = extractor.RunExtractor();
 
-            await TestUtils.WaitForCondition(() => handler.Assets.Any() && handler.Timeseries.Any(), 5);
+            await TestUtils.WaitForCondition(() => handler.Assets.Count != 0 && handler.Timeseries.Count != 0, 5);
 
             CommonTestUtils.VerifyStartingConditions(handler.Assets, handler.Timeseries, null, extractor, tester.Server.Ids.Custom, false);
 
@@ -955,7 +960,7 @@ namespace Test.Integration
 
             var runTask = extractor.RunExtractor();
 
-            await TestUtils.WaitForCondition(() => handler.AssetsRaw.Any() && handler.TimeseriesRaw.Any(), 5);
+            await TestUtils.WaitForCondition(() => handler.AssetsRaw.Count != 0 && handler.TimeseriesRaw.Count != 0, 5);
 
             CommonTestUtils.VerifyStartingConditions(
                 handler.AssetsRaw
@@ -1027,7 +1032,7 @@ namespace Test.Integration
 
             var runTask = extractor.RunExtractor();
 
-            await TestUtils.WaitForCondition(() => handler.Assets.Any() && handler.Timeseries.Any(), 5);
+            await TestUtils.WaitForCondition(() => handler.Assets.Count != 0 && handler.Timeseries.Count != 0, 5);
 
             var id = tester.Client.GetUniqueId(tester.Server.Ids.Wrong.RankImprecise);
 

--- a/Test/Integration/RebrowseTriggerManagerTests.cs
+++ b/Test/Integration/RebrowseTriggerManagerTests.cs
@@ -22,8 +22,7 @@ namespace Test.Integration
     {
         private readonly StaticServerTestFixture tester;
         private readonly ITestOutputHelper _output;
-        private IDictionary<string, NamespacePublicationDateState> _extractionStates =
-            new Dictionary<string, NamespacePublicationDateState>();
+        private Dictionary<string, NamespacePublicationDateState> _extractionStates = new();
 
         public RebrowseTriggerManagerTests(ITestOutputHelper output, StaticServerTestFixture tester)
         {
@@ -146,7 +145,8 @@ namespace Test.Integration
                 },
                 tester.Source.Token
             );
-            foreach (var id in _extractionStates) {
+            foreach (var id in _extractionStates)
+            {
                 _output.WriteLine($"Value of {id.Key} is {id.Value.LastTimestamp}");
             }
             Assert.True(_extractionStates.TryGetValue(npdId, out var newNpds));
@@ -155,9 +155,11 @@ namespace Test.Integration
             Assert.Equal(newTime.ToUnixTimeMilliseconds(), newNpds.LastTimestamp);
             tester.Server.Server.RemoveNode(addedId);
             await BaseExtractorTestFixture.TerminateRunTask(runTask, extractor);
-            try {
+            try
+            {
                 File.Delete(tester.Config.StateStorage.Location);
-            } catch {}
+            }
+            catch { }
         }
 
         public static IEnumerable<object[]> TriggeringConfigurationStates =>

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -222,7 +222,7 @@ namespace Test.Unit
                 .GetValue(pusher);
             var nodeToAssetIds = writer.NodeToAssetIds;
 
-            nodeToAssetIds[new NodeId("source")] = 123;
+            nodeToAssetIds[new NodeId("source", 0)] = 123;
 
             var time = DateTime.UtcNow;
 
@@ -231,17 +231,17 @@ namespace Test.Unit
                 new UAEvent
                 {
                     Time = time,
-                    EmittingNode = new NodeId("emitter"),
-                    SourceNode = new NodeId("source"),
-                    EventType = new UAObjectType(new NodeId("type")),
+                    EmittingNode = new NodeId("emitter", 0),
+                    SourceNode = new NodeId("source", 0),
+                    EventType = new UAObjectType(new NodeId("type", 0)),
                     EventId = "someid"
                 },
                 new UAEvent
                 {
                     Time = time,
-                    EmittingNode = new NodeId("emitter"),
-                    SourceNode = new NodeId("missingsource"),
-                    EventType = new UAObjectType(new NodeId("type")),
+                    EmittingNode = new NodeId("emitter", 0),
+                    SourceNode = new NodeId("missingsource", 0),
+                    EventType = new UAObjectType(new NodeId("type", 0)),
                     EventId = "someid2"
                 }
             };
@@ -263,9 +263,9 @@ namespace Test.Unit
             events = events.Append(new UAEvent
             {
                 Time = time,
-                EmittingNode = new NodeId("emitter"),
-                SourceNode = new NodeId("source"),
-                EventType = new UAObjectType(new NodeId("type")),
+                EmittingNode = new NodeId("emitter", 0),
+                SourceNode = new NodeId("source", 0),
+                EventType = new UAObjectType(new NodeId("type", 0)),
                 EventId = "someid3"
             }).ToArray();
 
@@ -460,14 +460,14 @@ namespace Test.Unit
                 .GetValue(pusher);
 
             var nodeToAssetIds = writer.NodeToAssetIds;
-            nodeToAssetIds[new NodeId("parent")] = 123;
+            nodeToAssetIds[new NodeId("parent", 0)] = 123;
 
             var rels = Enumerable.Empty<UAReference>();
             var assets = Enumerable.Empty<BaseUANode>();
             var update = new UpdateConfig();
 
             // Test debug mode
-            var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent", 0), null);
             node.FullAttributes.DataType = dt;
             tester.Config.DryRun = true;
             Assert.True((await pusher.PushNodes(assets, new[] { node }, rels, update, tester.Source.Token)).Variables);
@@ -475,7 +475,7 @@ namespace Test.Unit
             Assert.Empty(handler.Timeseries);
 
             // Fail to create timeseries
-            node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent", 0), null);
             node.FullAttributes.DataType = dt;
             handler.FailedRoutes.Add("/timeseries");
             Assert.False((await pusher.PushNodes(assets, new[] { node }, rels, update, tester.Source.Token)).Variables);
@@ -501,7 +501,7 @@ namespace Test.Unit
             Assert.True((await pusher.PushNodes(assets, new[] { node }, rels, update, tester.Source.Token)).Variables);
 
             // Create one, fail to update the other
-            var node2 = new UAVariable(tester.Server.Ids.Custom.MysteryVar, "MysteryVar", null, null, new NodeId("parent"), null);
+            var node2 = new UAVariable(tester.Server.Ids.Custom.MysteryVar, "MysteryVar", null, null, new NodeId("parent", 0), null);
             node2.FullAttributes.DataType = dt;
             node.Attributes.Description = "description";
             Assert.False((await pusher.PushNodes(assets, new[] { node, node2 }, rels, update, tester.Source.Token)).Variables);
@@ -547,7 +547,7 @@ namespace Test.Unit
             var rels = Enumerable.Empty<UAReference>();
             var assets = Enumerable.Empty<BaseUANode>();
             var update = new UpdateConfig();
-            var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent", 0), null);
             node.FullAttributes.DataType = dt;
 
             // Fail to create
@@ -562,7 +562,7 @@ namespace Test.Unit
             Assert.Equal("Variable 1", handler.TimeseriesRaw.First().Value.GetProperty("name").GetString());
 
             // Create another, do not overwrite the existing one, due to no update settings
-            var node2 = new UAVariable(tester.Server.Ids.Custom.MysteryVar, "MysteryVar", null, null, new NodeId("parent"), null);
+            var node2 = new UAVariable(tester.Server.Ids.Custom.MysteryVar, "MysteryVar", null, null, new NodeId("parent", 0), null);
             node2.FullAttributes.DataType = dt;
             node.Attributes.Description = "description";
             Assert.True((await pusher.PushNodes(assets, new[] { node, node2 }, rels, update, tester.Source.Token)).RawVariables);
@@ -610,7 +610,7 @@ namespace Test.Unit
             update.Variables.Description = true;
             update.Variables.Metadata = true;
             update.Variables.Name = true;
-            var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent", 0), null);
             node.FullAttributes.DataType = dt;
 
             // Fail to upsert
@@ -625,7 +625,7 @@ namespace Test.Unit
             Assert.Equal("Variable 1", handler.TimeseriesRaw.First().Value.GetProperty("name").GetString());
 
             // Create another, overwrite the existing due to update settings
-            var node2 = new UAVariable(tester.Server.Ids.Custom.MysteryVar, "MysteryVar", null, null, new NodeId("parent"), null);
+            var node2 = new UAVariable(tester.Server.Ids.Custom.MysteryVar, "MysteryVar", null, null, new NodeId("parent", 0), null);
             node2.FullAttributes.DataType = dt;
             node.Attributes.Description = "description";
             Assert.True((await pusher.PushNodes(assets, new[] { node, node2 }, rels, update, tester.Source.Token)).Variables);
@@ -679,14 +679,14 @@ namespace Test.Unit
 
             var organizes = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes);
 
-            var source = new UAObject(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var target = new UAObject(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
-            var sourceVar = new UAVariable(new NodeId("source2"), "Source", "Source", null, NodeId.Null, null);
-            var targetVar = new UAVariable(new NodeId("target2"), "Target", "Target", null, NodeId.Null, null);
+            var source = new UAObject(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var target = new UAObject(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
+            var sourceVar = new UAVariable(new NodeId("source2", 0), "Source", "Source", null, NodeId.Null, null);
+            var targetVar = new UAVariable(new NodeId("target2", 0), "Target", "Target", null, NodeId.Null, null);
 
             // Create one of each.
             var node = new UAObject(tester.Server.Ids.Base.Root, "BaseRoot", null, null, NodeId.Null, null);
-            var variable = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            var variable = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent", 0), null);
             variable.FullAttributes.DataType = dt;
             var rel = new UAReference(organizes, true, source, target);
 
@@ -762,10 +762,10 @@ namespace Test.Unit
 
             var organizes = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes);
 
-            var source = new UAObject(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var target = new UAObject(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
-            var sourceVar = new UAVariable(new NodeId("source2"), "Source", "Source", null, NodeId.Null, null);
-            var targetVar = new UAVariable(new NodeId("target2"), "Target", "Target", null, NodeId.Null, null);
+            var source = new UAObject(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var target = new UAObject(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
+            var sourceVar = new UAVariable(new NodeId("source2", 0), "Source", "Source", null, NodeId.Null, null);
+            var targetVar = new UAVariable(new NodeId("target2", 0), "Target", "Target", null, NodeId.Null, null);
 
             (handler, pusher) = tester.GetCDFPusher();
             using var extractor = tester.BuildExtractor(true, null, pusher);
@@ -793,7 +793,7 @@ namespace Test.Unit
 
             // Create one of each.
             var node = new UAObject(tester.Server.Ids.Base.Root, "BaseRoot", null, null, NodeId.Null, null);
-            var variable = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            var variable = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent", 0), null);
             variable.FullAttributes.DataType = dt;
             var rel = new UAReference(organizes, true, source, targetVar);
 
@@ -964,10 +964,10 @@ namespace Test.Unit
 
             var organizes = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes);
 
-            var source = new UAObject(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var target = new UAObject(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
-            var sourceVar = new UAVariable(new NodeId("source2"), "Source", "Source", null, NodeId.Null, null);
-            var targetVar = new UAVariable(new NodeId("target2"), "Target", "Target", null, NodeId.Null, null);
+            var source = new UAObject(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var target = new UAObject(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
+            var sourceVar = new UAVariable(new NodeId("source2", 0), "Source", "Source", null, NodeId.Null, null);
+            var targetVar = new UAVariable(new NodeId("target2", 0), "Target", "Target", null, NodeId.Null, null);
 
             (handler, pusher) = tester.GetCDFPusher();
             using var extractor = tester.BuildExtractor(true, null, pusher);
@@ -1041,10 +1041,10 @@ namespace Test.Unit
 
             var organizes = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes);
 
-            var source = new UAObject(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var target = new UAObject(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
-            var sourceVar = new UAVariable(new NodeId("source2"), "Source", "Source", null, NodeId.Null, null);
-            var targetVar = new UAVariable(new NodeId("target2"), "Target", "Target", null, NodeId.Null, null);
+            var source = new UAObject(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var target = new UAObject(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
+            var sourceVar = new UAVariable(new NodeId("source2", 0), "Source", "Source", null, NodeId.Null, null);
+            var targetVar = new UAVariable(new NodeId("target2", 0), "Target", "Target", null, NodeId.Null, null);
 
             tester.Config.Extraction.Relationships.Enabled = true;
             (handler, pusher) = tester.GetCDFPusher();
@@ -1156,20 +1156,20 @@ namespace Test.Unit
 
             // Datapoints
             // Not a variable
-            var node = new UAObject(new NodeId("test"), "test", null, null, NodeId.Null, null);
+            var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             NodeToRaw(extractor, node, ConverterType.Node, false);
             // Normal double
-            var variable = new UAVariable(new NodeId("test2"), "test2", null, null, NodeId.Null, null);
+            var variable = new UAVariable(new NodeId("test2", 0), "test2", null, null, NodeId.Null, null);
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             variable.FullAttributes.ValueRank = -1;
             NodeToRaw(extractor, variable, ConverterType.Variable, true);
             // Normal string
-            variable = new UAVariable(new NodeId("test3"), "test3", null, null, NodeId.Null, null);
+            variable = new UAVariable(new NodeId("test3", 0), "test3", null, null, NodeId.Null, null);
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.String);
             variable.FullAttributes.ValueRank = -1;
             NodeToRaw(extractor, variable, ConverterType.Variable, true);
             // Array
-            variable = new UAVariable(new NodeId("test4"), "test4", null, null, NodeId.Null, null);
+            variable = new UAVariable(new NodeId("test4", 0), "test4", null, null, NodeId.Null, null);
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             variable.FullAttributes.ValueRank = 1;
             variable.FullAttributes.ArrayDimensions = new[] { 4 };
@@ -1215,11 +1215,11 @@ namespace Test.Unit
             Assert.Empty(extractor.State.EmitterStates);
 
             // Add a couple emitters
-            node = new UAObject(new NodeId("test5"), "test5", null, null, NodeId.Null, null);
+            node = new UAObject(new NodeId("test5", 0), "test5", null, null, NodeId.Null, null);
             node.FullAttributes.EventNotifier = EventNotifiers.HistoryRead | EventNotifiers.SubscribeToEvents;
             NodeToRaw(extractor, node, ConverterType.Node, false);
 
-            variable = new UAVariable(new NodeId("test6"), "test6", null, null, NodeId.Null, null);
+            variable = new UAVariable(new NodeId("test6", 0), "test6", null, null, NodeId.Null, null);
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.String);
             variable.FullAttributes.ValueRank = -1;
             NodeToRaw(extractor, variable, ConverterType.Variable, true);
@@ -1472,7 +1472,7 @@ namespace Test.Unit
             var update = new UpdateConfig();
             var dt = new UADataType(DataTypeIds.Double);
             var node = new UAObject(tester.Server.Ids.Base.Root, "BaseRoot", null, null, NodeId.Null, null);
-            var variable = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            var variable = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent", 0), null);
             variable.FullAttributes.DataType = dt;
             var rel = new UAReference(extractor.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes), true, node, variable);
 

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -1272,9 +1272,9 @@ namespace Test.Unit
             tester.Config.Cognite.RawNodeBuffer.BrowseOnEmpty = true;
             await extractor.RunExtractor(true);
             Assert.True(extractor.State.NodeStates.Any());
-            Assert.True(handler.AssetsRaw.Any());
-            Assert.True(handler.TimeseriesRaw.Any());
-            Assert.True(handler.Timeseries.Any());
+            Assert.True(handler.AssetsRaw.Count != 0);
+            Assert.True(handler.TimeseriesRaw.Count != 0);
+            Assert.True(handler.Timeseries.Count != 0);
             Assert.Empty(handler.Assets);
 
             await extractor.WaitForSubscriptions();
@@ -1307,7 +1307,7 @@ namespace Test.Unit
             await TestUtils.WaitForCondition(async () =>
             {
                 await extractor.Streamer.PushDataPoints(new[] { pusher }, Enumerable.Empty<IPusher>(), tester.Source.Token);
-                return handler.Datapoints.ContainsKey(id) && handler.Datapoints[id].NumericDatapoints.Any();
+                return handler.Datapoints.ContainsKey(id) && handler.Datapoints[id].NumericDatapoints.Count != 0;
             }, 10);
 
             Assert.True(extractor.State.NodeStates.Where(state => state.FrontfillEnabled).Any());
@@ -1350,9 +1350,9 @@ namespace Test.Unit
             tester.Config.Cognite.RawNodeBuffer.BrowseOnEmpty = true;
             await extractor.RunExtractor(true);
             Assert.True(extractor.State.NodeStates.Any());
-            Assert.True(handler.AssetsRaw.Any());
-            Assert.True(handler.TimeseriesRaw.Any());
-            Assert.True(handler.Timeseries.Any());
+            Assert.True(handler.AssetsRaw.Count != 0);
+            Assert.True(handler.TimeseriesRaw.Count != 0);
+            Assert.True(handler.Timeseries.Count != 0);
             Assert.Empty(handler.Assets);
 
             await extractor.WaitForSubscriptions();
@@ -1384,7 +1384,7 @@ namespace Test.Unit
             await TestUtils.WaitForCondition(async () =>
             {
                 await extractor.Streamer.PushEvents(new[] { pusher }, Enumerable.Empty<IPusher>(), tester.Source.Token);
-                return handler.Events.Any();
+                return handler.Events.Count != 0;
             }, 10);
 
             tester.WipeEventHistory();
@@ -1424,9 +1424,9 @@ namespace Test.Unit
             tester.Config.Cognite.RawNodeBuffer.BrowseOnEmpty = true;
             await extractor.RunExtractor(true);
             Assert.True(extractor.State.NodeStates.Any());
-            Assert.True(handler.AssetsRaw.Any());
-            Assert.True(handler.TimeseriesRaw.Any());
-            Assert.True(handler.Timeseries.Any());
+            Assert.True(handler.AssetsRaw.Count != 0);
+            Assert.True(handler.TimeseriesRaw.Count != 0);
+            Assert.True(handler.Timeseries.Count != 0);
             Assert.Empty(handler.Assets);
 
             await extractor.WaitForSubscriptions();

--- a/Test/Unit/ConfigToolTest.cs
+++ b/Test/Unit/ConfigToolTest.cs
@@ -56,10 +56,14 @@ namespace Test.Unit
 
         public async Task DisposeAsync()
         {
-            Source?.Cancel();
+            if (Source != null)
+            {
+                await Source.CancelAsync();
+                Source.Dispose();
+                Source = null;
+            }
             await Explorer?.Close(CancellationToken.None);
             Explorer?.Dispose();
-            Source?.Dispose();
             Server?.Stop();
             Server?.Dispose();
 

--- a/Test/Unit/DeleteTest.cs
+++ b/Test/Unit/DeleteTest.cs
@@ -116,17 +116,17 @@ namespace Test.Unit
 
         private static UAObject GetObject(string id)
         {
-            return new UAObject(new NodeId(id), id, null, null, NodeId.Null, null);
+            return new UAObject(new NodeId(id, 0), id, null, null, NodeId.Null, null);
         }
 
         private static UAVariable GetVariable(string id)
         {
-            return new UAVariable(new NodeId(id), id, null, null, NodeId.Null, null);
+            return new UAVariable(new NodeId(id, 0), id, null, null, NodeId.Null, null);
         }
 
         private static UAReference GetReference(BaseUANode source, BaseUANode target, TypeManager manager)
         {
-            return new UAReference(manager.GetReferenceType(new NodeId("type")),
+            return new UAReference(manager.GetReferenceType(new NodeId("type", 0)),
                 true, source, target);
         }
 
@@ -258,10 +258,10 @@ namespace Test.Unit
         {
             // Create some test data
             var root = new NodeId(1);
-            var nodes = Enumerable.Range(1, count).Select(i => new UAObject(new NodeId($"object{i}"), $"object{i}", null, null, root, null)).ToList();
+            var nodes = Enumerable.Range(1, count).Select(i => new UAObject(new NodeId($"object{i}", 0), $"object{i}", null, null, root, null)).ToList();
             var variables = Enumerable.Range(1, count).Select(i =>
             {
-                var v = new UAVariable(new NodeId($"var{i}"), $"var{i}", null, null, root, null);
+                var v = new UAVariable(new NodeId($"var{i}", 0), $"var{i}", null, null, root, null);
                 if (i % 2 == 0)
                 {
                     v.FullAttributes.ShouldReadHistoryOverride = true;

--- a/Test/Unit/ExtractorUtilsTest.cs
+++ b/Test/Unit/ExtractorUtilsTest.cs
@@ -31,19 +31,19 @@ namespace Test.Unit
             // Null
             Assert.Throws<ArgumentNullException>(() => ExtractorUtils.SortNodes(null));
 
-            var arrParent = new UAVariable(new NodeId("arr1"), "arr1", null, null, NodeId.Null, null);
+            var arrParent = new UAVariable(new NodeId("arr1", 0), "arr1", null, null, NodeId.Null, null);
             arrParent.FullAttributes.ValueRank = 1;
             arrParent.FullAttributes.ArrayDimensions = new[] { 2 };
             var children = arrParent.CreateTimeseries();
             // Populated
             var nodes = new BaseUANode[]
             {
-                new UAObject(new NodeId("object1"), "obj1", null, null, NodeId.Null, null),
-                new UAObject(new NodeId("object2"), "obj2", null, null, NodeId.Null, null),
-                new UAVariable(new NodeId("var1"), "var1", null, null, NodeId.Null, null),
-                new UAVariable(new NodeId("var2"), "var2", null, null, NodeId.Null, null),
+                new UAObject(new NodeId("object1", 0), "obj1", null, null, NodeId.Null, null),
+                new UAObject(new NodeId("object2", 0), "obj2", null, null, NodeId.Null, null),
+                new UAVariable(new NodeId("var1", 0), "var1", null, null, NodeId.Null, null),
+                new UAVariable(new NodeId("var2", 0), "var2", null, null, NodeId.Null, null),
                 arrParent,
-                new UAVariable(new NodeId("arr2"), "arr2", null, null, NodeId.Null, null)
+                new UAVariable(new NodeId("arr2", 0), "arr2", null, null, NodeId.Null, null)
             };
             (nodes[5].Attributes as Cognite.OpcUa.Nodes.VariableAttributes).ValueRank = 1;
             (nodes[5].Attributes as Cognite.OpcUa.Nodes.VariableAttributes).ArrayDimensions = new[] { 2 };

--- a/Test/Unit/FailureBufferTest.cs
+++ b/Test/Unit/FailureBufferTest.cs
@@ -131,9 +131,9 @@ namespace Test.Unit
 
             var nodeInfluxStates = nodeStates.Select(state => new InfluxBufferState(state)).ToList();
 
-            var estate1 = new EventExtractionState(extractor, new NodeId("emitter1"), false, false, true);
-            var estate2 = new EventExtractionState(extractor, new NodeId("emitter2"), false, false, true);
-            var estate3 = new EventExtractionState(extractor, new NodeId("emitter3"), true, true, true);
+            var estate1 = new EventExtractionState(extractor, new NodeId("emitter1", 0), false, false, true);
+            var estate2 = new EventExtractionState(extractor, new NodeId("emitter2", 0), false, false, true);
+            var estate3 = new EventExtractionState(extractor, new NodeId("emitter3", 0), true, true, true);
             var evtStates = new[] { estate1, estate2, estate3 };
 
             var evtInfluxStates = evtStates.Select(state => new InfluxBufferState(state)).ToList();
@@ -285,9 +285,9 @@ namespace Test.Unit
             using var pusher = new InfluxPusher(iflog, tester.Config);
             var fb1 = new FailureBuffer(log, cfg, extractor, pusher);
 
-            var estate1 = new EventExtractionState(extractor, new NodeId("emitter1"), false, false, true);
-            var estate2 = new EventExtractionState(extractor, new NodeId("emitter2"), false, false, true);
-            var estate3 = new EventExtractionState(extractor, new NodeId("emitter3"), true, true, true);
+            var estate1 = new EventExtractionState(extractor, new NodeId("emitter1", 0), false, false, true);
+            var estate2 = new EventExtractionState(extractor, new NodeId("emitter2", 0), false, false, true);
+            var estate3 = new EventExtractionState(extractor, new NodeId("emitter3", 0), true, true, true);
 
             extractor.State.SetEmitterState(estate1);
             extractor.State.SetEmitterState(estate2);
@@ -382,9 +382,9 @@ namespace Test.Unit
             state3.UpdateFromBackfill(DateTime.MaxValue, true);
             state3.UpdateFromFrontfill(DateTime.MinValue, true);
 
-            var dps1 = dPusher.DataPoints[(new NodeId("state1"), -1)] = new List<UADataPoint>();
-            var dps2 = dPusher.DataPoints[(new NodeId("state2"), -1)] = new List<UADataPoint>();
-            var dps3 = dPusher.DataPoints[(new NodeId("state3"), -1)] = new List<UADataPoint>();
+            var dps1 = dPusher.DataPoints[(new NodeId("state1", 0), -1)] = new List<UADataPoint>();
+            var dps2 = dPusher.DataPoints[(new NodeId("state2", 0), -1)] = new List<UADataPoint>();
+            var dps3 = dPusher.DataPoints[(new NodeId("state3", 0), -1)] = new List<UADataPoint>();
 
             // Just read, this happens on startup. We'd expect nothing to really happen here.
             Assert.False(fb1.AnyPoints);
@@ -469,9 +469,9 @@ namespace Test.Unit
             var log = tester.Provider.GetRequiredService<ILogger<FailureBuffer>>();
             var fb1 = new FailureBuffer(log, cfg, extractor, pusher);
 
-            var estate1 = new EventExtractionState(extractor, new NodeId("emitter1"), false, false, true);
-            var estate2 = new EventExtractionState(extractor, new NodeId("emitter2"), false, false, true);
-            var estate3 = new EventExtractionState(extractor, new NodeId("emitter3"), true, true, true);
+            var estate1 = new EventExtractionState(extractor, new NodeId("emitter1", 0), false, false, true);
+            var estate2 = new EventExtractionState(extractor, new NodeId("emitter2", 0), false, false, true);
+            var estate3 = new EventExtractionState(extractor, new NodeId("emitter3", 0), true, true, true);
 
             extractor.State.SetEmitterState(estate1);
             extractor.State.RegisterNode(estate1.SourceId, estate1.Id);
@@ -484,9 +484,9 @@ namespace Test.Unit
 
             var evts = GetEvents(start, estate1.SourceId, 100).Concat(GetEvents(start, estate3.SourceId, 100)).ToList();
 
-            var evts1 = dPusher.Events[new NodeId("emitter1")] = new List<UAEvent>();
-            var evts2 = dPusher.Events[new NodeId("emitter2")] = new List<UAEvent>();
-            var evts3 = dPusher.Events[new NodeId("emitter3")] = new List<UAEvent>();
+            var evts1 = dPusher.Events[new NodeId("emitter1", 0)] = new List<UAEvent>();
+            var evts2 = dPusher.Events[new NodeId("emitter2", 0)] = new List<UAEvent>();
+            var evts3 = dPusher.Events[new NodeId("emitter3", 0)] = new List<UAEvent>();
 
             // Just read, this happens on startup. We'd expect nothing to really happen here.
             Assert.False(fb1.AnyPoints);
@@ -568,9 +568,9 @@ namespace Test.Unit
             extractor.State.SetNodeState(state2, "state2");
             extractor.State.SetNodeState(state3, "state3");
 
-            var dps1 = dPusher.DataPoints[(new NodeId("state1"), -1)] = new List<UADataPoint>();
-            var dps2 = dPusher.DataPoints[(new NodeId("state2"), -1)] = new List<UADataPoint>();
-            var dps3 = dPusher.DataPoints[(new NodeId("state3"), -1)] = new List<UADataPoint>();
+            var dps1 = dPusher.DataPoints[(new NodeId("state1", 0), -1)] = new List<UADataPoint>();
+            var dps2 = dPusher.DataPoints[(new NodeId("state2", 0), -1)] = new List<UADataPoint>();
+            var dps3 = dPusher.DataPoints[(new NodeId("state3", 0), -1)] = new List<UADataPoint>();
 
             foreach (var state in new[] { state1, state2, state3 })
             {
@@ -652,9 +652,9 @@ namespace Test.Unit
             var log = tester.Provider.GetRequiredService<ILogger<FailureBuffer>>();
             var fb1 = new FailureBuffer(log, cfg, extractor, null);
 
-            var estate1 = new EventExtractionState(extractor, new NodeId("emitter1"), false, false, true);
-            var estate2 = new EventExtractionState(extractor, new NodeId("emitter2"), false, false, true);
-            var estate3 = new EventExtractionState(extractor, new NodeId("emitter3"), true, true, true);
+            var estate1 = new EventExtractionState(extractor, new NodeId("emitter1", 0), false, false, true);
+            var estate2 = new EventExtractionState(extractor, new NodeId("emitter2", 0), false, false, true);
+            var estate3 = new EventExtractionState(extractor, new NodeId("emitter3", 0), true, true, true);
 
             extractor.State.SetEmitterState(estate1);
             extractor.State.RegisterNode(estate1.SourceId, estate1.Id);
@@ -667,13 +667,13 @@ namespace Test.Unit
 
             var evts = GetEvents(start, estate1.SourceId, 100)
                 .Concat(GetEvents(start, estate2.SourceId, 100))
-                .Concat(GetEvents(start, new NodeId("somemissingemitter"), 100))
+                .Concat(GetEvents(start, new NodeId("somemissingemitter", 0), 100))
                 .Concat(GetEvents(start, estate3.SourceId, 100)).ToList();
 
-            var evts1 = dPusher.Events[new NodeId("emitter1")] = new List<UAEvent>();
-            var evts2 = dPusher.Events[new NodeId("emitter2")] = new List<UAEvent>();
-            var evts3 = dPusher.Events[new NodeId("emitter3")] = new List<UAEvent>();
-            var evts4 = dPusher.Events[new NodeId("somemissingemitter")] = new List<UAEvent>();
+            var evts1 = dPusher.Events[new NodeId("emitter1", 0)] = new List<UAEvent>();
+            var evts2 = dPusher.Events[new NodeId("emitter2", 0)] = new List<UAEvent>();
+            var evts3 = dPusher.Events[new NodeId("emitter3", 0)] = new List<UAEvent>();
+            var evts4 = dPusher.Events[new NodeId("somemissingemitter", 0)] = new List<UAEvent>();
 
             Assert.Equal(0, new FileInfo(cfg.FailureBuffer.EventPath).Length);
 

--- a/Test/Unit/HistoryConsistencyTest.cs
+++ b/Test/Unit/HistoryConsistencyTest.cs
@@ -81,7 +81,7 @@ namespace Test.Unit
         private readonly HistoryConsistencyTestFixture tester;
         public HistoryConsistencyTest(ITestOutputHelper output, HistoryConsistencyTestFixture tester)
         {
-            if (tester == null) throw new ArgumentNullException(nameof(tester));
+            ArgumentNullException.ThrowIfNull(tester);
             this.tester = tester;
             tester.ResetConfig();
             tester.Init(output);

--- a/Test/Unit/HistoryReaderTest.cs
+++ b/Test/Unit/HistoryReaderTest.cs
@@ -59,7 +59,7 @@ namespace Test.Unit
             using var throttler = new TaskThrottler(2, false);
             var cps = new BlockingResourceCounter(1000);
 
-            var dummyState = new UAHistoryExtractionState(tester.Client, new NodeId("test"), true, true);
+            var dummyState = new UAHistoryExtractionState(tester.Client, new NodeId("test", 0), true, true);
 
             var log = tester.Provider.GetRequiredService<ILogger<HistoryReaderTest>>();
 
@@ -70,7 +70,7 @@ namespace Test.Unit
 
             var dt = new UADataType(DataTypeIds.Double);
 
-            var var1 = new UAVariable(new NodeId("state1"), "state1", null, null, NodeId.Null, null);
+            var var1 = new UAVariable(new NodeId("state1", 0), "state1", null, null, NodeId.Null, null);
             var1.FullAttributes.DataType = dt;
             var state1 = new VariableExtractionState(extractor, var1, true, true, true);
             extractor.State.SetNodeState(state1, "state1");
@@ -84,7 +84,7 @@ namespace Test.Unit
             var historyDataHandler = reader.GetType().GetMethod("HistoryDataHandler", BindingFlags.NonPublic | BindingFlags.Instance);
 
             // Test null historyData
-            var node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1")) { Completed = true };
+            var node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1", 0)) { Completed = true };
             historyDataHandler.Invoke(reader, new object[] { node });
             Assert.Equal(0, node.TotalRead);
 
@@ -99,7 +99,7 @@ namespace Test.Unit
 
             historyData.DataValues = frontfillDataValues;
 
-            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("badstate")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("badstate", 0)) { Completed = true };
             node.LastResult = historyData;
             historyDataHandler.Invoke(reader, new object[] { node });
             Assert.Equal(0, node.TotalRead);
@@ -107,7 +107,7 @@ namespace Test.Unit
             state1.RestartHistory();
 
             // Test frontfill OK
-            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1", 0)) { Completed = true };
             node.LastResult = historyData;
             historyDataHandler.Invoke(reader, new object[] { node });
             Assert.Equal(100, node.TotalRead);
@@ -120,7 +120,7 @@ namespace Test.Unit
                 .Select(idx => new DataValue(idx, StatusCodes.Good, start.AddSeconds(-idx))));
             historyData.DataValues = backfillDataValues;
             Assert.True(state1.IsBackfilling);
-            node = new HistoryReadNode(HistoryReadType.BackfillData, new NodeId("state1")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.BackfillData, new NodeId("state1", 0)) { Completed = true };
             node.LastResult = historyData;
             historyDataHandler.Invoke(backfillReader, new object[] { node });
             Assert.Equal(100, node.TotalRead);
@@ -135,7 +135,7 @@ namespace Test.Unit
             historyData.DataValues = badDps;
             state1.RestartHistory();
             queue.Clear();
-            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1")) { Completed = false };
+            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1", 0)) { Completed = false };
             node.LastResult = historyData;
             historyDataHandler.Invoke(reader, new object[] { node });
             Assert.Equal(100, node.TotalRead);
@@ -151,7 +151,7 @@ namespace Test.Unit
             // Get a datapoint from stream that happened after the last history point was read from the server, but arrived
             // at the extractor before the history data was parsed. This is an edge-case, but a potential lost datapoint 
             state1.UpdateFromStream(new[] { new UADataPoint(start.AddSeconds(100), "state1", 1.0) });
-            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1", 0)) { Completed = true };
             node.LastResult = historyData;
             historyDataHandler.Invoke(reader, new object[] { node });
             Assert.Equal(100, node.TotalRead);
@@ -164,7 +164,7 @@ namespace Test.Unit
             state1.RestartHistory();
             queue.Clear();
             cfg.IgnoreContinuationPoints = true;
-            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1", 0)) { Completed = true };
             node.LastResult = historyData;
             historyDataHandler.Invoke(reader, new object[] { node });
             Assert.Equal(100, node.TotalRead);
@@ -173,7 +173,7 @@ namespace Test.Unit
             Assert.Equal(start.AddSeconds(99), state1.SourceExtractedRange.Last);
 
             historyData.DataValues = null;
-            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1")) { Completed = false };
+            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1", 0)) { Completed = false };
             node.LastResult = historyData;
             historyDataHandler.Invoke(reader, new object[] { node });
             Assert.Equal(0, node.TotalRead);
@@ -193,7 +193,7 @@ namespace Test.Unit
             using var throttler = new TaskThrottler(2, false);
             var cps = new BlockingResourceCounter(1000);
 
-            var dummyState = new UAHistoryExtractionState(tester.Client, new NodeId("test"), true, true);
+            var dummyState = new UAHistoryExtractionState(tester.Client, new NodeId("test", 0), true, true);
 
             using var reader = new HistoryScheduler(log, tester.Client, extractor, extractor.TypeManager, cfg, HistoryReadType.FrontfillEvents,
                 throttler, cps, new[] { dummyState }, tester.Source.Token);
@@ -215,7 +215,7 @@ namespace Test.Unit
 
             // Test null historydata
             details.Filter = filter;
-            var node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter")) { Completed = true };
+            var node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter", 0)) { Completed = true };
             historyEventHandler.Invoke(reader, new object[] { node, details });
             Assert.Equal(0, node.TotalRead);
             Assert.False(state.IsFrontfilling);
@@ -227,20 +227,20 @@ namespace Test.Unit
                 .Select(idx => EventUtils.GetEventValues(start.AddSeconds(idx)))
                 .Select(values => new HistoryEventFieldList { EventFields = values }));
             var historyEvents = new HistoryEvent { Events = frontfillEvents };
-            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter", 0)) { Completed = true };
             node.LastResult = historyEvents;
             historyEventHandler.Invoke(reader, new object[] { node, null });
             Assert.Equal(0, node.TotalRead);
 
             // Test bad emitter
             historyEvents.Events = frontfillEvents;
-            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("bademitter")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("bademitter", 0)) { Completed = true };
             node.LastResult = historyEvents;
             historyEventHandler.Invoke(reader, new object[] { node, details });
             Assert.Equal(0, node.TotalRead);
 
             // Test frontfill OK
-            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter", 0)) { Completed = true };
             node.LastResult = historyEvents;
             historyEventHandler.Invoke(reader, new object[] { node, details });
             Assert.Equal(100, node.TotalRead);
@@ -254,7 +254,7 @@ namespace Test.Unit
                 .Select(values => new HistoryEventFieldList { EventFields = values }));
             historyEvents.Events = backfillEvents;
             Assert.True(state.IsBackfilling);
-            node = new HistoryReadNode(HistoryReadType.BackfillEvents, new NodeId("emitter")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.BackfillEvents, new NodeId("emitter", 0)) { Completed = true };
             node.LastResult = historyEvents;
             historyEventHandler.Invoke(backfillReader, new object[] { node, details });
             Assert.Equal(100, node.TotalRead);
@@ -276,7 +276,7 @@ namespace Test.Unit
             historyEvents.Events = badEvts;
             state.RestartHistory();
             queue.Clear();
-            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter")) { Completed = false };
+            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter", 0)) { Completed = false };
             node.LastResult = historyEvents;
             historyEventHandler.Invoke(reader, new object[] { node, details });
             Assert.Equal(0, node.TotalRead);
@@ -290,7 +290,7 @@ namespace Test.Unit
             state.RestartHistory();
             queue.Clear();
             state.UpdateFromStream(new UAEvent { Time = start.AddSeconds(100) });
-            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter", 0)) { Completed = true };
             node.LastResult = historyEvents;
             historyEventHandler.Invoke(reader, new object[] { node, details });
             Assert.Equal(100, node.TotalRead);
@@ -303,7 +303,7 @@ namespace Test.Unit
             state.RestartHistory();
             queue.Clear();
             cfg.IgnoreContinuationPoints = true;
-            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter")) { Completed = true };
+            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter", 0)) { Completed = true };
             node.LastResult = historyEvents;
             historyEventHandler.Invoke(reader, new object[] { node, details });
             Assert.Equal(100, node.TotalRead);
@@ -312,7 +312,7 @@ namespace Test.Unit
             Assert.Equal(start.AddSeconds(99), state.SourceExtractedRange.Last);
 
             historyEvents.Events = null;
-            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter")) { Completed = false };
+            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter", 0)) { Completed = false };
             node.LastResult = historyEvents;
             historyEventHandler.Invoke(reader, new object[] { node, details });
             Assert.Equal(0, node.TotalRead);

--- a/Test/Unit/InfluxPusherTest.cs
+++ b/Test/Unit/InfluxPusherTest.cs
@@ -202,11 +202,11 @@ namespace Test.Unit
                 "opcua_events_pushed_influx", "opcua_event_pushes_influx",
                 "opcua_skipped_events_influx");
 
-            var state = new EventExtractionState(tester.Client, new NodeId("emitter"), true, true, true);
+            var state = new EventExtractionState(tester.Client, new NodeId("emitter", 0), true, true, true);
             extractor.State.SetEmitterState(state);
-            extractor.State.RegisterNode(new NodeId("source"), extractor.GetUniqueId(new NodeId("source")));
-            extractor.State.RegisterNode(new NodeId("emitter"), extractor.GetUniqueId(new NodeId("emitter")));
-            extractor.State.RegisterNode(new NodeId("type"), extractor.GetUniqueId(new NodeId("type")));
+            extractor.State.RegisterNode(new NodeId("source", 0), extractor.GetUniqueId(new NodeId("source", 0)));
+            extractor.State.RegisterNode(new NodeId("emitter", 0), extractor.GetUniqueId(new NodeId("emitter", 0)));
+            extractor.State.RegisterNode(new NodeId("type", 0), extractor.GetUniqueId(new NodeId("type", 0)));
 
             Assert.Null(await pusher.PushEvents(null, tester.Source.Token));
             var invalidEvents = new[]
@@ -223,7 +223,7 @@ namespace Test.Unit
             Assert.Null(await pusher.PushEvents(invalidEvents, tester.Source.Token));
             Assert.True(CommonTestUtils.TestMetricValue("opcua_skipped_events_influx", 2));
 
-            var eventType = new UAObjectType(new NodeId("type"));
+            var eventType = new UAObjectType(new NodeId("type", 0));
             extractor.State.ActiveEvents[eventType.Id] = eventType;
 
             var time = DateTime.UtcNow;
@@ -233,8 +233,8 @@ namespace Test.Unit
                 new UAEvent
                 {
                     Time = time,
-                    EmittingNode = new NodeId("emitter"),
-                    SourceNode = new NodeId("source"),
+                    EmittingNode = new NodeId("emitter", 0),
+                    SourceNode = new NodeId("source", 0),
                     EventType = eventType,
                     EventId = "someid",
                     MetaData = new Dictionary<string, string>
@@ -246,8 +246,8 @@ namespace Test.Unit
                 new UAEvent
                 {
                     Time = time.AddSeconds(1),
-                    EmittingNode = new NodeId("emitter"),
-                    SourceNode = new NodeId("source"),
+                    EmittingNode = new NodeId("emitter", 0),
+                    SourceNode = new NodeId("source", 0),
                     EventType = eventType,
                     EventId = "someid2",
                     MetaData = new Dictionary<string, string>
@@ -271,7 +271,7 @@ namespace Test.Unit
             pusher.Reconfigure();
 
             Assert.True(await pusher.PushEvents(events, tester.Source.Token));
-            var ifEvents = await GetAllEvents(pusher, extractor, new NodeId("emitter"));
+            var ifEvents = await GetAllEvents(pusher, extractor, new NodeId("emitter", 0));
             Assert.Equal(2, ifEvents.Count());
             var eventsById = events.ToDictionary(evt => evt.EventId);
 
@@ -293,14 +293,14 @@ namespace Test.Unit
             events = events.Append(new UAEvent
             {
                 Time = time,
-                EmittingNode = new NodeId("emitter"),
-                SourceNode = new NodeId("source"),
-                EventType = new UAObjectType(new NodeId("type")),
+                EmittingNode = new NodeId("emitter", 0),
+                SourceNode = new NodeId("source", 0),
+                EventType = new UAObjectType(new NodeId("type", 0)),
                 EventId = "someid3"
             }).ToArray();
 
             Assert.True(await pusher.PushEvents(events, tester.Source.Token));
-            ifEvents = await GetAllEvents(pusher, extractor, new NodeId("emitter"));
+            ifEvents = await GetAllEvents(pusher, extractor, new NodeId("emitter", 0));
             Assert.Equal(3, ifEvents.Count());
             Assert.True(CommonTestUtils.TestMetricValue("opcua_event_pushes_influx", 2));
             Assert.True(CommonTestUtils.TestMetricValue("opcua_events_pushed_influx", 5));
@@ -405,18 +405,18 @@ namespace Test.Unit
 
             EventExtractionState[] GetStates()
             {
-                var state = new EventExtractionState(tester.Client, new NodeId("emitter"), true, true, true);
-                var state2 = new EventExtractionState(tester.Client, new NodeId("emitter2"), true, true, true);
+                var state = new EventExtractionState(tester.Client, new NodeId("emitter", 0), true, true, true);
+                var state2 = new EventExtractionState(tester.Client, new NodeId("emitter2", 0), true, true, true);
                 extractor.State.SetEmitterState(state);
                 extractor.State.SetEmitterState(state2);
                 return new[] { state, state2 };
             }
 
-            extractor.State.RegisterNode(new NodeId("source"), extractor.GetUniqueId(new NodeId("source")));
-            extractor.State.RegisterNode(new NodeId("emitter"), extractor.GetUniqueId(new NodeId("emitter")));
-            extractor.State.RegisterNode(new NodeId("emitter2"), extractor.GetUniqueId(new NodeId("emitter2")));
-            extractor.State.RegisterNode(new NodeId("type"), extractor.GetUniqueId(new NodeId("type")));
-            extractor.State.RegisterNode(new NodeId("type2"), extractor.GetUniqueId(new NodeId("type2")));
+            extractor.State.RegisterNode(new NodeId("source", 0), extractor.GetUniqueId(new NodeId("source", 0)));
+            extractor.State.RegisterNode(new NodeId("emitter", 0), extractor.GetUniqueId(new NodeId("emitter", 0)));
+            extractor.State.RegisterNode(new NodeId("emitter2", 0), extractor.GetUniqueId(new NodeId("emitter2", 0)));
+            extractor.State.RegisterNode(new NodeId("type", 0), extractor.GetUniqueId(new NodeId("type", 0)));
+            extractor.State.RegisterNode(new NodeId("type2", 0), extractor.GetUniqueId(new NodeId("type2", 0)));
 
             var states = GetStates();
 
@@ -446,29 +446,29 @@ namespace Test.Unit
                 new UAEvent
                 {
                     Time = GetTs(1000),
-                    EmittingNode = new NodeId("emitter"),
-                    EventType = new UAObjectType (new NodeId("type")),
+                    EmittingNode = new NodeId("emitter", 0),
+                    EventType = new UAObjectType (new NodeId("type", 0)),
                     EventId = "someid"
                 },
                 new UAEvent
                 {
                     Time = GetTs(3000),
-                    EmittingNode = new NodeId("emitter"),
-                    EventType = new UAObjectType(new NodeId("type2")),
+                    EmittingNode = new NodeId("emitter", 0),
+                    EventType = new UAObjectType(new NodeId("type2", 0)),
                     EventId = "someid2"
                 },
                 new UAEvent
                 {
                     Time = GetTs(1000),
-                    EmittingNode = new NodeId("emitter2"),
-                    EventType = new UAObjectType (new NodeId("type")),
+                    EmittingNode = new NodeId("emitter2", 0),
+                    EventType = new UAObjectType (new NodeId("type", 0)),
                     EventId = "someid3"
                 },
                 new UAEvent
                 {
                     Time = GetTs(2000),
-                    EmittingNode = new NodeId("emitter2"),
-                    EventType = new UAObjectType (new NodeId("type")),
+                    EmittingNode = new NodeId("emitter2", 0),
+                    EventType = new UAObjectType (new NodeId("type", 0)),
                     EventId = "someid4"
                 }
             };

--- a/Test/Unit/LooperTest.cs
+++ b/Test/Unit/LooperTest.cs
@@ -103,13 +103,13 @@ namespace Test.Unit
 
         private void InitPusherLoopTest(UAExtractor extractor, params DummyPusher[] pushers)
         {
-            var evtState = new EventExtractionState(tester.Client, new NodeId("id"), false, false, true);
+            var evtState = new EventExtractionState(tester.Client, new NodeId("id", 0), false, false, true);
             evtState.InitToEmpty();
             evtState.FinalizeRangeInit();
             extractor.State.SetEmitterState(evtState);
 
             var dpState = new VariableExtractionState(tester.Client,
-                new UAVariable(new NodeId("id"), "test", null, null, NodeId.Null, null),
+                new UAVariable(new NodeId("id", 0), "test", null, null, NodeId.Null, null),
                 false, false, true);
             dpState.InitToEmpty();
             dpState.FinalizeRangeInit();
@@ -119,7 +119,7 @@ namespace Test.Unit
 
             foreach (var pusher in pushers)
             {
-                pusher.UniqueToNodeId["id"] = (new NodeId("id"), -1);
+                pusher.UniqueToNodeId["id"] = (new NodeId("id", 0), -1);
             }
         }
 
@@ -134,7 +134,7 @@ namespace Test.Unit
 
             var dps = Enumerable.Range(0, 100).Select(idx => new UADataPoint(start.AddMilliseconds(idx), "id", idx));
             var evts = Enumerable.Range(0, 100).Select(idx =>
-                new UAEvent { EmittingNode = new NodeId("id"), Time = start.AddMilliseconds(idx) });
+                new UAEvent { EmittingNode = new NodeId("id", 0), Time = start.AddMilliseconds(idx) });
 
             InitPusherLoopTest(extractor, pusher1, pusher2);
 
@@ -142,10 +142,10 @@ namespace Test.Unit
             pusher2.Initialized = true;
 
             // Test all OK
-            var dps1 = pusher1.DataPoints[(new NodeId("id"), -1)] = new List<UADataPoint>();
-            var dps2 = pusher2.DataPoints[(new NodeId("id"), -1)] = new List<UADataPoint>();
-            var evts1 = pusher1.Events[new NodeId("id")] = new List<UAEvent>();
-            var evts2 = pusher2.Events[new NodeId("id")] = new List<UAEvent>();
+            var dps1 = pusher1.DataPoints[(new NodeId("id", 0), -1)] = new List<UADataPoint>();
+            var dps2 = pusher2.DataPoints[(new NodeId("id", 0), -1)] = new List<UADataPoint>();
+            var evts1 = pusher1.Events[new NodeId("id", 0)] = new List<UAEvent>();
+            var evts2 = pusher2.Events[new NodeId("id", 0)] = new List<UAEvent>();
 
             tester.Config.Extraction.DataPushDelay = "100";
             extractor.Looper.Run();
@@ -230,7 +230,7 @@ namespace Test.Unit
 
             var dps = Enumerable.Range(0, 100).Select(idx => new UADataPoint(start.AddMilliseconds(idx), "id", idx));
             var evts = Enumerable.Range(0, 100).Select(idx =>
-                new UAEvent { EmittingNode = new NodeId("id"), Time = start.AddMilliseconds(idx) });
+                new UAEvent { EmittingNode = new NodeId("id", 0), Time = start.AddMilliseconds(idx) });
 
             InitPusherLoopTest(extractor, pusher1, pusher2, pusher3);
 
@@ -240,12 +240,12 @@ namespace Test.Unit
             pusher2.TestConnectionResult = false;
             pusher3.Initialized = true;
 
-            var dps1 = pusher1.DataPoints[(new NodeId("id"), -1)] = new List<UADataPoint>();
-            var dps2 = pusher2.DataPoints[(new NodeId("id"), -1)] = new List<UADataPoint>();
-            var dps3 = pusher3.DataPoints[(new NodeId("id"), -1)] = new List<UADataPoint>();
-            var evts1 = pusher1.Events[new NodeId("id")] = new List<UAEvent>();
-            var evts2 = pusher2.Events[new NodeId("id")] = new List<UAEvent>();
-            var evts3 = pusher3.Events[new NodeId("id")] = new List<UAEvent>();
+            var dps1 = pusher1.DataPoints[(new NodeId("id", 0), -1)] = new List<UADataPoint>();
+            var dps2 = pusher2.DataPoints[(new NodeId("id", 0), -1)] = new List<UADataPoint>();
+            var dps3 = pusher3.DataPoints[(new NodeId("id", 0), -1)] = new List<UADataPoint>();
+            var evts1 = pusher1.Events[new NodeId("id", 0)] = new List<UAEvent>();
+            var evts2 = pusher2.Events[new NodeId("id", 0)] = new List<UAEvent>();
+            var evts3 = pusher3.Events[new NodeId("id", 0)] = new List<UAEvent>();
 
             Assert.Empty(dps1);
             Assert.Empty(dps2);
@@ -277,8 +277,8 @@ namespace Test.Unit
             // Add some missing nodes to each of the pushers, and verify that they are pushed on recovery
             var refManager = extractor.TypeManager;
 
-            var objects = new[] { new UAObject(new NodeId("missing1"), "missing1", null, null, new NodeId("test"), null) };
-            var variables = new[] { new UAVariable(new NodeId("missing2"), "missing2", null, null, new NodeId("test"), null) };
+            var objects = new[] { new UAObject(new NodeId("missing1", 0), "missing1", null, null, new NodeId("test", 0), null) };
+            var variables = new[] { new UAVariable(new NodeId("missing2", 0), "missing2", null, null, new NodeId("test", 0), null) };
 
             var reference = new UAReference(
                 refManager.GetReferenceType(ReferenceTypeIds.Organizes),
@@ -286,7 +286,7 @@ namespace Test.Unit
                 objects[0],
                 variables[0]);
 
-            
+
             var input = new PusherInput(
                 objects,
                 variables,

--- a/Test/Unit/MQTTBridgeTests.cs
+++ b/Test/Unit/MQTTBridgeTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MQTTnet;
 using MQTTnet.Client;
-using MQTTnet.Client.Options;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -64,7 +63,7 @@ namespace Test.Unit
                     .Build();
                 client = new MqttFactory().CreateMqttClient();
                 baseBuilder = new MqttApplicationMessageBuilder()
-                    .WithAtLeastOnceQoS();
+                    .WithQualityOfServiceLevel(MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce);
                 client.ConnectAsync(options).Wait();
             }
 
@@ -147,7 +146,7 @@ namespace Test.Unit
                     Table = "assets",
                     Rows = assets.Select(asset => new RawRowCreateDto<AssetCreate> { Key = asset.ExternalId, Columns = asset })
                 };
-                var data = JsonSerializer.SerializeToUtf8Bytes(wrapper, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+                var data = JsonSerializer.SerializeToUtf8Bytes(wrapper, Oryx.Cognite.Common.jsonOptions);
 
                 var msg = baseBuilder
                     .WithPayload(data)
@@ -696,6 +695,7 @@ namespace Test.Unit
                     ExternalId = "test-event-9"
                 }
             };
+
             await tester.PublishAssets(assets);
             Assert.Equal(2, tester.Handler.Assets.Count);
             await tester.PublishEvents(roundOne);

--- a/Test/Unit/MQTTPusherTest.cs
+++ b/Test/Unit/MQTTPusherTest.cs
@@ -184,7 +184,7 @@ namespace Test.Unit
             Assert.Null(await pusher.PushEvents(invalidEvents, tester.Source.Token));
             Assert.True(CommonTestUtils.TestMetricValue("opcua_skipped_events_mqtt", 2));
 
-            handler.MockAsset(tester.Client.GetUniqueId(new NodeId("source")));
+            handler.MockAsset(tester.Client.GetUniqueId(new NodeId("source", 0)));
 
             var time = DateTime.UtcNow;
 
@@ -193,17 +193,17 @@ namespace Test.Unit
                 new UAEvent
                 {
                     Time = time,
-                    EmittingNode = new NodeId("emitter"),
-                    SourceNode = new NodeId("source"),
-                    EventType = new UAObjectType(new NodeId("type")),
+                    EmittingNode = new NodeId("emitter", 0),
+                    SourceNode = new NodeId("source", 0),
+                    EventType = new UAObjectType(new NodeId("type", 0)),
                     EventId = "someid"
                 },
                 new UAEvent
                 {
                     Time = time,
-                    EmittingNode = new NodeId("emitter"),
-                    SourceNode = new NodeId("missingsource"),
-                    EventType = new UAObjectType(new NodeId("type")),
+                    EmittingNode = new NodeId("emitter", 0),
+                    SourceNode = new NodeId("missingsource", 0),
+                    EventType = new UAObjectType(new NodeId("type", 0)),
                     EventId = "someid2"
                 }
             };
@@ -222,9 +222,9 @@ namespace Test.Unit
             events = events.Append(new UAEvent
             {
                 Time = time,
-                EmittingNode = new NodeId("emitter"),
-                SourceNode = new NodeId("source"),
-                EventType = new UAObjectType(new NodeId("type")),
+                EmittingNode = new NodeId("emitter", 0),
+                SourceNode = new NodeId("source", 0),
+                EventType = new UAObjectType(new NodeId("type", 0)),
                 EventId = "someid3"
             }).ToArray();
 
@@ -365,10 +365,10 @@ namespace Test.Unit
             var update = new UpdateConfig();
             var rels = Enumerable.Empty<UAReference>();
 
-            handler.MockAsset(tester.Client.GetUniqueId(new NodeId("parent")));
+            handler.MockAsset(tester.Client.GetUniqueId(new NodeId("parent", 0)));
 
             // Test debug mode
-            var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent", 0), null);
             node.FullAttributes.DataType = dt;
             tester.Config.DryRun = true;
             var waitTask = bridge.WaitForNextMessage(1);
@@ -401,7 +401,7 @@ namespace Test.Unit
             await waitTask;
 
             // Create new node
-            var node2 = new UAVariable(tester.Server.Ids.Custom.MysteryVar, "MysteryVar", null, null, new NodeId("parent"), null);
+            var node2 = new UAVariable(tester.Server.Ids.Custom.MysteryVar, "MysteryVar", null, null, new NodeId("parent", 0), null);
             node2.FullAttributes.DataType = dt;
             waitTask = bridge.WaitForNextMessage();
             Assert.True((await pusher.PushNodes(assets, new[] { node, node2 }, rels, update, tester.Source.Token)).Variables);
@@ -439,7 +439,7 @@ namespace Test.Unit
             var assets = Enumerable.Empty<BaseUANode>();
             var rels = Enumerable.Empty<UAReference>();
             var update = new UpdateConfig();
-            var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            var node = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent", 0), null);
             node.FullAttributes.DataType = dt;
 
             // Create one
@@ -450,7 +450,7 @@ namespace Test.Unit
             Assert.Equal("Variable 1", handler.TimeseriesRaw.First().Value.GetProperty("name").GetString());
 
             // Create another, do not overwrite the existing one, due to no update settings
-            var node2 = new UAVariable(tester.Server.Ids.Custom.MysteryVar, "MysteryVar", null, null, new NodeId("parent"), null);
+            var node2 = new UAVariable(tester.Server.Ids.Custom.MysteryVar, "MysteryVar", null, null, new NodeId("parent", 0), null);
             node2.FullAttributes.DataType = dt;
             node.Attributes.Description = "description";
             waitTask = bridge.WaitForNextMessage(topic: tester.Config.Mqtt.RawTopic);
@@ -488,10 +488,10 @@ namespace Test.Unit
 
             var organizes = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes);
 
-            var source = new UAObject(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var target = new UAObject(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
-            var sourceVar = new UAVariable(new NodeId("source2"), "Source", "Source", null, NodeId.Null, null);
-            var targetVar = new UAVariable(new NodeId("target2"), "Target", "Target", null, NodeId.Null, null);
+            var source = new UAObject(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var target = new UAObject(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
+            var sourceVar = new UAVariable(new NodeId("source2", 0), "Source", "Source", null, NodeId.Null, null);
+            var targetVar = new UAVariable(new NodeId("target2", 0), "Target", "Target", null, NodeId.Null, null);
 
             var assets = Enumerable.Empty<BaseUANode>();
             var tss = Enumerable.Empty<UAVariable>();
@@ -556,10 +556,10 @@ namespace Test.Unit
 
             var organizes = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes);
 
-            var source = new UAObject(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var target = new UAObject(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
-            var sourceVar = new UAVariable(new NodeId("source2"), "Source", "Source", null, NodeId.Null, null);
-            var targetVar = new UAVariable(new NodeId("target2"), "Target", "Target", null, NodeId.Null, null);
+            var source = new UAObject(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var target = new UAObject(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
+            var sourceVar = new UAVariable(new NodeId("source2", 0), "Source", "Source", null, NodeId.Null, null);
+            var targetVar = new UAVariable(new NodeId("target2", 0), "Target", "Target", null, NodeId.Null, null);
 
             tester.Config.Mqtt.RawMetadata = new RawMetadataConfig
             {
@@ -647,9 +647,9 @@ namespace Test.Unit
 
             var rels = Enumerable.Empty<UAReference>();
 
-            var ts = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent"), null);
+            var ts = new UAVariable(tester.Server.Ids.Base.DoubleVar1, "Variable 1", null, null, new NodeId("parent", 0), null);
             ts.FullAttributes.DataType = dt;
-            var ts2 = new UAVariable(tester.Server.Ids.Base.DoubleVar2, "Variable 2", null, null, new NodeId("parent"), null);
+            var ts2 = new UAVariable(tester.Server.Ids.Base.DoubleVar2, "Variable 2", null, null, new NodeId("parent", 0), null);
             ts2.FullAttributes.DataType = dt;
             var node = new UAObject(tester.Server.Ids.Base.Root, "BaseRoot", null, null, NodeId.Null, null);
             var node2 = new UAObject(tester.Server.Ids.Custom.Root, "BaseRoot", null, null, NodeId.Null, null);
@@ -690,10 +690,10 @@ namespace Test.Unit
 
             var organizes = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes);
 
-            var source = new UAObject(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var target = new UAObject(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
-            var sourceVar = new UAVariable(new NodeId("source2"), "Source", "Source", null, NodeId.Null, null);
-            var targetVar = new UAVariable(new NodeId("target2"), "Target", "Target", null, NodeId.Null, null);
+            var source = new UAObject(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var target = new UAObject(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
+            var sourceVar = new UAVariable(new NodeId("source2", 0), "Source", "Source", null, NodeId.Null, null);
+            var targetVar = new UAVariable(new NodeId("target2", 0), "Target", "Target", null, NodeId.Null, null);
 
             var stateStoreConfig = new StateStoreConfig
             {

--- a/Test/Unit/PubSubTests.cs
+++ b/Test/Unit/PubSubTests.cs
@@ -27,7 +27,7 @@ namespace Test.Unit
         private readonly PubSubTestFixture tester;
         public PubSubTests(ITestOutputHelper output, PubSubTestFixture tester)
         {
-            if (tester == null) throw new ArgumentNullException(nameof(tester));
+            ArgumentNullException.ThrowIfNull(tester);
             tester.Init(output);
             this.tester = tester;
             tester.Server.UpdateNode(tester.Ids.Base.DoubleVar1, 17);

--- a/Test/Unit/PusherUtilsTest.cs
+++ b/Test/Unit/PusherUtilsTest.cs
@@ -63,7 +63,7 @@ namespace Test.Unit
         public void TestGetTsUpdate()
         {
             using var extractor = tester.BuildExtractor();
-            var node = new UAVariable(new NodeId("test"), "test", null, null, new NodeId("parent"), null);
+            var node = new UAVariable(new NodeId("test", 0), "test", null, null, new NodeId("parent", 0), null);
             node.Attributes.Description = "description";
             node.Attributes.Properties = new List<BaseUANode>();
             node.FullAttributes.DataType = new UADataType(DataTypeIds.Boolean);
@@ -71,7 +71,7 @@ namespace Test.Unit
             var now = DateTime.UtcNow;
             for (int i = 1; i < 5; i++)
             {
-                var prop = new UAVariable(new NodeId($"prop{i}"), $"prop{i}", null, null, NodeId.Null, null);
+                var prop = new UAVariable(new NodeId($"prop{i}", 0), $"prop{i}", null, null, NodeId.Null, null);
                 prop.FullAttributes.DataType = pdt;
                 prop.FullAttributes.Value = new Variant($"value{i}");
                 node.Attributes.Properties.Add(prop);
@@ -93,8 +93,8 @@ namespace Test.Unit
             };
             var nodeToAssetIds = new Dictionary<NodeId, long>
             {
-                { new NodeId("parent"), 111 },
-                { new NodeId("parent2"), 222 }
+                { new NodeId("parent", 0), 111 },
+                { new NodeId("parent2", 0), 222 }
             };
 
             var update = new TypeUpdateConfig();
@@ -118,7 +118,7 @@ namespace Test.Unit
 
             // Update everything
             var oldProperties = node.Properties.ToList();
-            node = new UAVariable(new NodeId("test2"), "test2", null, null, new NodeId("parent2"), null);
+            node = new UAVariable(new NodeId("test2", 0), "test2", null, null, new NodeId("parent2", 0), null);
             node.Attributes.Description = "description2";
             node.Attributes.Properties = oldProperties;
             node.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
@@ -146,7 +146,7 @@ namespace Test.Unit
             Assert.Null(result.ExternalId);
 
             // Update with null values, and missing asset
-            node = new UAVariable(new NodeId("test3"), null, null, null, new NodeId("parent3"), null);
+            node = new UAVariable(new NodeId("test3", 0), null, null, null, new NodeId("parent3", 0), null);
             node.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             result = PusherUtils.GetTSUpdate(tester.Config, extractor, ts, node, update, nodeToAssetIds);
             Assert.Null(result.AssetId);
@@ -158,14 +158,14 @@ namespace Test.Unit
         public void TestGetAssetUpdate()
         {
             using var extractor = tester.BuildExtractor();
-            var node = new UAObject(new NodeId("test"), "test", null, null, new NodeId("parent"), null);
+            var node = new UAObject(new NodeId("test", 0), "test", null, null, new NodeId("parent", 0), null);
             node.Attributes.Description = "description";
             node.Attributes.Properties = new List<BaseUANode>();
             var pdt = new UADataType(DataTypeIds.String);
             var now = DateTime.UtcNow;
             for (int i = 1; i < 5; i++)
             {
-                var prop = new UAVariable(new NodeId($"prop{i}"), $"prop{i}", null, null, NodeId.Null, null);
+                var prop = new UAVariable(new NodeId($"prop{i}", 0), $"prop{i}", null, null, NodeId.Null, null);
                 prop.FullAttributes.DataType = pdt;
                 prop.FullAttributes.Value = new Variant($"value{i}");
                 node.FullAttributes.Properties.Add(prop);
@@ -206,7 +206,7 @@ namespace Test.Unit
 
             // Update everything
             var oldProperties = node.Properties.ToList();
-            node = new UAObject(new NodeId("test2"), "test2", null, null, new NodeId("parent2"), null);
+            node = new UAObject(new NodeId("test2", 0), "test2", null, null, new NodeId("parent2", 0), null);
             node.Attributes.Description = "description2";
             node.Attributes.Properties = oldProperties;
             oldProperties.RemoveAt(1);
@@ -232,7 +232,7 @@ namespace Test.Unit
             Assert.Equal("value-new", result.Metadata.Set["prop-new"]);
             Assert.Null(result.ExternalId);
 
-            node = new UAObject(new NodeId("test3"), null, null, null, NodeId.Null, null);
+            node = new UAObject(new NodeId("test3", 0), null, null, null, NodeId.Null, null);
             result = PusherUtils.GetAssetUpdate(tester.Config, asset, node, extractor, update);
             Assert.Null(result.ParentExternalId);
             Assert.Null(result.Description);
@@ -250,16 +250,16 @@ namespace Test.Unit
 
             var properties = new List<BaseUANode>
             {
-                new UAVariable(new NodeId("prop1"), "prop1", null, null, NodeId.Null, null),
-                new UAObject(new NodeId("prop2"), "prop2", null, null, NodeId.Null, null),
+                new UAVariable(new NodeId("prop1", 0), "prop1", null, null, NodeId.Null, null),
+                new UAObject(new NodeId("prop2", 0), "prop2", null, null, NodeId.Null, null),
             };
-            var deepProp = new UAVariable(new NodeId("prop3"), "prop3", null, null, NodeId.Null, null);
+            var deepProp = new UAVariable(new NodeId("prop3", 0), "prop3", null, null, NodeId.Null, null);
             properties[1].Attributes.AddProperty(deepProp);
             deepProp.FullAttributes.Value = new Variant("value3");
             (properties[0] as UAVariable).FullAttributes.Value = new Variant(new[] { 1, 2, 3, 4 });
 
             // Test create asset
-            var node = new UAObject(new NodeId("test"), "test", null, null, new NodeId("parent"), null);
+            var node = new UAObject(new NodeId("test", 0), "test", null, null, new NodeId("parent", 0), null);
             foreach (var prop in properties) node.Attributes.AddProperty(prop);
             var result = PusherUtils.CreateRawUpdate(log, tester.Client.StringConverter, node, null, ConverterType.Node);
             Assert.Equal(@"{""externalId"":""gp.base:s=test"",""name"":""test"",""description"":null,""metadata"":{""prop1"":[1,2,3,4]," +
@@ -275,8 +275,8 @@ namespace Test.Unit
             Assert.Equal(@"{""externalId"":""gp.base:s=test"",""name"":""test"",""description"":""desc"",""metadata"":{""prop1"":[1,2,3,4]," +
                 @"""prop2"":{""prop3"":""value3""}},""parentExternalId"":""gp.base:s=parent""}", result.ToString());
 
-            var variable = new UAVariable(new NodeId("test"), "test", null, null, new NodeId("parent"), null);
-            variable.FullAttributes.DataType = new UADataType(new NodeId("dt"));
+            var variable = new UAVariable(new NodeId("test", 0), "test", null, null, new NodeId("parent", 0), null);
+            variable.FullAttributes.DataType = new UADataType(new NodeId("dt", 0));
             variable.FullAttributes.Value = new Variant("test");
 
             foreach (var prop in properties) variable.Attributes.AddProperty(prop);

--- a/Test/Unit/PusherUtilsTest.cs
+++ b/Test/Unit/PusherUtilsTest.cs
@@ -24,7 +24,7 @@ namespace Test.Unit
         private readonly StaticServerTestFixture tester;
         public PusherUtilsTest(ITestOutputHelper output, StaticServerTestFixture tester)
         {
-            if (tester == null) throw new ArgumentNullException(nameof(tester));
+            ArgumentNullException.ThrowIfNull(tester);
             tester.ResetConfig();
             tester.Init(output);
             this.tester = tester;

--- a/Test/Unit/StreamerTest.cs
+++ b/Test/Unit/StreamerTest.cs
@@ -33,9 +33,9 @@ namespace Test.Unit
         {
             using var pusher = new DummyPusher(new DummyPusherConfig());
 
-            pusher.UniqueToNodeId["id"] = (new NodeId("id"), -1);
+            pusher.UniqueToNodeId["id"] = (new NodeId("id", 0), -1);
             var dps = new List<UADataPoint>();
-            pusher.DataPoints[(new NodeId("id"), -1)] = dps;
+            pusher.DataPoints[(new NodeId("id", 0), -1)] = dps;
             using var extractor = tester.BuildExtractor(pushers: pusher);
 
             using var evt = new ManualResetEvent(false);
@@ -56,7 +56,7 @@ namespace Test.Unit
             var start = DateTime.UtcNow;
 
             var state = new VariableExtractionState(tester.Client,
-                new UAVariable(new NodeId("id"), "test", null, null, NodeId.Null, null),
+                new UAVariable(new NodeId("id", 0), "test", null, null, NodeId.Null, null),
                 false, false, true);
             state.InitToEmpty();
             state.FinalizeRangeInit();
@@ -101,7 +101,7 @@ namespace Test.Unit
             using var pusher = new DummyPusher(new DummyPusherConfig());
             using var extractor = tester.BuildExtractor(pushers: pusher);
 
-            var id = new NodeId("id");
+            var id = new NodeId("id", 0);
 
             var queue = (Queue<UAEvent>)extractor.Streamer.GetType()
                 .GetField("eventQueue", BindingFlags.NonPublic | BindingFlags.Instance)
@@ -120,7 +120,7 @@ namespace Test.Unit
             extractor.Streamer.AllowEvents = true;
             var start = DateTime.UtcNow;
 
-            var state = new EventExtractionState(tester.Client, new NodeId("id"), false, false, true);
+            var state = new EventExtractionState(tester.Client, new NodeId("id", 0), false, false, true);
             state.InitToEmpty();
             state.FinalizeRangeInit();
             extractor.State.SetEmitterState(state);
@@ -169,13 +169,13 @@ namespace Test.Unit
             using var pusher = new DummyPusher(new DummyPusherConfig());
             using var pusher2 = new DummyPusher(new DummyPusherConfig());
 
-            pusher.UniqueToNodeId["id"] = (new NodeId("id"), -1);
+            pusher.UniqueToNodeId["id"] = (new NodeId("id", 0), -1);
             var dps = new List<UADataPoint>();
-            pusher.DataPoints[(new NodeId("id"), -1)] = dps;
+            pusher.DataPoints[(new NodeId("id", 0), -1)] = dps;
 
-            pusher2.UniqueToNodeId["id"] = (new NodeId("id"), -1);
+            pusher2.UniqueToNodeId["id"] = (new NodeId("id", 0), -1);
             var dps2 = new List<UADataPoint>();
-            pusher2.DataPoints[(new NodeId("id"), -1)] = dps2;
+            pusher2.DataPoints[(new NodeId("id", 0), -1)] = dps2;
 
             using var extractor = tester.BuildExtractor(true, null, pusher, pusher2);
 
@@ -183,7 +183,7 @@ namespace Test.Unit
             var start = DateTime.UtcNow;
 
             var state = new VariableExtractionState(tester.Client,
-                new UAVariable(new NodeId("id"), "test", null, null, NodeId.Null, null),
+                new UAVariable(new NodeId("id", 0), "test", null, null, NodeId.Null, null),
                 true, true, true);
             state.InitToEmpty();
             state.FinalizeRangeInit();
@@ -236,7 +236,7 @@ namespace Test.Unit
             extractor.Streamer.AllowEvents = true;
             var start = DateTime.UtcNow;
 
-            var id = new NodeId("id");
+            var id = new NodeId("id", 0);
 
             var state = new EventExtractionState(tester.Client, id, true, true, true);
             state.InitToEmpty();
@@ -285,7 +285,7 @@ namespace Test.Unit
         public void TestDataHandler()
         {
             using var extractor = tester.BuildExtractor();
-            var var1 = new UAVariable(new NodeId("id"), "node", null, null, NodeId.Null, null);
+            var var1 = new UAVariable(new NodeId("id", 0), "node", null, null, NodeId.Null, null);
             var1.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             var node = new VariableExtractionState(tester.Client, var1, true, true, true);
             extractor.State.SetNodeState(node, "id");
@@ -302,7 +302,7 @@ namespace Test.Unit
             CommonTestUtils.ResetMetricValue("opcua_bad_datapoints");
 
             // Test against existing node
-            var item = new MonitoredItem() { StartNodeId = new NodeId("id"), CacheQueueSize = 10 };
+            var item = new MonitoredItem() { StartNodeId = new NodeId("id", 0), CacheQueueSize = 10 };
             var values = new[]
             {
                 (DateTime.UtcNow, 100.0, StatusCodes.Good), // OK value
@@ -333,7 +333,7 @@ namespace Test.Unit
 
             Assert.True(CommonTestUtils.TestMetricValue("opcua_bad_datapoints", 3));
 
-            var item2 = new MonitoredItem() { StartNodeId = new NodeId("otherid"), CacheQueueSize = 10 };
+            var item2 = new MonitoredItem() { StartNodeId = new NodeId("otherid", 0), CacheQueueSize = 10 };
             foreach (var not in notifications) item2.SaveValueInCache(not);
             extractor.Streamer.DataSubscriptionHandler(item2, null);
 
@@ -344,7 +344,7 @@ namespace Test.Unit
         {
             CommonTestUtils.ResetMetricValue("opcua_array_points_missed");
             using var extractor = tester.BuildExtractor();
-            var var1 = new UAVariable(new NodeId("id"), "node", null, null, NodeId.Null, null);
+            var var1 = new UAVariable(new NodeId("id", 0), "node", null, null, NodeId.Null, null);
             var1.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             var node1 = new VariableExtractionState(tester.Client, var1, true, true, true);
 
@@ -441,8 +441,8 @@ namespace Test.Unit
                 .GetField("eventQueue", BindingFlags.NonPublic | BindingFlags.Instance)
                 .GetValue(extractor.Streamer);
 
-            var item = new MonitoredItem() { StartNodeId = new NodeId("emitter"), NodeClass = NodeClass.Object };
-            var item2 = new MonitoredItem() { StartNodeId = new NodeId("someotherid"), NodeClass = NodeClass.Object };
+            var item = new MonitoredItem() { StartNodeId = new NodeId("emitter", 0), NodeClass = NodeClass.Object };
+            var item2 = new MonitoredItem() { StartNodeId = new NodeId("someotherid", 0), NodeClass = NodeClass.Object };
 
             var values = EventUtils.GetEventValues(DateTime.UtcNow);
             var rawEvt = new EventFieldList { EventFields = values };
@@ -462,7 +462,7 @@ namespace Test.Unit
 
             // Test null eventFields
             var rawEvt2 = new EventFieldList { EventFields = null };
-            item2.StartNodeId = new NodeId("emitter");
+            item2.StartNodeId = new NodeId("emitter", 0);
             item2.SaveValueInCache(rawEvt2);
             extractor.Streamer.EventSubscriptionHandler(item2, null);
             Assert.Empty(queue);
@@ -525,7 +525,7 @@ namespace Test.Unit
 
             var filter = new EventFilter { SelectClauses = EventUtils.GetSelectClause(tester) };
             var values = EventUtils.GetEventValues(DateTime.UtcNow);
-            var emitter = new NodeId("emitter");
+            var emitter = new NodeId("emitter", 0);
 
             UAEvent created = null;
 
@@ -534,8 +534,8 @@ namespace Test.Unit
             Assert.NotNull(created);
             Assert.Equal(emitter, created.EmittingNode);
             Assert.Equal("message", created.Message);
-            Assert.Equal(new NodeId("source"), created.SourceNode);
-            Assert.Equal(new NodeId("test"), created.EventType.Id);
+            Assert.Equal(new NodeId("source", 0), created.SourceNode);
+            Assert.Equal(new NodeId("test", 0), created.EventType.Id);
             Assert.Equal(DateTime.UtcNow, created.Time, TimeSpan.FromMinutes(10));
             Assert.Single(created.MetaData);
             Assert.True(created.MetaData.ContainsKey("EUProp"));
@@ -552,7 +552,7 @@ namespace Test.Unit
 
             // Bad type
             var badTypeValues = EventUtils.GetEventValues(DateTime.UtcNow);
-            badTypeValues[2] = new NodeId("SomeOtherType");
+            badTypeValues[2] = new NodeId("SomeOtherType", 0);
             created = extractor.Streamer.ConstructEvent(filter, badTypeValues, emitter);
             Assert.Null(created);
 
@@ -585,7 +585,7 @@ namespace Test.Unit
         {
             CommonTestUtils.ResetMetricValue("opcua_array_points_missed");
             using var extractor = tester.BuildExtractor();
-            var var1 = new UAVariable(new NodeId("id"), "node", null, null, NodeId.Null, null);
+            var var1 = new UAVariable(new NodeId("id", 0), "node", null, null, NodeId.Null, null);
             var1.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             var1.AsEvents = true;
             var node1 = new VariableExtractionState(tester.Client, var1, true, true, true);

--- a/Test/Unit/StringConversionTest.cs
+++ b/Test/Unit/StringConversionTest.cs
@@ -51,7 +51,7 @@ namespace Test.Unit
                 Key = "somekey",
                 Value = new NodeId("abc", 2)
             }));
-            var readValueId = new ReadValueId { AttributeId = Attributes.Value, NodeId = new NodeId("test") };
+            var readValueId = new ReadValueId { AttributeId = Attributes.Value, NodeId = new NodeId("test", 0) };
             var readValueIdStr = @"{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13}";
             Assert.Equal(readValueIdStr, converter.ConvertToString(new Variant(readValueId)));
             var ids = new ReadValueIdCollection { readValueId, readValueId };
@@ -197,7 +197,7 @@ namespace Test.Unit
             }
 
             TestConvert(new NodeId(123u), @"{""idType"":0,""identifier"":123}");
-            TestConvert(new NodeId("test"), @"{""idType"":1,""identifier"":""test""}");
+            TestConvert(new NodeId("test", 0), @"{""idType"":1,""identifier"":""test""}");
             TestConvert(new NodeId(Guid.Parse("123e4567-e89b-12d3-a456-426614174000")),
                 @"{""idType"":2,""identifier"":""123e4567-e89b-12d3-a456-426614174000""}");
             TestConvert(new NodeId(new byte[] { 6, 45, 213, 93 }), @"{""idType"":3,""identifier"":""Bi3VXQ==""}");
@@ -249,20 +249,20 @@ namespace Test.Unit
             }
 
             tester.Config.Extraction.DataTypes.ExpandNodeIds = true;
-            var node = new UAObject(new NodeId("test"), "test", null, null, NodeId.Null, null);
+            var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             TestConvert(node,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""parentExternalId"":null,"
                 + @"""NodeId"":{""idType"":1,""identifier"":""test""}}");
 
-            node.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("test-type"));
+            node.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("test-type", 0));
             TestConvert(node,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""parentExternalId"":null,"
                 + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
                 + @"""TypeDefinitionId"":{""idType"":1,""identifier"":""test-type""}}");
 
-            node = new UAObject(new NodeId("test"), "test", null, null, new NodeId("parent"), null);
+            node = new UAObject(new NodeId("test", 0), "test", null, null, new NodeId("parent", 0), null);
             TestConvert(node,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""parentExternalId"":""gp.base:s=parent"","
@@ -272,7 +272,7 @@ namespace Test.Unit
             options = new JsonSerializerOptions();
             converter.AddConverters(options, ConverterType.Variable);
 
-            var variable = new UAVariable(new NodeId("test"), "test", null, null, NodeId.Null, null);
+            var variable = new UAVariable(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.Boolean);
 
             TestConvert(variable,
@@ -299,7 +299,7 @@ namespace Test.Unit
             tester.Config.Extraction.DataTypes.AppendInternalValues = true;
             tester.Config.Events.Enabled = true;
             tester.Config.Events.History = true;
-            var node = new UAObject(new NodeId("test"), "test", null, null, NodeId.Null, null);
+            var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             TestConvert(node,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""parentExternalId"":null,"
@@ -313,7 +313,7 @@ namespace Test.Unit
                 + @"""InternalInfo"":{""EventNotifier"":5,""ShouldSubscribeEvents"":true,"
                 + @"""ShouldReadHistoryEvents"":true,""NodeClass"":1}}");
 
-            var variable = new UAVariable(new NodeId("test"), "test", null, null, NodeId.Null, null);
+            var variable = new UAVariable(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             options = new JsonSerializerOptions();
             converter.AddConverters(options, ConverterType.Variable);
             variable.FullAttributes.AccessLevel |= AccessLevels.CurrentRead | AccessLevels.HistoryRead;
@@ -347,7 +347,7 @@ namespace Test.Unit
             var converter = tester.Client.StringConverter;
             converter.AddConverters(options, ConverterType.Node);
 
-            var node = new UAObject(new NodeId("test", 2), "test", null, null, new NodeId("parent"), null);
+            var node = new UAObject(new NodeId("test", 2), "test", null, null, new NodeId("parent", 0), null);
             node.FullAttributes.EventNotifier = 5;
 
             tester.Config.Extraction.DataTypes.AppendInternalValues = true;
@@ -373,7 +373,7 @@ namespace Test.Unit
             options = new JsonSerializerOptions();
             converter.AddConverters(options, ConverterType.Variable);
 
-            var variable = new UAVariable(new NodeId("test", 2), "test", null, null, new NodeId("parent"), null);
+            var variable = new UAVariable(new NodeId("test", 2), "test", null, null, new NodeId("parent", 0), null);
             variable.FullAttributes.AccessLevel = 5;
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             variable.FullAttributes.ValueRank = -1;

--- a/Test/Unit/TransformationTest.cs
+++ b/Test/Unit/TransformationTest.cs
@@ -36,10 +36,10 @@ namespace Test.Unit
             };
             var nodes = new[]
             {
-                new UAObject(new NodeId(1), null, null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent"), null),
+                new UAObject(new NodeId(1), null, null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent", 0), null),
             };
             var filter = new NodeFilter(raw);
             var matched = nodes.Where(node => filter.IsMatch(node, nss)).ToList();
@@ -61,10 +61,10 @@ namespace Test.Unit
             };
             var nodes = new[]
             {
-                new UAObject(new NodeId(1), "TestTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent"), null)
+                new UAObject(new NodeId(1), "TestTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent", 0), null)
             };
             nodes[0].Attributes.Description = "Some Test";
             nodes[1].Attributes.Description = "Some Other test";
@@ -90,10 +90,10 @@ namespace Test.Unit
             };
             var nodes = new[]
             {
-                new UAObject(new NodeId(1), "TestTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId("id"), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent"), null),
+                new UAObject(new NodeId(1), "TestTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId("id", 0), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent", 0), null),
             };
             var filter = new NodeFilter(raw);
             var matched = nodes.Where(node => filter.IsMatch(node, nss)).ToList();
@@ -114,10 +114,10 @@ namespace Test.Unit
             };
             var nodes = new[]
             {
-                new UAObject(new NodeId(1, 1), "TestTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(2, 2), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(3, 2), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4, 3), "Other", null, null, new NodeId("parent"), null),
+                new UAObject(new NodeId(1, 1), "TestTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(2, 2), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(3, 2), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4, 3), "Other", null, null, new NodeId("parent", 0), null),
             };
             var filter = new NodeFilter(raw);
             var matched = nodes.Where(node => filter.IsMatch(node, nss)).ToList();
@@ -140,10 +140,10 @@ namespace Test.Unit
 
             var nodes = new[]
             {
-                new UAObject(new NodeId(1), "TestTest", null, null, new NodeId("parent"), new UAObjectType(new NodeId(1))),
-                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent"), new UAObjectType(new NodeId(2))),
-                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent"), new UAObjectType(new NodeId("test"))),
+                new UAObject(new NodeId(1), "TestTest", null, null, new NodeId("parent", 0), new UAObjectType(new NodeId(1))),
+                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent", 0), new UAObjectType(new NodeId(2))),
+                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent", 0), new UAObjectType(new NodeId("test", 0))),
             };
             var filter = new NodeFilter(raw);
             var matched = nodes.Where(node => filter.IsMatch(node, nss)).ToList();
@@ -176,11 +176,11 @@ namespace Test.Unit
 
             var nodes = new BaseUANode[]
             {
-                new UAVariable(new NodeId(1), "TestTest", null, null, new NodeId("parent"), null),
-                new UAVariable(new NodeId(2), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAVariable(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent"), null),
-                new UAVariable(new NodeId(5), "Test", null, null, new NodeId("parent"), null)
+                new UAVariable(new NodeId(1), "TestTest", null, null, new NodeId("parent", 0), null),
+                new UAVariable(new NodeId(2), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAVariable(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent", 0), null),
+                new UAVariable(new NodeId(5), "Test", null, null, new NodeId("parent", 0), null)
             };
             (nodes[2].Attributes as Cognite.OpcUa.Nodes.VariableAttributes).ArrayDimensions = new[] { 4 };
             (nodes[4].Attributes as Cognite.OpcUa.Nodes.VariableAttributes).ArrayDimensions = new[] { 4 };
@@ -215,15 +215,15 @@ namespace Test.Unit
                 }
             };
 
-            var parent1 = new UAObject(new NodeId("parent1"), "parent1", null, null, NodeId.Null, null);
-            var parent2 = new UAObject(new NodeId("parent2"), "parent2", null, null, NodeId.Null, null);
+            var parent1 = new UAObject(new NodeId("parent1", 0), "parent1", null, null, NodeId.Null, null);
+            var parent2 = new UAObject(new NodeId("parent2", 0), "parent2", null, null, NodeId.Null, null);
 
             var nodes = new[]
             {
-                new UAObject(new NodeId(1, 1), "TestTest", null, parent1, new NodeId("parent1"), null) { Parent = parent1 },
-                new UAObject(new NodeId(2, 2), "OtherTest", null, parent1, new NodeId("parent1"), null) { Parent = parent1 },
-                new UAObject(new NodeId(3, 2), "Test", null, parent2, new NodeId("parent2"), null) { Parent = parent2 },
-                new UAObject(new NodeId(4, 3), "Other", null, parent2, new NodeId("parent2"), null) { Parent = parent2 },
+                new UAObject(new NodeId(1, 1), "TestTest", null, parent1, new NodeId("parent1", 0), null) { Parent = parent1 },
+                new UAObject(new NodeId(2, 2), "OtherTest", null, parent1, new NodeId("parent1", 0), null) { Parent = parent1 },
+                new UAObject(new NodeId(3, 2), "Test", null, parent2, new NodeId("parent2", 0), null) { Parent = parent2 },
+                new UAObject(new NodeId(4, 3), "Other", null, parent2, new NodeId("parent2", 0), null) { Parent = parent2 },
             };
             var filter = new NodeFilter(raw);
             var matched = nodes.Where(node => filter.IsMatch(node, nss)).ToList();
@@ -246,10 +246,10 @@ namespace Test.Unit
 
             var nodes = new BaseUANode[]
             {
-                new UAVariableType(new NodeId(1), "TestTest", null, null, new NodeId("parent")),
-                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObjectType(new NodeId(4), "Other", null, null, new NodeId("parent")),
+                new UAVariableType(new NodeId(1), "TestTest", null, null, new NodeId("parent", 0)),
+                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObjectType(new NodeId(4), "Other", null, null, new NodeId("parent", 0)),
             };
             var filter = new NodeFilter(raw);
             var matched = nodes.Where(node => filter.IsMatch(node, nss)).ToList();
@@ -274,11 +274,11 @@ namespace Test.Unit
 
             var nodes = new BaseUANode[]
             {
-                new UAVariable(new NodeId(1), "TestTest", null, null, new NodeId("parent"), null),
-                new UAVariable(new NodeId(2), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAVariable(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent"), null),
-                new UAVariable(new NodeId(5), "Test", null, null, new NodeId("parent"), null)
+                new UAVariable(new NodeId(1), "TestTest", null, null, new NodeId("parent", 0), null),
+                new UAVariable(new NodeId(2), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAVariable(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent", 0), null),
+                new UAVariable(new NodeId(5), "Test", null, null, new NodeId("parent", 0), null)
             };
             (nodes[2].Attributes as Cognite.OpcUa.Nodes.VariableAttributes).Historizing = true;
             (nodes[4].Attributes as Cognite.OpcUa.Nodes.VariableAttributes).Historizing = true;
@@ -320,8 +320,8 @@ namespace Test.Unit
                 Namespace = "test-",
                 NodeClass = NodeClass.Variable
             };
-            var parent1 = new UAObject(new NodeId("parent1"), "parent1", null, null, NodeId.Null, null);
-            var parent2 = new UAObject(new NodeId("parent2"), "parent2", null, null, NodeId.Null, null);
+            var parent1 = new UAObject(new NodeId("parent1", 0), "parent1", null, null, NodeId.Null, null);
+            var parent2 = new UAObject(new NodeId("parent2", 0), "parent2", null, null, NodeId.Null, null);
             // Each node deviates on only one point.
             var nodes = new List<BaseUANode>();
             for (int i = 0; i < 10; i++)
@@ -379,10 +379,10 @@ namespace Test.Unit
             };
             var nodes = new[]
             {
-                new UAObject(new NodeId(1), null, null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent"), null),
+                new UAObject(new NodeId(1), null, null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent", 0), null),
             };
             var cfg = new FullConfig();
             cfg.GenerateDefaults();
@@ -410,10 +410,10 @@ namespace Test.Unit
             };
             var nodes = new[]
             {
-                new UAObject(new NodeId(1), null, null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent"), null),
+                new UAObject(new NodeId(1), null, null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent", 0), null),
             };
             var cfg = new FullConfig();
             cfg.GenerateDefaults();
@@ -448,10 +448,10 @@ namespace Test.Unit
             };
             var nodes = new BaseUANode[]
             {
-                new UAVariable(new NodeId(1), null, null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent"), null),
+                new UAVariable(new NodeId(1), null, null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(2), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4), "Other", null, null, new NodeId("parent", 0), null),
             };
             var cfg = new FullConfig();
             cfg.GenerateDefaults();
@@ -481,10 +481,10 @@ namespace Test.Unit
             };
             var nodes = new BaseUANode[]
             {
-                new UAVariable(new NodeId(1), null, null, null, new NodeId("parent"), null),
-                new UAVariable(new NodeId(2), "OtherTest", null, null, new NodeId("parent"), null),
-                new UAVariable(new NodeId(3), "Test", null, null, new NodeId("parent"), null),
-                new UAObject(new NodeId(4), "TestTest", null, null, new NodeId("parent"), null),
+                new UAVariable(new NodeId(1), null, null, null, new NodeId("parent", 0), null),
+                new UAVariable(new NodeId(2), "OtherTest", null, null, new NodeId("parent", 0), null),
+                new UAVariable(new NodeId(3), "Test", null, null, new NodeId("parent", 0), null),
+                new UAObject(new NodeId(4), "TestTest", null, null, new NodeId("parent", 0), null),
             };
             var cfg = new FullConfig();
             cfg.GenerateDefaults();

--- a/Test/Unit/TypeManagerTest.cs
+++ b/Test/Unit/TypeManagerTest.cs
@@ -35,21 +35,21 @@ namespace Test.Unit
             var config = tester.Config.Extraction.DataTypes;
             config.IgnoreDataTypes = new List<ProtoNodeId>
             {
-                new NodeId("enum").ToProtoNodeId(tester.Client),
-                new NodeId("test").ToProtoNodeId(tester.Client),
+                new NodeId("enum", 0).ToProtoNodeId(tester.Client),
+                new NodeId("test", 0).ToProtoNodeId(tester.Client),
                 new ProtoNodeId { NamespaceUri = "some.missing.uri", NodeId = "i=123" }
             };
             mgr = new TypeManager(tester.Config, tester.Client, tester.Log);
             mgr.InitDataTypeConfig();
-            mgr.GetDataType(new NodeId("enum"));
-            mgr.GetDataType(new NodeId("test"));
+            mgr.GetDataType(new NodeId("enum", 0));
+            mgr.GetDataType(new NodeId("test", 0));
             // with ignore data types
             mgr.BuildTypeInfo();
             Assert.Equal(2, mgr.NodeMap.Values.OfType<UADataType>().Count());
 
-            var dt1 = mgr.NodeMap[new NodeId("enum")] as UADataType;
+            var dt1 = mgr.NodeMap[new NodeId("enum", 0)] as UADataType;
             Assert.True(dt1.ShouldIgnore);
-            var dt2 = mgr.NodeMap[new NodeId("test")] as UADataType;
+            var dt2 = mgr.NodeMap[new NodeId("test", 0)] as UADataType;
             Assert.True(dt2.ShouldIgnore);
         }
 
@@ -62,23 +62,23 @@ namespace Test.Unit
             var config = tester.Config.Extraction.DataTypes;
             config.CustomNumericTypes = new List<ProtoDataType>
             {
-                new ProtoDataType { Enum = true, NodeId = new NodeId("enum").ToProtoNodeId(tester.Client) },
-                new ProtoDataType { NodeId = new NodeId("test").ToProtoNodeId(tester.Client) },
+                new ProtoDataType { Enum = true, NodeId = new NodeId("enum", 0).ToProtoNodeId(tester.Client) },
+                new ProtoDataType { NodeId = new NodeId("test", 0).ToProtoNodeId(tester.Client) },
                 new ProtoDataType { NodeId = new ProtoNodeId { NamespaceUri = "some.missing.uri", NodeId = "i=123" } }
             };
             mgr = new TypeManager(tester.Config, tester.Client, tester.Log);
             mgr.InitDataTypeConfig();
-            mgr.GetDataType(new NodeId("enum"));
-            mgr.GetDataType(new NodeId("test"));
+            mgr.GetDataType(new NodeId("enum", 0));
+            mgr.GetDataType(new NodeId("test", 0));
 
             // with custom numeric types
             mgr.BuildTypeInfo();
             Assert.Equal(2, mgr.NodeMap.Values.OfType<UADataType>().Count());
 
-            var dt1 = mgr.NodeMap[new NodeId("enum")] as UADataType;
+            var dt1 = mgr.NodeMap[new NodeId("enum", 0)] as UADataType;
             Assert.NotNull(dt1.EnumValues);
             Assert.False(dt1.IsString);
-            var dt2 = mgr.NodeMap[new NodeId("test")] as UADataType;
+            var dt2 = mgr.NodeMap[new NodeId("test", 0)] as UADataType;
             Assert.False(dt2.IsString);
         }
 
@@ -100,7 +100,7 @@ namespace Test.Unit
             config.AutoIdentifyTypes = true;
 
             // child of number
-            var dt1 = mgr.GetDataType(new NodeId("dt1"));
+            var dt1 = mgr.GetDataType(new NodeId("dt1", 0));
             dt1.Parent = mgr.GetDataType(DataTypeIds.Number);
             mgr.BuildTypeInfo();
             Assert.False(dt1.IsString);
@@ -108,7 +108,7 @@ namespace Test.Unit
             Assert.Equal(2, mgr.NodeMap.Values.OfType<UADataType>().Count());
 
             // Grandchild of number
-            var dt2 = mgr.GetDataType(new NodeId("dt2"));
+            var dt2 = mgr.GetDataType(new NodeId("dt2", 0));
             dt2.Parent = dt1;
             mgr.BuildTypeInfo();
             Assert.False(dt2.IsString);
@@ -116,15 +116,15 @@ namespace Test.Unit
             Assert.Equal(3, mgr.NodeMap.Values.OfType<UADataType>().Count());
 
             // Child of unknown
-            var dt3 = mgr.GetDataType(new NodeId("dt3"));
-            dt3.Parent = mgr.GetDataType(new NodeId("udt"));
+            var dt3 = mgr.GetDataType(new NodeId("dt3", 0));
+            dt3.Parent = mgr.GetDataType(new NodeId("udt", 0));
             mgr.BuildTypeInfo();
             Assert.True(dt3.IsString);
             Assert.False(dt3.IsStep);
             Assert.Equal(5, mgr.NodeMap.Values.OfType<UADataType>().Count());
 
             // Child of known
-            var dt4 = mgr.GetDataType(new NodeId("dt4"));
+            var dt4 = mgr.GetDataType(new NodeId("dt4", 0));
             dt4.Parent = dt2;
             mgr.BuildTypeInfo();
             Assert.False(dt4.IsString);
@@ -132,7 +132,7 @@ namespace Test.Unit
             Assert.Equal(6, mgr.NodeMap.Values.OfType<UADataType>().Count());
 
             // Child of bool
-            var dt5 = mgr.GetDataType(new NodeId("dt5"));
+            var dt5 = mgr.GetDataType(new NodeId("dt5", 0));
             dt5.Parent = mgr.GetDataType(DataTypeIds.Boolean);
             mgr.BuildTypeInfo();
             Assert.False(dt5.IsString);
@@ -140,7 +140,7 @@ namespace Test.Unit
             Assert.Equal(8, mgr.NodeMap.Values.OfType<UADataType>().Count());
 
             // Child of enum
-            var dt6 = mgr.GetDataType(new NodeId("dt6"));
+            var dt6 = mgr.GetDataType(new NodeId("dt6", 0));
             dt6.Parent = mgr.GetDataType(DataTypeIds.Enumeration);
             mgr.BuildTypeInfo();
             Assert.False(dt6.IsString);
@@ -157,7 +157,7 @@ namespace Test.Unit
             Assert.Equal(11, mgr.NodeMap.Values.OfType<UADataType>().Count());
 
             // Recognized NodeId
-            var dt8 = mgr.GetDataType(new NodeId("dt6"));
+            var dt8 = mgr.GetDataType(new NodeId("dt6", 0));
             mgr.BuildTypeInfo();
             Assert.False(dt8.IsString);
             Assert.True(dt8.IsStep);
@@ -170,10 +170,10 @@ namespace Test.Unit
             {
                 IgnoreDataTypes = new List<ProtoNodeId>
                 {
-                    new NodeId("ignore").ToProtoNodeId(tester.Client)
+                    new NodeId("ignore", 0).ToProtoNodeId(tester.Client)
                 }
             };
-            var node = new UAVariable(new NodeId("node"), "node", null, null, NodeId.Null, null);
+            var node = new UAVariable(new NodeId("node", 0), "node", null, null, NodeId.Null, null);
             node.FullAttributes.ValueRank = ValueRanks.Scalar;
             var config = tester.Config.Extraction.DataTypes;
 
@@ -190,7 +190,7 @@ namespace Test.Unit
             Assert.True(node.AllowTSMap(tester.Log, config));
 
             // Ignored datatype
-            node.FullAttributes.DataType = new UADataType(new NodeId("ignore"));
+            node.FullAttributes.DataType = new UADataType(new NodeId("ignore", 0));
             node.FullAttributes.DataType.ShouldIgnore = true;
             Assert.False(node.AllowTSMap(tester.Log, config));
 

--- a/Test/Unit/TypesTest.cs
+++ b/Test/Unit/TypesTest.cs
@@ -64,8 +64,8 @@ namespace Test.Unit
                 }
             }
 
-            var nodeA = new UAObject(new NodeId("node"), null, null, null, NodeId.Null, null);
-            var nodeB = new UAObject(new NodeId("node"), null, null, null, NodeId.Null, null);
+            var nodeA = new UAObject(new NodeId("node", 0), null, null, null, NodeId.Null, null);
+            var nodeB = new UAObject(new NodeId("node", 0), null, null, null, NodeId.Null, null);
 
             (int, int) Update(BaseUANode nodeA, BaseUANode nodeB)
             {
@@ -79,18 +79,18 @@ namespace Test.Unit
             Assert.Equal(csA, csB);
 
             // Test name
-            nodeA = new UAObject(new NodeId("node"), "name", null, null, NodeId.Null, null);
+            nodeA = new UAObject(new NodeId("node", 0), "name", null, null, NodeId.Null, null);
             (csA, csB) = Update(nodeA, nodeB);
             AssertNotEqualIf(update.Name);
-            nodeB = new UAObject(new NodeId("node"), "name", null, null, NodeId.Null, null);
+            nodeB = new UAObject(new NodeId("node", 0), "name", null, null, NodeId.Null, null);
             (csA, csB) = Update(nodeA, nodeB);
             Assert.Equal(csA, csB);
 
             // Test context
-            nodeA = new UAObject(new NodeId("node"), "name", null, null, new NodeId("parent"), null);
+            nodeA = new UAObject(new NodeId("node", 0), "name", null, null, new NodeId("parent", 0), null);
             (csA, csB) = Update(nodeA, nodeB);
             AssertNotEqualIf(update.Context);
-            nodeB = new UAObject(new NodeId("node"), "name", null, null, new NodeId("parent"), null);
+            nodeB = new UAObject(new NodeId("node", 0), "name", null, null, new NodeId("parent", 0), null);
             (csA, csB) = Update(nodeA, nodeB);
             Assert.Equal(csA, csB);
 
@@ -131,11 +131,11 @@ namespace Test.Unit
             Assert.Equal(csA, csB);
 
             // Test NodeType metadata
-            nodeA.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type"));
-            nodeB.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type2"));
+            nodeA.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type", 0));
+            nodeB.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type2", 0));
             (csA, csB) = Update(nodeA, nodeB);
             AssertNotEqualIf(ntMeta && update.Metadata);
-            nodeB.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type"));
+            nodeB.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type", 0));
             (csA, csB) = Update(nodeA, nodeB);
             Assert.Equal(csA, csB);
 
@@ -155,10 +155,10 @@ namespace Test.Unit
             Assert.Equal(csA, csB);
 
             // Test variable types
-            var typeA = new UAVariableType(new NodeId("typeA"), "typeA", null, null, NodeId.Null);
+            var typeA = new UAVariableType(new NodeId("typeA", 0), "typeA", null, null, NodeId.Null);
             typeA.FullAttributes.DataType = pdt;
             typeA.FullAttributes.Value = new Variant("value1");
-            var typeB = new UAVariableType(new NodeId("typeA"), "typeA", null, null, NodeId.Null);
+            var typeB = new UAVariableType(new NodeId("typeA", 0), "typeA", null, null, NodeId.Null);
             typeB.FullAttributes.DataType = pdt;
             typeB.FullAttributes.Value = new Variant("value2");
             (csA, csB) = Update(typeA, typeB);
@@ -171,7 +171,7 @@ namespace Test.Unit
         public void TestDebugDescription()
         {
             // Super basic
-            var node = new UAObject(new NodeId("test"), "name", null, null, NodeId.Null, null);
+            var node = new UAObject(new NodeId("test", 0), "name", null, null, NodeId.Null, null);
             var str = node.ToString();
             var refStr = "Object: name\n"
                        + "    Id: s=test\n";
@@ -181,7 +181,7 @@ namespace Test.Unit
             var pdt = new UADataType(DataTypeIds.String);
             pdt.Attributes.DisplayName = "String";
 
-            node = new UAObject(new NodeId("test"), "name", null, null, new NodeId("parent"), null);
+            node = new UAObject(new NodeId("test", 0), "name", null, null, new NodeId("parent", 0), null);
             node.Attributes.Description = "description";
             node.FullAttributes.EventNotifier = EventNotifiers.HistoryRead | EventNotifiers.SubscribeToEvents;
             var propA = CommonTestUtils.GetSimpleVariable("propA", pdt);
@@ -195,7 +195,7 @@ namespace Test.Unit
             {
                 propA, nestedProp, propB
             };
-            node.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type"));
+            node.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type", 0));
 
             str = node.ToString();
             refStr = "Object: name\n"
@@ -237,11 +237,11 @@ namespace Test.Unit
         public void TestBuildMetadata()
         {
             using var extractor = tester.BuildExtractor();
-            var node = new UAObject(new NodeId("test"), "test", null, null, NodeId.Null, null);
+            var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             Assert.Empty(node.BuildMetadata(tester.Config, extractor, false));
             Assert.Empty(node.BuildMetadata(tester.Config, extractor, true));
             tester.Config.Extraction.NodeTypes.Metadata = true;
-            node.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type"));
+            node.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type", 0));
             node.FullAttributes.TypeDefinition.Attributes.DisplayName = "SomeType";
             // Test extras only
             Assert.Single(node.BuildMetadata(tester.Config, extractor, true));
@@ -281,14 +281,14 @@ namespace Test.Unit
             Assert.Equal("nestedValue", meta["propB_nestedProp"]);
 
             // Test null name
-            var nullNameProp = new UAVariable(new NodeId("nullName"), null, null, null, NodeId.Null, null);
+            var nullNameProp = new UAVariable(new NodeId("nullName", 0), null, null, null, NodeId.Null, null);
             nullNameProp.FullAttributes.DataType = pdt;
             node.Attributes.AddProperty(nullNameProp);
             meta = node.BuildMetadata(tester.Config, extractor, true);
             Assert.Equal(4, meta.Count);
 
             // Test null value
-            var nullValueProp = new UAVariable(new NodeId("nullValue"), "nullValue", null, null, NodeId.Null, null);
+            var nullValueProp = new UAVariable(new NodeId("nullValue", 0), "nullValue", null, null, NodeId.Null, null);
             nullValueProp.FullAttributes.DataType = pdt;
             node.Attributes.AddProperty(nullValueProp);
             meta = node.BuildMetadata(tester.Config, extractor, true);
@@ -296,7 +296,7 @@ namespace Test.Unit
             Assert.Equal("", meta["nullValue"]);
 
             // Test duplicated properties
-            var propA2 = new UAVariable(new NodeId("propA2"), "propA", null, null, NodeId.Null, null);
+            var propA2 = new UAVariable(new NodeId("propA2", 0), "propA", null, null, NodeId.Null, null);
             propA2.FullAttributes.DataType = pdt;
             node.Attributes.AddProperty(propA2);
             propA2.FullAttributes.Value = new Variant("valueA2");
@@ -306,7 +306,7 @@ namespace Test.Unit
 
             // Test overwrite extras
             Assert.Equal("SomeType", meta["TypeDefinition"]);
-            var propNT = new UAVariable(new NodeId("TypeDef"), "TypeDefinition", null, null, NodeId.Null, null);
+            var propNT = new UAVariable(new NodeId("TypeDef", 0), "TypeDefinition", null, null, NodeId.Null, null);
             propNT.FullAttributes.DataType = pdt;
             propNT.FullAttributes.Value = new Variant("SomeOtherType");
             node.Attributes.AddProperty(propNT);
@@ -320,7 +320,7 @@ namespace Test.Unit
         {
             using var extractor = tester.BuildExtractor();
 
-            var node = new UAObject(new NodeId("test"), "test", null, null, new NodeId("parent"), null);
+            var node = new UAObject(new NodeId("test", 0), "test", null, null, new NodeId("parent", 0), null);
             node.Attributes.Description = "description";
             var ts = DateTime.UtcNow;
             var pdt = new UADataType(DataTypeIds.String);
@@ -373,14 +373,14 @@ namespace Test.Unit
         public void TestToJson()
         {
             using var extractor = tester.BuildExtractor();
-            var node = new UAObject(new NodeId("test"), "test", null, null, NodeId.Null, null);
+            var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             var converter = tester.Client.StringConverter;
             var log = tester.Provider.GetRequiredService<ILogger<TypesTest>>();
             Assert.Equal("", MetadataToJson(log, node, extractor));
 
             // Extras only
             tester.Config.Extraction.NodeTypes.Metadata = true;
-            node.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type"));
+            node.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type", 0));
             node.FullAttributes.TypeDefinition.Attributes.DisplayName = "SomeType";
             Assert.Equal(@"{""TypeDefinition"":""SomeType""}", MetadataToJson(log, node, extractor));
 
@@ -415,7 +415,7 @@ namespace Test.Unit
                 MetadataToJson(log, node, extractor));
 
             // Test null name
-            var nullNameProp = new UAVariable(new NodeId("nullName"), null, null, null, NodeId.Null, null);
+            var nullNameProp = new UAVariable(new NodeId("nullName", 0), null, null, null, NodeId.Null, null);
             nullNameProp.FullAttributes.DataType = pdt;
             node.Attributes.AddProperty(nullNameProp);
             Assert.Equal(@"{""TypeDefinition"":""SomeType"",""propA"":""valueA"","
@@ -423,7 +423,7 @@ namespace Test.Unit
                 MetadataToJson(log, node, extractor));
 
             // Test null value
-            var nullValueProp = new UAVariable(new NodeId("nullValue"), "nullValue", null, null, NodeId.Null, null);
+            var nullValueProp = new UAVariable(new NodeId("nullValue", 0), "nullValue", null, null, NodeId.Null, null);
             nullValueProp.FullAttributes.DataType = pdt;
             node.Attributes.AddProperty(nullValueProp);
             Assert.Equal(@"{""TypeDefinition"":""SomeType"",""propA"":""valueA"","
@@ -431,7 +431,7 @@ namespace Test.Unit
                 MetadataToJson(log, node, extractor));
 
             // Test duplicated properties
-            var propA2 = new UAVariable(new NodeId("propA2"), "propA", null, null, NodeId.Null, null);
+            var propA2 = new UAVariable(new NodeId("propA2", 0), "propA", null, null, NodeId.Null, null);
             propA2.FullAttributes.DataType = pdt;
             node.Attributes.AddProperty(propA2);
             propA2.FullAttributes.Value = new Variant("valueA2");
@@ -443,16 +443,16 @@ namespace Test.Unit
         public void TestToJsonComplexTypes()
         {
             using var extractor = tester.BuildExtractor();
-            var node = new UAObject(new NodeId("test"), "test", null, null, NodeId.Null, null);
+            var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             var converter = tester.Client.StringConverter;
             var log = tester.Provider.GetRequiredService<ILogger<TypesTest>>();
 
             var pdt = new UADataType(DataTypeIds.ReadValueId);
-            var prop = new UAVariable(new NodeId("readvalueid"), "readvalueid", null, null, NodeId.Null, null);
+            var prop = new UAVariable(new NodeId("readvalueid", 0), "readvalueid", null, null, NodeId.Null, null);
 
             // Test simple value
             prop.FullAttributes.DataType = pdt;
-            var value = new ReadValueId { NodeId = new NodeId("test"), AttributeId = Attributes.Value };
+            var value = new ReadValueId { NodeId = new NodeId("test", 0), AttributeId = Attributes.Value };
             prop.FullAttributes.Value = new Variant(value);
             node.Attributes.AddProperty(prop);
 
@@ -461,7 +461,7 @@ namespace Test.Unit
 
             // Test nested
             node.Attributes.Properties.Clear();
-            var outerProp = new UAObject(new NodeId("outer"), "outer", null, null, NodeId.Null, null);
+            var outerProp = new UAObject(new NodeId("outer", 0), "outer", null, null, NodeId.Null, null);
             outerProp.Attributes.AddProperty(prop);
             node.Attributes.AddProperty(outerProp);
             Assert.Equal(@"{""outer"":{""readvalueid"":{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13}}}",
@@ -484,7 +484,7 @@ namespace Test.Unit
             pdt.Attributes.DisplayName = "String";
 
             // basic
-            var node = new UAVariable(new NodeId("test"), "name", null, null, NodeId.Null, null);
+            var node = new UAVariable(new NodeId("test", 0), "name", null, null, NodeId.Null, null);
             node.FullAttributes.ValueRank = ValueRanks.Scalar;
             var str = node.ToString();
             var refStr = "Variable: name\n"
@@ -492,14 +492,14 @@ namespace Test.Unit
             Assert.Equal(refStr.ReplaceLineEndings(), str.ReplaceLineEndings());
 
             // full
-            node = new UAVariable(new NodeId("test"), "name", null, null, new NodeId("parent"), null);
+            node = new UAVariable(new NodeId("test", 0), "name", null, null, new NodeId("parent", 0), null);
             node.Attributes.Description = "description";
             node.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             node.FullAttributes.DataType.Attributes.DisplayName = "Double";
             node.FullAttributes.AccessLevel = AccessLevels.CurrentRead | AccessLevels.HistoryRead;
             node.FullAttributes.ValueRank = ValueRanks.Any;
             node.FullAttributes.ArrayDimensions = new int[] { 4 };
-            node.FullAttributes.TypeDefinition = new UAVariableType(new NodeId("type"));
+            node.FullAttributes.TypeDefinition = new UAVariableType(new NodeId("type", 0));
             node.AsEvents = true;
 
             var propA = CommonTestUtils.GetSimpleVariable("propA", pdt);
@@ -558,8 +558,8 @@ namespace Test.Unit
         [Fact]
         public void TestGetArrayChildren()
         {
-            var id = new NodeId("test");
-            var node = new UAVariable(id, "name", null, null, NodeId.Null, new UAVariableType(new NodeId("test")));
+            var id = new NodeId("test", 0);
+            var node = new UAVariable(id, "name", null, null, NodeId.Null, new UAVariableType(new NodeId("test", 0)));
             Assert.Single(node.CreateTimeseries());
             Assert.Null(node.ArrayChildren);
 
@@ -590,8 +590,8 @@ namespace Test.Unit
         [Fact]
         public void TestGetTimeseries()
         {
-            var id = new NodeId("test");
-            var node = new UAVariable(id, "name", null, null, NodeId.Null, new UAVariableType(new NodeId("test")));
+            var id = new NodeId("test", 0);
+            var node = new UAVariable(id, "name", null, null, NodeId.Null, new UAVariableType(new NodeId("test", 0)));
 
             node.FullAttributes.AccessLevel = AccessLevels.CurrentRead | AccessLevels.HistoryRead;
             node.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
@@ -622,7 +622,7 @@ namespace Test.Unit
 
             var pdt = new UADataType(DataTypeIds.String);
 
-            var node = new UAVariable(new NodeId("test"), "test", null, null, new NodeId("parent"), null);
+            var node = new UAVariable(new NodeId("test", 0), "test", null, null, new NodeId("parent", 0), null);
             node.Attributes.Description = "description";
             node.FullAttributes.DataType = new UADataType(DataTypeIds.Boolean);
             node.Attributes.Properties = new List<BaseUANode>();
@@ -673,7 +673,7 @@ namespace Test.Unit
         {
             using var extractor = tester.BuildExtractor();
 
-            var node = new UAVariable(new NodeId("test"), "test", null, null, new NodeId("parent"), null);
+            var node = new UAVariable(new NodeId("test", 0), "test", null, null, new NodeId("parent", 0), null);
             node.Attributes.Description = "description";
             node.FullAttributes.DataType = new UADataType(DataTypeIds.Boolean);
             node.Attributes.Properties = new List<BaseUANode>();
@@ -690,10 +690,10 @@ namespace Test.Unit
 
             var nodeToAssetIds = new Dictionary<NodeId, long>
             {
-                { new NodeId("parent"), 111 },
-                { new NodeId("parent2"), 222 }
+                { new NodeId("parent", 0), 111 },
+                { new NodeId("parent2", 0), 222 }
             };
-            extractor.State.RegisterNode(new NodeId("parent2"), "value4");
+            extractor.State.RegisterNode(new NodeId("parent2", 0), "value4");
 
             var ts = node.ToTimeseries(tester.Config, extractor, extractor, 123, nodeToAssetIds, null);
             Assert.Equal("gp.base:s=test", ts.ExternalId);
@@ -841,7 +841,7 @@ namespace Test.Unit
             Assert.False(dt.IsString);
 
             // Custom type
-            dt = new UADataType(new NodeId("test"));
+            dt = new UADataType(new NodeId("test", 0));
             Assert.False(dt.IsStep);
             Assert.True(dt.IsString);
 
@@ -849,19 +849,19 @@ namespace Test.Unit
             var config = new DataTypeConfig();
 
             // Override step
-            dt = new UADataType(new ProtoDataType { IsStep = true }, new NodeId("test"), config);
+            dt = new UADataType(new ProtoDataType { IsStep = true }, new NodeId("test", 0), config);
             Assert.True(dt.IsStep);
             Assert.False(dt.IsString);
 
             // Override enum, strings disabled
-            dt = new UADataType(new ProtoDataType { Enum = true }, new NodeId("test"), config);
+            dt = new UADataType(new ProtoDataType { Enum = true }, new NodeId("test", 0), config);
             Assert.True(dt.IsStep);
             Assert.False(dt.IsString);
             Assert.NotNull(dt.EnumValues);
 
             // Override enum, strings enabled
             config.EnumsAsStrings = true;
-            dt = new UADataType(new ProtoDataType { Enum = true }, new NodeId("test"), config);
+            dt = new UADataType(new ProtoDataType { Enum = true }, new NodeId("test", 0), config);
             Assert.False(dt.IsStep);
             Assert.True(dt.IsString);
             Assert.NotNull(dt.EnumValues);
@@ -869,7 +869,7 @@ namespace Test.Unit
 
             // Child constructor
             var rootDt = new UADataType(DataTypeIds.Boolean);
-            dt = new UADataType(new NodeId("test"), rootDt);
+            dt = new UADataType(new NodeId("test", 0), rootDt);
             Assert.True(dt.IsStep);
             Assert.False(dt.IsString);
 
@@ -877,7 +877,7 @@ namespace Test.Unit
             {
                 [123] = "test"
             };
-            dt = new UADataType(new NodeId("test"), rootDt);
+            dt = new UADataType(new NodeId("test", 0), rootDt);
             Assert.True(dt.IsStep);
             Assert.False(dt.IsString);
             Assert.NotNull(dt.EnumValues);
@@ -904,7 +904,7 @@ namespace Test.Unit
 
             // Enum double
             var config = new DataTypeConfig();
-            dt = new UADataType(new ProtoDataType { Enum = true }, new NodeId("test"), config);
+            dt = new UADataType(new ProtoDataType { Enum = true }, new NodeId("test", 0), config);
             dp = dt.ToDataPoint(extractor, 123, now, "id");
             Assert.Equal("id", dp.Id);
             Assert.Equal(123, dp.DoubleValue);
@@ -912,7 +912,7 @@ namespace Test.Unit
 
             // Enum string
             config.EnumsAsStrings = true;
-            dt = new UADataType(new ProtoDataType { Enum = true }, new NodeId("test"), config);
+            dt = new UADataType(new ProtoDataType { Enum = true }, new NodeId("test", 0), config);
             dt.EnumValues[123] = "enum";
             dp = dt.ToDataPoint(extractor, 123, now, "id");
             Assert.Equal("id", dp.Id);
@@ -933,7 +933,7 @@ namespace Test.Unit
 
             // Test complex type
             dt = new UADataType(DataTypeIds.ReadValueId);
-            var value = new Variant(new ReadValueId { AttributeId = Attributes.Value, NodeId = new NodeId("test") });
+            var value = new Variant(new ReadValueId { AttributeId = Attributes.Value, NodeId = new NodeId("test", 0) });
             dp = dt.ToDataPoint(extractor, value, now, "id");
             Assert.Equal("id", dp.Id);
             Assert.Equal(@"{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13}", dp.StringValue);
@@ -952,7 +952,7 @@ namespace Test.Unit
             Assert.Equal(refStr.ReplaceLineEndings(), str.ReplaceLineEndings());
 
             // full
-            dt = new UADataType(new NodeId("test"))
+            dt = new UADataType(new NodeId("test", 0))
             {
                 IsString = false,
                 IsStep = true,
@@ -983,8 +983,8 @@ namespace Test.Unit
             {
                 EventId = "test.test",
                 Time = now,
-                EmittingNode = new NodeId("emitter"),
-                EventType = new UAObjectType(new NodeId("type"))
+                EmittingNode = new NodeId("emitter", 0),
+                EventType = new UAObjectType(new NodeId("type", 0))
             };
             evt.EventType.Attributes.DisplayName = "EventType";
 
@@ -996,7 +996,7 @@ namespace Test.Unit
             Assert.Equal(refStr.ReplaceLineEndings(), str.ReplaceLineEndings());
 
             evt.Message = "message";
-            evt.SourceNode = new NodeId("source");
+            evt.SourceNode = new NodeId("source", 0);
             evt.MetaData = new Dictionary<string, string>
             {
                 { "key", "value1" },
@@ -1024,12 +1024,12 @@ namespace Test.Unit
             // minimal
             var now = DateTime.UtcNow;
             using var extractor = tester.BuildExtractor();
-            var state = new EventExtractionState(tester.Client, new NodeId("emitter"), true, true, true);
+            var state = new EventExtractionState(tester.Client, new NodeId("emitter", 0), true, true, true);
             extractor.State.SetEmitterState(state);
-            extractor.State.RegisterNode(new NodeId("type"), tester.Client.GetUniqueId(new NodeId("type")));
-            var type = new UAObjectType(new NodeId("type"));
+            extractor.State.RegisterNode(new NodeId("type", 0), tester.Client.GetUniqueId(new NodeId("type", 0)));
+            var type = new UAObjectType(new NodeId("type", 0));
             extractor.State.ActiveEvents[type.Id] = type;
-            extractor.State.RegisterNode(new NodeId("emitter"), tester.Client.GetUniqueId(new NodeId("emitter")));
+            extractor.State.RegisterNode(new NodeId("emitter", 0), tester.Client.GetUniqueId(new NodeId("emitter", 0)));
 
             ILogger log = tester.Provider.GetRequiredService<ILogger<TypesTest>>();
             // No event should be created without all of these
@@ -1037,7 +1037,7 @@ namespace Test.Unit
             {
                 EventId = "test.test",
                 Time = DateTime.MinValue,
-                EmittingNode = new NodeId("emitter"),
+                EmittingNode = new NodeId("emitter", 0),
                 EventType = type,
                 SourceNode = NodeId.Null
             };
@@ -1056,16 +1056,16 @@ namespace Test.Unit
             }
 
             // full
-            extractor.State.RegisterNode(new NodeId("source"), tester.Client.GetUniqueId(new NodeId("source")));
+            extractor.State.RegisterNode(new NodeId("source", 0), tester.Client.GetUniqueId(new NodeId("source", 0)));
             evt.Message = "message";
             evt.Time = now;
-            evt.SourceNode = new NodeId("source");
+            evt.SourceNode = new NodeId("source", 0);
             evt.SetMetadata(extractor.StringConverter, new[]
             {
                 new EventFieldValue(new RawTypeField("key1"), "value1"),
                 new EventFieldValue(new RawTypeField("key1"), 123),
                 new EventFieldValue(new RawTypeField("key1"), Variant.Null),
-                new EventFieldValue(new RawTypeField("key1"), new NodeId("meta")),
+                new EventFieldValue(new RawTypeField("key1"), new NodeId("meta", 0)),
             }, log);
 
             bytes = evt.ToStorableBytes(extractor);
@@ -1094,12 +1094,12 @@ namespace Test.Unit
 
             var evt = new UAEvent
             {
-                EmittingNode = new NodeId("emitter"),
+                EmittingNode = new NodeId("emitter", 0),
                 MetaData = new Dictionary<string, string>(),
                 EventId = "eventid",
-                EventType = new UAObjectType(new NodeId("type")),
+                EventType = new UAObjectType(new NodeId("type", 0)),
                 Message = "message",
-                SourceNode = new NodeId("source"),
+                SourceNode = new NodeId("source", 0),
                 Time = ts
             };
             evt.EventType.Attributes.DisplayName = "EventType";
@@ -1123,7 +1123,7 @@ namespace Test.Unit
             // With parentId mapping
             conv = evt.ToStatelessCDFEvent(extractor, 123, new Dictionary<NodeId, string>
             {
-                { new NodeId("source"), "source" }
+                { new NodeId("source", 0), "source" }
             });
             Assert.Equal(new[] { "source" }, conv.AssetExternalIds);
 
@@ -1157,12 +1157,12 @@ namespace Test.Unit
 
             var evt = new UAEvent
             {
-                EmittingNode = new NodeId("emitter"),
+                EmittingNode = new NodeId("emitter", 0),
                 MetaData = new Dictionary<string, string>(),
                 EventId = "eventid",
-                EventType = new UAObjectType(new NodeId("type")),
+                EventType = new UAObjectType(new NodeId("type", 0)),
                 Message = "message",
-                SourceNode = new NodeId("source"),
+                SourceNode = new NodeId("source", 0),
                 Time = ts
             };
             evt.MetaData["field"] = "value";
@@ -1171,7 +1171,7 @@ namespace Test.Unit
             // Plain
             var nodeToAsset = new Dictionary<NodeId, long>
             {
-                { new NodeId("source"), 111 }
+                { new NodeId("source", 0), 111 }
             };
 
             var conv = evt.ToCDFEvent(extractor, 123, null);
@@ -1218,11 +1218,11 @@ namespace Test.Unit
 
             var evt = new UAEvent
             {
-                EmittingNode = new NodeId("emitter"),
+                EmittingNode = new NodeId("emitter", 0),
                 EventId = "eventid",
-                EventType = new UAObjectType(new NodeId("type")),
+                EventType = new UAObjectType(new NodeId("type", 0)),
                 Message = "message",
-                SourceNode = new NodeId("source"),
+                SourceNode = new NodeId("source", 0),
                 Time = ts
             };
 
@@ -1230,11 +1230,11 @@ namespace Test.Unit
 
             var rawMeta = new[]
             {
-                new EventFieldValue(new RawTypeField("test-simple"), new NodeId("test")),
-                new EventFieldValue(new RawTypeField("test-complex"), new Variant(new ReadValueId { AttributeId = 1, NodeId = new NodeId("test2") })),
+                new EventFieldValue(new RawTypeField("test-simple"), new NodeId("test", 0)),
+                new EventFieldValue(new RawTypeField("test-complex"), new Variant(new ReadValueId { AttributeId = 1, NodeId = new NodeId("test2", 0) })),
                 new EventFieldValue(new RawTypeField(new QualifiedNameCollection { "deep", "deep-2", "deep-simple" }), 123.123),
                 new EventFieldValue(new RawTypeField(new QualifiedNameCollection { "deep", "deep-2", "deep-complex" }),
-                    new Variant(new ReadValueId { AttributeId = 1, NodeId = new NodeId("test2") })),
+                    new Variant(new ReadValueId { AttributeId = 1, NodeId = new NodeId("test2", 0) })),
                 new EventFieldValue(new RawTypeField(new QualifiedNameCollection { "deep", "deep-2" }), new [] { 1, 2, 3, 4 }),
                 new EventFieldValue(new RawTypeField(new QualifiedNameCollection { "deep", "deep-2", "Value" }), 123.321)
             };
@@ -1258,10 +1258,10 @@ namespace Test.Unit
             var organizes = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes);
             var hasComponent = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.HasComponent);
 
-            var source = new UAObject(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var target = new UAObject(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
-            var sourceVar = new UAVariable(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var targetVar = new UAVariable(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
+            var source = new UAObject(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var target = new UAObject(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
+            var sourceVar = new UAVariable(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var targetVar = new UAVariable(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
             // asset - asset
             var reference = new UAReference(organizes, true, source, target);
             reference.Type.Attributes.DisplayName = "Organizes";
@@ -1291,10 +1291,10 @@ namespace Test.Unit
             var organizes = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes);
             var hasComponent = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.HasComponent);
 
-            var source = new UAObject(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var target = new UAObject(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
-            var sourceVar = new UAVariable(new NodeId("source2"), "Source", "Source", null, NodeId.Null, null);
-            var targetVar = new UAVariable(new NodeId("target2"), "Target", "Target", null, NodeId.Null, null);
+            var source = new UAObject(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var target = new UAObject(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
+            var sourceVar = new UAVariable(new NodeId("source2", 0), "Source", "Source", null, NodeId.Null, null);
+            var targetVar = new UAVariable(new NodeId("target2", 0), "Target", "Target", null, NodeId.Null, null);
 
             var reference = new UAReference(organizes, true, source, target);
             Assert.Equal(reference, reference);
@@ -1320,8 +1320,8 @@ namespace Test.Unit
         {
             using var extractor = tester.BuildExtractor();
             var organizes = tester.Client.TypeManager.GetReferenceType(ReferenceTypeIds.Organizes);
-            var source = new UAObject(new NodeId("source"), "Source", "Source", null, NodeId.Null, null);
-            var target = new UAVariable(new NodeId("target"), "Target", "Target", null, NodeId.Null, null);
+            var source = new UAObject(new NodeId("source", 0), "Source", "Source", null, NodeId.Null, null);
+            var target = new UAVariable(new NodeId("target", 0), "Target", "Target", null, NodeId.Null, null);
 
             var reference = new UAReference(organizes, true, source, target);
             reference.Type.Attributes.DisplayName = "Organizes";

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -920,8 +920,8 @@ namespace Test.Unit
             var nodes = new[]
             {
                 new UAVariable(tester.Server.Ids.Base.DoubleVar1, "DoubleVar1", null, null, tester.Server.Ids.Base.Root, null),
-                new UAVariable(new NodeId("missing-node"), "MissingNode", null, null, tester.Server.Ids.Base.Root, null),
-                new UAVariable(new NodeId("missing-node2"), "MissingNode2", null, null, tester.Server.Ids.Base.Root, null),
+                new UAVariable(new NodeId("missing-node", 0), "MissingNode", null, null, tester.Server.Ids.Base.Root, null),
+                new UAVariable(new NodeId("missing-node2", 0), "MissingNode2", null, null, tester.Server.Ids.Base.Root, null),
             };
 
             await tester.Client.ReadNodeData(nodes, tester.Source.Token);

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -83,9 +83,13 @@ namespace Test.Unit
 
         public async Task DisposeAsync()
         {
-            Source.Cancel();
+            if (Source != null)
+            {
+                await Source.CancelAsync();
+                Source.Dispose();
+                Source = null;
+            }
             await Client.Close(CancellationToken.None);
-            Source.Dispose();
             Server.Stop();
             await Provider.DisposeAsync();
         }

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -1288,7 +1288,7 @@ namespace Test.Unit
             Assert.Equal(new NodeId("string-ns", 2), tester.Client.Context.ToNodeId(nodeId));
             nodeId = new ExpandedNodeId(new byte[] { 12, 12, 6 }, 1);
             Assert.Equal(new NodeId(new byte[] { 12, 12, 6 }, 1), tester.Client.Context.ToNodeId(nodeId));
-            nodeId = new ExpandedNodeId("other-server", "opc.tcp://some-other-server.test", 1);
+            nodeId = new ExpandedNodeId("other-server", 0, "opc.tcp://some-other-server.test", 1);
             Assert.Null(tester.Client.Context.ToNodeId(nodeId));
         }
         [Fact]

--- a/Test/Unit/UAExtractorTest.cs
+++ b/Test/Unit/UAExtractorTest.cs
@@ -121,13 +121,13 @@ namespace Test.Unit
             var ids = tester.Server.Ids.Base;
             var nodes = new List<BaseUANode>
             {
-                new UAObject(new NodeId("object1"), "object1", null, null, root, null),
-                new UAObject(new NodeId("object2"), "object2", null, null, root, null)
+                new UAObject(new NodeId("object1", 0), "object1", null, null, root, null),
+                new UAObject(new NodeId("object2", 0), "object2", null, null, root, null)
             };
             var variables = new List<UAVariable>
             {
-                new UAVariable(new NodeId("var1"), "var1", null, null, root, null),
-                new UAVariable(new NodeId("var2"), "var2", null, null, root, null)
+                new UAVariable(new NodeId("var1", 0), "var1", null, null, root, null),
+                new UAVariable(new NodeId("var2", 0), "var2", null, null, root, null)
             };
 
             variables[0].FullAttributes.ShouldReadHistoryOverride = true;
@@ -176,14 +176,14 @@ namespace Test.Unit
             using var extractor = tester.BuildExtractor();
 
             tester.Config.Extraction.DataTypes.DataTypeMetadata = true;
-            var variable = new UAVariable(new NodeId("test"), "test", null, null, NodeId.Null, null);
+            var variable = new UAVariable(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             var fields = variable.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
             Assert.Single(fields);
             Assert.Equal("Double", fields["dataType"]);
 
             tester.Config.Extraction.NodeTypes.Metadata = true;
-            var node = new UAObject(new NodeId("test"), "test", null, null, NodeId.Null, new UAObjectType(new NodeId("type")));
+            var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, new UAObjectType(new NodeId("type", 0)));
             node.FullAttributes.TypeDefinition.Attributes.DisplayName = "SomeType";
             fields = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
             Assert.Single(fields);
@@ -193,7 +193,7 @@ namespace Test.Unit
             tester.Config.Extraction.NodeTypes.Metadata = false;
 
             tester.Config.Extraction.NodeTypes.AsNodes = true;
-            var type = new UAVariableType(new NodeId("test"), "test", null, null, NodeId.Null);
+            var type = new UAVariableType(new NodeId("test", 0), "test", null, null, NodeId.Null);
             type.FullAttributes.DataType = new UADataType(DataTypeIds.String);
             type.FullAttributes.Value = new Variant("value");
             fields = type.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
@@ -205,15 +205,15 @@ namespace Test.Unit
         {
             tester.Config.Extraction.NodeMap = new Dictionary<string, ProtoNodeId>
             {
-                { "Test1", new NodeId("test").ToProtoNodeId(tester.Client) },
+                { "Test1", new NodeId("test", 0).ToProtoNodeId(tester.Client) },
                 { "Test2", new NodeId("test2", 2).ToProtoNodeId(tester.Client) }
             };
             var ctx = new SessionContext(tester.Config, tester.Log);
             ctx.UpdateFromSession(tester.Client.SessionManager.Session);
 
-            Assert.Equal("Test1", ctx.GetUniqueId(new NodeId("test")));
+            Assert.Equal("Test1", ctx.GetUniqueId(new NodeId("test", 0)));
             Assert.Equal("Test2", ctx.GetUniqueId(new NodeId("test2", 2)));
-            Assert.Equal("Test1[0]", ctx.GetUniqueId(new NodeId("test"), 0));
+            Assert.Equal("Test1[0]", ctx.GetUniqueId(new NodeId("test", 0), 0));
         }
 
         [Fact]

--- a/Test/Unit/UAExtractorTest.cs
+++ b/Test/Unit/UAExtractorTest.cs
@@ -74,7 +74,7 @@ namespace Test.Unit
 
             var task = extractor.RunExtractor();
             await extractor.WaitForSubscriptions();
-            Assert.True(pusher.PushedNodes.Any());
+            Assert.True(pusher.PushedNodes.Count != 0);
             pusher.PushedNodes.Clear();
             await extractor.OnServerReconnect(tester.Client);
 

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -71,7 +71,7 @@ namespace Test.Utils
             await Client.Run(Source.Token, 0);
         }
 
-        private void ResetType(object obj, object reference)
+        private static void ResetType(object obj, object reference)
         {
             if (obj == null) return;
             var type = obj.GetType();
@@ -206,7 +206,7 @@ namespace Test.Utils
 
         public static async Task TerminateRunTask(Task runTask, UAExtractor extractor)
         {
-            if (extractor == null) throw new ArgumentNullException(nameof(extractor));
+            ArgumentNullException.ThrowIfNull(extractor);
             await extractor.Close(false);
             try
             {
@@ -259,9 +259,12 @@ namespace Test.Utils
 
         public virtual async Task DisposeAsync()
         {
-            Source?.Cancel();
-            Source?.Dispose();
-            Source = null;
+            if (Source != null)
+            {
+                await Source.CancelAsync();
+                Source.Dispose();
+                Source = null;
+            }
             if (Client != null)
             {
                 await Client.Close(CancellationToken.None);

--- a/Test/Utils/DummyPusher.cs
+++ b/Test/Utils/DummyPusher.cs
@@ -138,7 +138,7 @@ namespace Test.Utils
                 {
                     int idx = state.IsArray ? 0 : -1;
 
-                    if (DataPoints.TryGetValue((state.SourceId, idx), out var dps) && dps.Any())
+                    if (DataPoints.TryGetValue((state.SourceId, idx), out var dps) && dps.Count != 0)
                     {
                         var (min, max) = dps.MinMax(dp => dp.Timestamp);
                         if (backfillEnabled)

--- a/Test/Utils/EventUtils.cs
+++ b/Test/Utils/EventUtils.cs
@@ -19,7 +19,7 @@ namespace Test.Utils
             ArgumentNullException.ThrowIfNull(tester);
             ArgumentNullException.ThrowIfNull(extractor);
             // Add state
-            var state = new EventExtractionState(tester.Client, new NodeId("emitter"), true, true, true);
+            var state = new EventExtractionState(tester.Client, new NodeId("emitter", 0), true, true, true);
             if (init)
             {
                 state.InitExtractedRange(DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)), DateTime.UtcNow.AddHours(1));
@@ -27,11 +27,11 @@ namespace Test.Utils
             }
             extractor.State.SetEmitterState(state);
 
-            var fields = baseFields.Select(field => new TypeField(new UAVariable(new NodeId(field), field, new QualifiedName(field), null, null, null)));
-            fields = fields.Append(new TypeField(new UAVariable(new NodeId("EUProp"), "EUProp", new QualifiedName("EUProp"), null, null, null)));
-            var type = new UAObjectType(new NodeId("test"), "TestEvent", null, null, null);
+            var fields = baseFields.Select(field => new TypeField(new UAVariable(new NodeId(field, 0), field, new QualifiedName(field), null, null, null)));
+            fields = fields.Append(new TypeField(new UAVariable(new NodeId("EUProp", 0), "EUProp", new QualifiedName("EUProp"), null, null, null)));
+            var type = new UAObjectType(new NodeId("test", 0), "TestEvent", null, null, null);
             type.AllCollectedFields = fields.ToHashSet();
-            extractor.State.ActiveEvents[new NodeId("test")] = type;
+            extractor.State.ActiveEvents[new NodeId("test", 0)] = type;
 
             return state;
         }
@@ -51,8 +51,8 @@ namespace Test.Utils
             return new Variant[]
             {
                 new byte[] { 0, 0, 0, 0, 2 },
-                new NodeId("source"),
-                new NodeId("test"),
+                new NodeId("source", 0),
+                new NodeId("test", 0),
                 new LocalizedText("message"),
                 time,
                 new int[] { 1, 2, 3 },

--- a/Test/Utils/EventUtils.cs
+++ b/Test/Utils/EventUtils.cs
@@ -16,8 +16,8 @@ namespace Test.Utils
 
         public static EventExtractionState PopulateEventData(UAExtractor extractor, BaseExtractorTestFixture tester, bool init)
         {
-            if (tester == null) throw new ArgumentNullException(nameof(tester));
-            if (extractor == null) throw new ArgumentNullException(nameof(extractor));
+            ArgumentNullException.ThrowIfNull(tester);
+            ArgumentNullException.ThrowIfNull(extractor);
             // Add state
             var state = new EventExtractionState(tester.Client, new NodeId("emitter"), true, true, true);
             if (init)
@@ -38,7 +38,7 @@ namespace Test.Utils
 
         public static SimpleAttributeOperandCollection GetSelectClause(BaseExtractorTestFixture tester)
         {
-            if (tester == null) throw new ArgumentNullException(nameof(tester));
+            ArgumentNullException.ThrowIfNull(tester);
             var attrs = baseFields.Select(field => new SimpleAttributeOperand(ObjectTypeIds.BaseEventType, new QualifiedName(field)));
             attrs = attrs.Append(new SimpleAttributeOperand(tester.Server.Ids.Custom.Array, new QualifiedName("Array"))); // some other field
             attrs = attrs.Append(new SimpleAttributeOperand(tester.Server.Ids.Custom.EUProp, new QualifiedName("EUProp")));


### PR DESCRIPTION
Yes, somehow 700 lines of code. The OPC-UA SDK devs really like to make subtle breaking changes on public methods in patch versions, and here they made one that affected 500 method calls in tests.