### PR TITLE
Restart history when subscriptions are recreated

### DIFF
--- a/ConfigurationTool/Checks/Events.cs
+++ b/ConfigurationTool/Checks/Events.cs
@@ -147,7 +147,8 @@ namespace Cognite.OpcUa.Config
                 var task = new EventSubscriptionTask(
                         (item, args) => { },
                         states.Take(baseConfig.Source.SubscriptionChunk),
-                        BuildEventFilter(TypeManager.EventFields));
+                        BuildEventFilter(TypeManager.EventFields),
+                        Callbacks);
 
                 await ToolUtil.RunWithTimeout(task.Run(log, SessionManager, Config, SubscriptionManager!, token), 120);
             }

--- a/ConfigurationTool/Checks/Subscriptions.cs
+++ b/ConfigurationTool/Checks/Subscriptions.cs
@@ -104,7 +104,8 @@ namespace Cognite.OpcUa.Config
                 {
                     var task = new DataPointSubscriptionTask(
                         ToolUtil.GetSimpleListWriterHandler(dps, states.ToDictionary(state => state.SourceId), this, log, true),
-                        states.Take(chunkSize));
+                        states.Take(chunkSize),
+                        Callbacks);
 
                     await ToolUtil.RunWithTimeout(task.Run(log, SessionManager, Config, SubscriptionManager!, token), 120);
                     baseConfig.Source.SubscriptionChunk = chunkSize;

--- a/ConfigurationTool/UAServerExplorer.cs
+++ b/ConfigurationTool/UAServerExplorer.cs
@@ -17,6 +17,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
 
 using Cognite.Extractor.Common;
 using Cognite.OpcUa.Nodes;
+using Cognite.OpcUa.Subscriptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
@@ -267,6 +268,14 @@ namespace Cognite.OpcUa.Config
         public Task OnServicelevelBelowThreshold(UAClient source)
         {
             return Task.CompletedTask;
+        }
+
+        public void OnSubscriptionFailure(SubscriptionName subscription)
+        {
+        }
+
+        public void OnCreatedSubscription(SubscriptionName subscription)
+        {
         }
 
         public FullConfig FinalConfig => baseConfig;

--- a/Extractor/History/HistoryReader.cs
+++ b/Extractor/History/HistoryReader.cs
@@ -306,21 +306,19 @@ namespace Cognite.OpcUa.History
 
         public void AddStates(IEnumerable<VariableExtractionState> varStates, IEnumerable<EventExtractionState> eventStates)
         {
-            bool shouldTrigger = false;
             lock (statesLock)
             {
                 foreach (var state in varStates.Where(s => s.FrontfillEnabled))
                 {
-                    shouldTrigger |= activeVarStates.TryAdd(state.SourceId, state);
+                    activeVarStates[state.SourceId] = state;
                 }
 
                 foreach (var state in eventStates.Where(s => s.FrontfillEnabled))
                 {
-                    shouldTrigger |= activeEventStates.TryAdd(state.SourceId, state);
+                    activeEventStates[state.SourceId] = state;
                 }
-                shouldTrigger &= state.IsGood;
             }
-            if (shouldTrigger)
+            if (state.IsGood)
             {
                 stateChangedEvent.Set();
             }

--- a/Extractor/History/HistoryReader.cs
+++ b/Extractor/History/HistoryReader.cs
@@ -18,48 +18,65 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
 using Cognite.Extractor.Common;
 using Cognite.OpcUa.Config;
 using Cognite.OpcUa.TypeCollectors;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
+using Opc.Ua;
 using System;
 using System.Collections.Generic;
+using System.CommandLine.Parsing;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Cognite.OpcUa.History
 {
+
+
+
     public sealed class HistoryReader : IDisposable
     {
         private readonly UAClient uaClient;
         private readonly UAExtractor extractor;
-        private readonly HistoryConfig config;
+        private readonly FullConfig config;
         private readonly TypeManager typeManager;
         private CancellationTokenSource source;
+        private CancellationTokenSource? runTaskSource;
         // private ILogger log = Log.Logger.ForContext<HistoryReader>();
         private readonly TaskThrottler throttler;
         private readonly BlockingResourceCounter continuationPoints;
-
         private readonly OperationWaiter waiter;
-
         private readonly ILogger<HistoryReader> log;
 
+        private readonly Dictionary<NodeId, VariableExtractionState> activeVarStates = new();
+        private readonly Dictionary<NodeId, EventExtractionState> activeEventStates = new();
+        private readonly object statesLock = new();
+
+        public bool IsRunning => runTaskSource != null;
+
         public HistoryReader(ILogger<HistoryReader> log,
-            UAClient uaClient, UAExtractor extractor, TypeManager typeManager, HistoryConfig config, CancellationToken token)
+            UAClient uaClient, UAExtractor extractor, TypeManager typeManager, FullConfig config, CancellationToken token)
         {
             this.log = log;
             this.config = config;
             this.uaClient = uaClient;
             this.extractor = extractor;
             this.typeManager = typeManager;
-            var throttling = config.Throttling;
+            var throttling = config.History.Throttling;
             throttler = new TaskThrottler(throttling.MaxParallelism, false, throttling.MaxPerMinute, TimeSpan.FromMinutes(1));
             source = CancellationTokenSource.CreateLinkedTokenSource(token);
             continuationPoints = new BlockingResourceCounter(
                 throttling.MaxNodeParallelism > 0 ? throttling.MaxNodeParallelism : 1_000);
             waiter = new OperationWaiter();
+            state = new State(config);
         }
 
-        private async Task Run(IEnumerable<UAHistoryExtractionState> states, HistoryReadType type)
+        private async Task RunHistoryBatch(IEnumerable<UAHistoryExtractionState> states, HistoryReadType type)
         {
-            using var scheduler = new HistoryScheduler(log, uaClient, extractor, typeManager, config, type,
+            using var scheduler = new HistoryScheduler(log, uaClient, extractor, typeManager, config.History, type,
                 throttler, continuationPoints, states, source.Token);
 
             using var op = waiter.GetInstance();
@@ -76,58 +93,264 @@ namespace Cognite.OpcUa.History
 
         public void MaxNodeParallelismChanged()
         {
-            continuationPoints.SetCapacity(config.Throttling.MaxNodeParallelism > 0 ? config.Throttling.MaxNodeParallelism : 1_000);
+            continuationPoints.SetCapacity(config.History.Throttling.MaxNodeParallelism > 0 ? config.History.Throttling.MaxNodeParallelism : 1_000);
         }
 
-        /// <summary>
-        /// Frontfill data for the given list of states. Chunks by time granularity and given chunksizes.
-        /// </summary>
-        /// <param name="states">Nodes to be read</param>
-        public async Task FrontfillData(IEnumerable<VariableExtractionState> states)
+        private readonly AutoResetEvent stateChangedEvent = new AutoResetEvent(true);
+
+        private Task? activeTask;
+
+        public async Task Run(CancellationToken token)
         {
-            await Run(states, HistoryReadType.FrontfillData);
+            if (runTaskSource != null) throw new InvalidOperationException("Attempt to start history reader more than once");
+            runTaskSource = CancellationTokenSource.CreateLinkedTokenSource(token);
+            var waitTask = CommonUtils.WaitAsync(stateChangedEvent, Timeout.InfiniteTimeSpan, runTaskSource.Token);
+            while (!runTaskSource.Token.IsCancellationRequested)
+            {
+                if (activeTask != null)
+                {
+                    var res = await Task.WhenAny(activeTask, waitTask);
+
+                    if (runTaskSource.IsCancellationRequested) break;
+
+                    if (res == activeTask)
+                    {
+                        if (res.Exception != null && !typeof(OperationCanceledException).IsAssignableFrom(res.Exception.GetType()))
+                        {
+                            ExceptionDispatchInfo.Capture(res.Exception).Throw();
+                        }
+
+                        activeTask = null;
+                        continue;
+                    }
+                }
+                else
+                {
+                    await waitTask;
+                    if (runTaskSource.IsCancellationRequested) break;
+                }
+
+                waitTask = CommonUtils.WaitAsync(stateChangedEvent, Timeout.InfiniteTimeSpan, runTaskSource.Token);
+
+                if (activeTask != null)
+                {
+                    log.LogInformation("Received event, stopping history");
+
+                    await Terminate(runTaskSource.Token);
+
+                    var res = await Task.WhenAny(activeTask, Task.Delay(5, runTaskSource.Token));
+                    if (res != activeTask)
+                    {
+                        log.LogWarning("Timed out waiting for active history task to complete");
+                    }
+                    else if (res.Exception != null && !typeof(OperationCanceledException).IsAssignableFrom(res.Exception.GetType()))
+                    {
+                        ExceptionDispatchInfo.Capture(res.Exception).Throw();
+                    }
+                }
+
+                RestartHistoryInStates();
+
+                if (state.IsGood)
+                {
+                    log.LogInformation("State is good: {State}, starting history read", state);
+
+                    activeTask = RunAllHistory();
+                }
+                else
+                {
+                    log.LogInformation("State is bad: {State}, starting history once status improves", state);
+                }
+            }
+            await Terminate(token);
+            runTaskSource = null;
         }
-        /// <summary>
-        /// Backfill data for the given list of states. Chunks by time granularity and given chunksizes.
-        /// </summary>
-        /// <param name="states">Nodes to be read</param>
-        public async Task BackfillData(IEnumerable<VariableExtractionState> states)
+
+        private async Task RunAllHistory()
         {
-            await Run(states, HistoryReadType.BackfillData);
+            IEnumerable<EventExtractionState> eventStates;
+            IEnumerable<VariableExtractionState> variableStates;
+
+            lock (statesLock)
+            {
+                eventStates = activeEventStates.Values.ToArray();
+                variableStates = activeVarStates.Values.ToArray();
+            }
+
+            var tasks = new List<Task>();
+
+            if (!config.History.Enabled) return;
+
+            if (config.History.Data && variableStates.Any())
+            {
+                tasks.Add(Task.Run(async () =>
+                {
+                    await RunHistoryBatch(variableStates, HistoryReadType.FrontfillData);
+                    if (config.History.Backfill)
+                    {
+                        await RunHistoryBatch(variableStates, HistoryReadType.BackfillData);
+                    }
+                }));
+            }
+            if (config.Events.History && eventStates.Any())
+            {
+                tasks.Add(Task.Run(async () =>
+                {
+                    await RunHistoryBatch(eventStates, HistoryReadType.FrontfillEvents);
+                    if (config.History.Backfill)
+                    {
+                        await RunHistoryBatch(eventStates, HistoryReadType.BackfillEvents);
+                    }
+                }));
+            }
+            await Task.WhenAll(tasks);
         }
-        /// <summary>
-        /// Frontfill events for the given list of states. Chunks by time granularity and given chunksizes.
-        /// </summary>
-        /// <param name="states">Emitters to be read from</param>
-        /// <param name="nodes">SourceNodes to read for</param>
-        public async Task FrontfillEvents(IEnumerable<EventExtractionState> states)
-        {
-            await Run(states, HistoryReadType.FrontfillEvents);
-        }
-        /// <summary>
-        /// Backfill events for the given list of states. Chunks by time granularity and given chunksizes.
-        /// </summary>
-        /// <param name="states">Emitters to be read from</param>
-        /// <param name="nodes">SourceNodes to read for</param>
-        public async Task BackfillEvents(IEnumerable<EventExtractionState> states)
-        {
-            await Run(states, HistoryReadType.BackfillEvents);
-        }
+
         private readonly SemaphoreSlim terminateSem = new SemaphoreSlim(1);
+
+        class State
+        {
+            private HashSet<StateIssue> issues = new();
+
+            public bool AddIssue(StateIssue issue)
+            {
+                return issues.Add(issue);
+            }
+
+            public bool RemoveIssue(StateIssue issue)
+            {
+                return issues.Remove(issue);
+            }
+
+            public State(FullConfig config)
+            {
+                if (config.Subscriptions.Events && config.Events.Enabled && config.Events.History)
+                {
+                    issues.Add(StateIssue.EventSubscription);
+                }
+                if (config.Subscriptions.DataPoints && config.History.Data)
+                {
+                    issues.Add(StateIssue.DataPointSubscription);
+                }
+                issues.Add(StateIssue.NodeHierarchyRead);
+            }
+
+            public bool IsGood => issues.Count == 0;
+
+            public override string ToString()
+            {
+                if (IsGood)
+                {
+                    return "Good";
+                }
+
+                return "Bad. Issues: " + string.Join(", ", issues);
+            }
+        }
+
+        private readonly State state;
+
+        public enum StateIssue
+        {
+            ServiceLevel,
+            ServerConnection,
+            DataPointSubscription,
+            EventSubscription,
+            NodeHierarchyRead
+        }
+
+        private void RestartHistoryInStates()
+        {
+            lock (statesLock)
+            {
+                foreach (var state in activeVarStates)
+                {
+                    state.Value.RestartHistory();
+                }
+                foreach (var state in activeEventStates)
+                {
+                    state.Value.RestartHistory();
+                }
+            }
+        }
+
+        public void RemoveIssue(StateIssue issue)
+        {
+            bool stateOk = state.IsGood;
+
+            if (state.RemoveIssue(issue))
+            {
+                log.LogDebug("Removed history issue: {Issue}. New state: {State}", issue, state);
+            }
+
+            if (stateOk != state.IsGood)
+            {
+                stateChangedEvent.Set();
+            }
+        }
+
+        public void AddIssue(StateIssue issue)
+        {
+            bool stateOk = state.IsGood;
+
+            if (state.AddIssue(issue))
+            {
+                log.LogDebug("Added history issue: {Issue}. New state: {State}", issue, state);
+            }
+
+            if (stateOk != state.IsGood)
+            {
+                stateChangedEvent.Set();
+            }
+        }
+
+        public void AddStates(IEnumerable<VariableExtractionState> varStates, IEnumerable<EventExtractionState> eventStates)
+        {
+            bool shouldTrigger = false;
+            lock (statesLock)
+            {
+                foreach (var state in varStates.Where(s => s.FrontfillEnabled))
+                {
+                    shouldTrigger |= activeVarStates.TryAdd(state.SourceId, state);
+                }
+
+                foreach (var state in eventStates.Where(s => s.FrontfillEnabled))
+                {
+                    shouldTrigger |= activeEventStates.TryAdd(state.SourceId, state);
+                }
+                shouldTrigger &= state.IsGood;
+            }
+            if (shouldTrigger)
+            {
+                stateChangedEvent.Set();
+            }
+        }
+
+        public void RequestRestart()
+        {
+            stateChangedEvent.Set();
+        }
+
+        public async Task RequestRestartWaitForTermination(CancellationToken token)
+        {
+            await Terminate(token);
+            RestartHistoryInStates();
+            stateChangedEvent.Set();
+        }
 
         /// <summary>
         /// Request the history read terminate, then wait for all operations to finish before quitting.
         /// </summary>
         /// <param name="timeoutsec">Timeout in seconds</param>
         /// <returns>True if successfully aborted, false if waiting timed out</returns>
-        public async Task<bool> Terminate(CancellationToken token, int timeoutsec = 30)
+        private async Task<bool> Terminate(CancellationToken token, int timeoutsec = 30)
         {
             await terminateSem.WaitAsync(token);
             try
             {
                 source.Cancel();
                 log.LogInformation("Terminating any active history reads");
-                bool timedOut = await waiter.Wait(timeoutsec * 1000, token);
+                bool timedOut = !await waiter.Wait(timeoutsec * 1000, token);
                 if (timedOut)
                 {
                     log.LogWarning("Terminating history reads timed out after {Timeout} seconds", timeoutsec);
@@ -149,13 +372,14 @@ namespace Cognite.OpcUa.History
             {
                 terminateSem.Release();
             }
-
         }
 
         public void Dispose()
         {
             source.Cancel();
             source.Dispose();
+            runTaskSource?.Cancel();
+            runTaskSource?.Dispose();
             waiter.Dispose();
             throttler.Dispose();
         }

--- a/Extractor/IClientCallbacks.cs
+++ b/Extractor/IClientCallbacks.cs
@@ -1,4 +1,5 @@
 ﻿using Cognite.Extractor.Common;
+using Cognite.OpcUa.Subscriptions;
 using System.Threading.Tasks;
 
 namespace Cognite.OpcUa
@@ -28,5 +29,17 @@ namespace Cognite.OpcUa
         /// the configured threshold.
         /// </summary>
         Task OnServicelevelBelowThreshold(UAClient source);
+
+        /// <summary>
+        /// Invoked when a subscription is dropped.
+        /// </summary>
+        /// <param name="subscription">Dropped subscription</param>
+        void OnSubscriptionFailure(SubscriptionName subscription);
+
+        /// <summary>
+        /// Invoked when a subscription is created or recreated.
+        /// </summary>
+        /// <param name="subscription"></param>
+        void OnCreatedSubscription(SubscriptionName subscription);
     }
 }

--- a/Extractor/NodeMetricsManager.cs
+++ b/Extractor/NodeMetricsManager.cs
@@ -157,7 +157,8 @@ namespace Cognite.OpcUa
 
             client.SubscriptionManager.EnqueueTask(new NodeMetricsSubscriptionTask(
                 SubscriptionHandler,
-                metrics));
+                metrics,
+                client.Callbacks));
         }
         /// <summary>
         /// Converts datapoint callback to metric value

--- a/Extractor/RebrowseTriggerManager.cs
+++ b/Extractor/RebrowseTriggerManager.cs
@@ -303,7 +303,7 @@ namespace Cognite.OpcUa
                 throw new InvalidOperationException("Client not initialized");
 
             _uaClient.SubscriptionManager.EnqueueTask(
-                new RebrowseTriggerSubscriptionTask(OnRebrowseTriggerNotification(token), nodes)
+                new RebrowseTriggerSubscriptionTask(OnRebrowseTriggerNotification(token), nodes, _extractor)
             );
         }
     }

--- a/Extractor/SessionManager.cs
+++ b/Extractor/SessionManager.cs
@@ -689,7 +689,7 @@ namespace Cognite.OpcUa
 
         public void EnsureServiceLevelSubscription()
         {
-            client.SubscriptionManager!.EnqueueTask(new ServiceLevelSubscriptionTask(OnServiceLevelUpdate));
+            client.SubscriptionManager!.EnqueueTask(new ServiceLevelSubscriptionTask(OnServiceLevelUpdate, client.Callbacks));
         }
 
         protected virtual void Dispose(bool disposing)

--- a/Extractor/SessionManager.cs
+++ b/Extractor/SessionManager.cs
@@ -614,7 +614,7 @@ namespace Cognite.OpcUa
                     await client.Callbacks.OnServicelevelBelowThreshold(client);
                 }
             }
-            else if (oldServiceLevel < config.Redundancy.ServiceLevelThreshold && !fromConnectionChange)
+            else if (oldServiceLevel < config.Redundancy.ServiceLevelThreshold)
             {
                 // We have moved from being at low SL to high, so we should restart history before we set the service level.
                 log.LogInformation("New service level {Level} is a above threshold {Threshold}, triggering callback", newLevel, config.Redundancy.ServiceLevelThreshold);

--- a/Extractor/Subscriptions/AuditSubscriptionTask.cs
+++ b/Extractor/Subscriptions/AuditSubscriptionTask.cs
@@ -12,11 +12,11 @@ namespace Cognite.OpcUa.Subscriptions
     public class AuditSubscriptionTask : BaseCreateSubscriptionTask<string>
     {
         private readonly MonitoredItemNotificationEventHandler handler;
-        public AuditSubscriptionTask(MonitoredItemNotificationEventHandler handler)
+        public AuditSubscriptionTask(MonitoredItemNotificationEventHandler handler, IClientCallbacks callbacks)
             : base(SubscriptionName.Audit, new Dictionary<NodeId, string>
             {
                 { ObjectIds.Server, "Audit: Server" }
-            })
+            }, callbacks)
         {
             this.handler = handler;
         }

--- a/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
+++ b/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
@@ -14,7 +14,8 @@ namespace Cognite.OpcUa.Subscriptions
 {
     public abstract class BaseCreateSubscriptionTask<T> : PendingSubscriptionTask
     {
-        protected SubscriptionName SubscriptionName { get; }
+        public override SubscriptionName SubscriptionToCreate => SubscriptionName;
+        public SubscriptionName SubscriptionName { get; }
         protected Dictionary<NodeId, T> Items { get; }
         private static readonly Gauge numSubscriptions = Metrics
             .CreateGauge("opcua_subscriptions", "Number of active monitored items");

--- a/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
+++ b/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
@@ -16,14 +16,16 @@ namespace Cognite.OpcUa.Subscriptions
     {
         public override SubscriptionName SubscriptionToCreate => SubscriptionName;
         public SubscriptionName SubscriptionName { get; }
+        protected IClientCallbacks Callbacks { get; }
         protected Dictionary<NodeId, T> Items { get; }
         private static readonly Gauge numSubscriptions = Metrics
             .CreateGauge("opcua_subscriptions", "Number of active monitored items");
 
-        protected BaseCreateSubscriptionTask(SubscriptionName name, Dictionary<NodeId, T> items)
+        protected BaseCreateSubscriptionTask(SubscriptionName name, Dictionary<NodeId, T> items, IClientCallbacks callbacks)
         {
             SubscriptionName = name;
             Items = items;
+            Callbacks = callbacks;
         }
 
         protected abstract MonitoredItem CreateMonitoredItem(T item, FullConfig config);
@@ -201,6 +203,7 @@ namespace Cognite.OpcUa.Subscriptions
                 ex => config.Source.Retries.ShouldRetryException(ex, outerStatusCodes),
                 logger,
                 token);
+            Callbacks.OnCreatedSubscription(SubscriptionName);
             logger.LogDebug("Finished creating subscription {Name}", SubscriptionName);
         }
     }

--- a/Extractor/Subscriptions/DataPointSubscriptionTask.cs
+++ b/Extractor/Subscriptions/DataPointSubscriptionTask.cs
@@ -17,8 +17,8 @@ namespace Cognite.OpcUa.Subscriptions
     public class DataPointSubscriptionTask : BaseCreateSubscriptionTask<VariableExtractionState>
     {
         private readonly MonitoredItemNotificationEventHandler handler;
-        public DataPointSubscriptionTask(MonitoredItemNotificationEventHandler handler, IEnumerable<VariableExtractionState> states)
-            : base(SubscriptionName.DataPoints, states.ToDictionary(s => s.SourceId))
+        public DataPointSubscriptionTask(MonitoredItemNotificationEventHandler handler, IEnumerable<VariableExtractionState> states, IClientCallbacks callbacks)
+            : base(SubscriptionName.DataPoints, states.ToDictionary(s => s.SourceId), callbacks)
         {
             this.handler = handler;
         }

--- a/Extractor/Subscriptions/EventSubscriptionTask.cs
+++ b/Extractor/Subscriptions/EventSubscriptionTask.cs
@@ -18,8 +18,9 @@ namespace Cognite.OpcUa.Subscriptions
         public EventSubscriptionTask(
             MonitoredItemNotificationEventHandler handler,
             IEnumerable<EventExtractionState> states,
-            EventFilter filter)
-            : base(SubscriptionName.Events, states.ToDictionary(s => s.SourceId))
+            EventFilter filter,
+            IClientCallbacks callbacks)
+            : base(SubscriptionName.Events, states.ToDictionary(s => s.SourceId), callbacks)
         {
             this.filter = filter;
             this.handler = handler;

--- a/Extractor/Subscriptions/NodeMetricsSubscriptionTask.cs
+++ b/Extractor/Subscriptions/NodeMetricsSubscriptionTask.cs
@@ -14,8 +14,8 @@ namespace Cognite.OpcUa.Subscriptions
     internal class NodeMetricsSubscriptionTask : BaseCreateSubscriptionTask<NodeMetricState>
     {
         private readonly MonitoredItemNotificationEventHandler handler;
-        public NodeMetricsSubscriptionTask(MonitoredItemNotificationEventHandler handler, Dictionary<NodeId, NodeMetricState> states)
-            : base(SubscriptionName.NodeMetrics, states)
+        public NodeMetricsSubscriptionTask(MonitoredItemNotificationEventHandler handler, Dictionary<NodeId, NodeMetricState> states, IClientCallbacks callbacks)
+            : base(SubscriptionName.NodeMetrics, states, callbacks)
         {
             this.handler = handler;
         }

--- a/Extractor/Subscriptions/RebrowseTriggerSubscriptionTask.cs
+++ b/Extractor/Subscriptions/RebrowseTriggerSubscriptionTask.cs
@@ -12,8 +12,10 @@ namespace Cognite.OpcUa.Subscriptions
     {
         private MonitoredItemNotificationEventHandler handler;
 
-        public RebrowseTriggerSubscriptionTask(MonitoredItemNotificationEventHandler handler,
-            Dictionary<NodeId, (NodeId, string)> ids) : base(SubscriptionName.RebrowseTriggers, ids)
+        public RebrowseTriggerSubscriptionTask(
+            MonitoredItemNotificationEventHandler handler,
+            Dictionary<NodeId, (NodeId, string)> ids,
+            IClientCallbacks callbacks) : base(SubscriptionName.RebrowseTriggers, ids, callbacks)
         {
             this.handler = handler;
         }

--- a/Extractor/Subscriptions/RecreateSubscriptionTask.cs
+++ b/Extractor/Subscriptions/RecreateSubscriptionTask.cs
@@ -16,10 +16,11 @@ namespace Cognite.OpcUa.Subscriptions
 
         public override string TaskName => $"Recreate subscription {oldSubscription.Id}";
 
-        public RecreateSubscriptionTask(Subscription oldSubscription, SubscriptionName subscription)
-            : base(subscription, new Dictionary<Opc.Ua.NodeId, MonitoredItem>())
+        public RecreateSubscriptionTask(Subscription oldSubscription, SubscriptionName subscription, IClientCallbacks callbacks)
+            : base(subscription, new Dictionary<NodeId, MonitoredItem>(), callbacks)
         {
             this.oldSubscription = oldSubscription;
+            callbacks.OnSubscriptionFailure(subscription);
         }
 
 
@@ -29,7 +30,11 @@ namespace Cognite.OpcUa.Subscriptions
             // If the session is currently unset, we will recreate all subscriptions eventually,
             // so no point to doing it now.
             if (session == null) return false;
-            if (!oldSubscription.PublishingStopped) return false;
+            if (!oldSubscription.PublishingStopped)
+            {
+                Callbacks.OnCreatedSubscription(SubscriptionName);
+                return false;
+            }
             if (!session.Subscriptions.Any(s => s.Id == oldSubscription.Id)) return false;
             try
             {

--- a/Extractor/Subscriptions/RecreateSubscriptionTask.cs
+++ b/Extractor/Subscriptions/RecreateSubscriptionTask.cs
@@ -16,8 +16,8 @@ namespace Cognite.OpcUa.Subscriptions
 
         public override string TaskName => $"Recreate subscription {oldSubscription.Id}";
 
-        public RecreateSubscriptionTask(Subscription oldSubscription)
-            : base(Enum.Parse<SubscriptionName>(oldSubscription.DisplayName.Split(' ').First()), new Dictionary<Opc.Ua.NodeId, MonitoredItem>())
+        public RecreateSubscriptionTask(Subscription oldSubscription, SubscriptionName subscription)
+            : base(subscription, new Dictionary<Opc.Ua.NodeId, MonitoredItem>())
         {
             this.oldSubscription = oldSubscription;
         }

--- a/Extractor/Subscriptions/ServiceLevelSubscriptionTask.cs
+++ b/Extractor/Subscriptions/ServiceLevelSubscriptionTask.cs
@@ -13,8 +13,8 @@ namespace Cognite.OpcUa.Subscriptions
     internal class ServiceLevelSubscriptionTask : BaseCreateSubscriptionTask<NodeId>
     {
         private MonitoredItemNotificationEventHandler handler;
-        public ServiceLevelSubscriptionTask(MonitoredItemNotificationEventHandler handler)
-            : base(SubscriptionName.ServiceLevel, new Dictionary<NodeId, NodeId> { { VariableIds.Server_ServiceLevel, VariableIds.Server_ServiceLevel } })
+        public ServiceLevelSubscriptionTask(MonitoredItemNotificationEventHandler handler, IClientCallbacks callbacks)
+            : base(SubscriptionName.ServiceLevel, new Dictionary<NodeId, NodeId> { { VariableIds.Server_ServiceLevel, VariableIds.Server_ServiceLevel } }, callbacks)
         {
             this.handler = handler;
         }

--- a/Extractor/Subscriptions/SubscriptionManager.cs
+++ b/Extractor/Subscriptions/SubscriptionManager.cs
@@ -1,5 +1,6 @@
 ﻿using Cognite.Extractor.Common;
 using Cognite.OpcUa.Config;
+using Cognite.OpcUa.History;
 using Microsoft.Extensions.Logging;
 using Opc.Ua.Client;
 using System;
@@ -14,6 +15,8 @@ namespace Cognite.OpcUa.Subscriptions
     {
         public abstract string TaskName { get; }
 
+        public abstract SubscriptionName SubscriptionToCreate { get; }
+
         public abstract Task<bool> ShouldRun(ILogger logger, SessionManager sessionManager, CancellationToken token);
 
         public abstract Task Run(ILogger logger, SessionManager sessionManager, FullConfig config, SubscriptionManager subscriptionManager, CancellationToken token);
@@ -23,7 +26,7 @@ namespace Cognite.OpcUa.Subscriptions
 
     public class SubscriptionManager
     {
-        private readonly SessionManager sessionManager;
+        private readonly UAClient client;
         private readonly FullConfig config;
 
         private readonly ILogger logger;
@@ -34,9 +37,9 @@ namespace Cognite.OpcUa.Subscriptions
 
         public SubscriptionStateCache Cache { get; } = new();
 
-        public SubscriptionManager(SessionManager sessionManager, FullConfig config, ILogger logger)
+        public SubscriptionManager(UAClient client, FullConfig config, ILogger logger)
         {
-            this.sessionManager = sessionManager;
+            this.client = client;
             this.config = config;
             this.logger = logger;
         }
@@ -52,7 +55,11 @@ namespace Cognite.OpcUa.Subscriptions
                 return;
             }
 
-            EnqueueTaskEnsureUnique(new RecreateSubscriptionTask(sub));
+            var subName = Enum.Parse<SubscriptionName>(sub.DisplayName.Split(' ').First());
+
+            client.Callbacks.OnSubscriptionFailure(subName);
+
+            EnqueueTaskEnsureUnique(new RecreateSubscriptionTask(sub, subName));
         }
 
         public void EnqueueTaskEnsureUnique(PendingSubscriptionTask task)
@@ -97,9 +104,10 @@ namespace Cognite.OpcUa.Subscriptions
         {
             try
             {
-                if (!await task.ShouldRun(logger, sessionManager, token)) return;
+                if (!await task.ShouldRun(logger, client.SessionManager, token)) return;
 
-                await task.Run(logger, sessionManager, config, this, token);
+                await task.Run(logger, client.SessionManager, config, this, token);
+                client.Callbacks.OnCreatedSubscription(task.SubscriptionToCreate);
             }
             finally
             {

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -235,7 +235,7 @@ namespace Cognite.OpcUa
 
             if (SubscriptionManager == null)
             {
-                SubscriptionManager = new SubscriptionManager(SessionManager, Config, log);
+                SubscriptionManager = new SubscriptionManager(this, Config, log);
                 Callbacks.TaskScheduler.ScheduleTask("SubscriptionManager", SubscriptionManager.RunTaskLoop);
             }
 

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -1228,6 +1228,15 @@ namespace Cognite.OpcUa
         }
         #endregion
 
+        protected override async ValueTask DisposeAsyncCore()
+        {
+            Starting.Set(0);
+            historyReader?.Dispose();
+            pubSubManager?.Dispose();
+
+            await base.DisposeAsyncCore();
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -674,7 +674,8 @@ namespace Cognite.OpcUa
                 uaClient.SubscriptionManager.EnqueueTask(new EventSubscriptionTask(
                     Streamer.EventSubscriptionHandler,
                     subscribeStates,
-                    uaClient.BuildEventFilter(TypeManager.EventFields)));
+                    uaClient.BuildEventFilter(TypeManager.EventFields),
+                    this));
             }
 
             if (Config.Subscriptions.DataPoints)
@@ -683,7 +684,8 @@ namespace Cognite.OpcUa
 
                 uaClient.SubscriptionManager.EnqueueTask(new DataPointSubscriptionTask(
                     Streamer.DataSubscriptionHandler,
-                    subscribeStates));
+                    subscribeStates,
+                    this));
             }
 
             if (rebrowseTriggerManager is not null)
@@ -1046,7 +1048,8 @@ namespace Cognite.OpcUa
                 await uaClient.SubscriptionManager.EnqueueTaskAndWait(new EventSubscriptionTask(
                     Streamer.EventSubscriptionHandler,
                     subscribeStates,
-                    uaClient.BuildEventFilter(TypeManager.EventFields)),
+                    uaClient.BuildEventFilter(TypeManager.EventFields),
+                    this),
                     Source.Token);
             }
 
@@ -1068,7 +1071,8 @@ namespace Cognite.OpcUa
 
                 await uaClient.SubscriptionManager.EnqueueTaskAndWait(new DataPointSubscriptionTask(
                     Streamer.DataSubscriptionHandler,
-                    subscribeStates),
+                    subscribeStates,
+                    this),
                     Source.Token);
             }
 
@@ -1103,7 +1107,7 @@ namespace Cognite.OpcUa
             {
                 if (uaClient.SubscriptionManager == null) throw new InvalidOperationException("Client not initialized");
 
-                tasks.Add(token => uaClient.SubscriptionManager.EnqueueTaskAndWait(new AuditSubscriptionTask(AuditEventSubscriptionHandler), token));
+                tasks.Add(token => uaClient.SubscriptionManager.EnqueueTaskAndWait(new AuditSubscriptionTask(AuditEventSubscriptionHandler, this), token));
             }
             return tasks;
         }

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -63,7 +63,7 @@ namespace Cognite.OpcUa
         private readonly ConcurrentQueue<NodeId> extraNodesToBrowse = new ConcurrentQueue<NodeId>();
         public IEnumerable<NodeTransformation>? Transformations { get; private set; }
         public StringConverter StringConverter => uaClient.StringConverter;
-        private readonly PubSubManager? pubSubManager;
+        private PubSubManager? pubSubManager;
         public NamespaceTable? NamespaceTable => uaClient.NamespaceTable;
 
         public TypeManager TypeManager => uaClient.TypeManager;
@@ -1232,7 +1232,9 @@ namespace Cognite.OpcUa
         {
             Starting.Set(0);
             historyReader?.Dispose();
+            historyReader = null;
             pubSubManager?.Dispose();
+            pubSubManager = null;
 
             await base.DisposeAsyncCore();
         }
@@ -1243,7 +1245,9 @@ namespace Cognite.OpcUa
             {
                 Starting.Set(0);
                 historyReader?.Dispose();
+                historyReader = null;
                 pubSubManager?.Dispose();
+                pubSubManager = null;
             }
             base.Dispose(disposing);
         }

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -1047,8 +1047,7 @@ namespace Cognite.OpcUa
                     Streamer.EventSubscriptionHandler,
                     subscribeStates,
                     uaClient.BuildEventFilter(TypeManager.EventFields)),
-                    Source.Token
-                    );
+                    Source.Token);
             }
 
             Interlocked.Increment(ref subscribed);

--- a/ExtractorLauncher/Program.cs
+++ b/ExtractorLauncher/Program.cs
@@ -91,6 +91,7 @@ namespace Cognite.OpcUa
         // For testing
         public static bool CommandDryRun { get; set; }
         public static Action<ServiceCollection, BaseExtractorParams>? OnLaunch { get; set; }
+        public static CancellationToken? RootToken { get; set; }
         public static async Task<int> Main(string[] args)
         {
             return await GetCommandLineOptions().InvokeAsync(args);
@@ -128,7 +129,7 @@ namespace Cognite.OpcUa
                 }
                 else
                 {
-                    await ExtractorStarter.RunExtractor(null, setup, services, CancellationToken.None);
+                    await ExtractorStarter.RunExtractor(null, setup, services, RootToken ?? CancellationToken.None);
                 }
             }, rootBinder);
 
@@ -139,7 +140,7 @@ namespace Cognite.OpcUa
             {
                 setup.ConfigTool = true;
                 if (!OnLaunchCommon(setup)) return;
-                await ExtractorStarter.RunConfigTool(null, setup, services, CancellationToken.None);
+                await ExtractorStarter.RunConfigTool(null, setup, services, RootToken ?? CancellationToken.None);
             }, toolBinder);
 
             return new CommandLineBuilder(rootCommand)

--- a/Test/CommonTestUtils.cs
+++ b/Test/CommonTestUtils.cs
@@ -25,6 +25,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Cognite.OpcUa;
 using Cognite.OpcUa.Config;
+using Cognite.OpcUa.History;
 using Cognite.OpcUa.Nodes;
 using CogniteSdk;
 using Microsoft.Extensions.DependencyInjection;
@@ -382,6 +383,13 @@ namespace Test
                 variable.FullAttributes.ValueRank = ValueRanks.OneDimension;
             }
             return variable;
+        }
+
+        public static async Task RunHistory(HistoryReader reader, IEnumerable<UAHistoryExtractionState> states, HistoryReadType type)
+        {
+            var task = (Task)reader.GetType().GetMethod("RunHistoryBatch", BindingFlags.Instance | BindingFlags.NonPublic)
+                .Invoke(reader, new object[] { states, type });
+            await task;
         }
     }
 }

--- a/Test/Unit/FDMTests.cs
+++ b/Test/Unit/FDMTests.cs
@@ -3,6 +3,7 @@ using Cognite.OpcUa.Config;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
+using Serilog;
 using Server;
 using System;
 using System.CommandLine;
@@ -129,7 +130,7 @@ namespace Test.Unit
                 ReferenceTypeIds.HasSubtype.ToString()));
         }
 
-        [Fact]
+        [Fact(Timeout = 10000)]
         public async Task TestDeleteNodesAndEdges()
         {
             try
@@ -161,7 +162,9 @@ namespace Test.Unit
             }
             finally
             {
+                tester.Log.LogDebug("Start dispose");
                 await extractor.DisposeAsync();
+                tester.Log.LogDebug("End dispose");
             }
 
             tester.Config.Extraction.Transformations = tester.Config.Extraction.Transformations

--- a/Test/Unit/MQTTPusherTest.cs
+++ b/Test/Unit/MQTTPusherTest.cs
@@ -62,7 +62,7 @@ namespace Test.Unit
         private readonly MQTTBridge bridge;
         private readonly CDFMockHandler handler;
         private readonly MQTTPusher pusher;
-        private readonly CancellationTokenSource bridgeSource;
+        private CancellationTokenSource bridgeSource;
 
         public MQTTPusherTest(ITestOutputHelper output, MQTTPusherTestFixture tester)
         {
@@ -757,8 +757,9 @@ namespace Test.Unit
         {
             bridge?.Dispose();
             pusher?.Dispose();
-            bridgeSource?.Dispose();
             bridgeSource?.Cancel();
+            bridgeSource?.Dispose();
+            bridgeSource = null;
         }
     }
 }

--- a/Test/Unit/StreamerTest.cs
+++ b/Test/Unit/StreamerTest.cs
@@ -193,35 +193,31 @@ namespace Test.Unit
             extractor.State.SetNodeState(state, "id");
             var toPush = Enumerable.Range(0, 1000).Select(idx => new UADataPoint(start.AddMilliseconds(idx), "id", idx)).ToList();
             extractor.Streamer.Enqueue(toPush);
-            bool result = await extractor.Streamer.PushDataPoints(new[] { pusher, pusher2 }, Enumerable.Empty<IPusher>(), tester.Source.Token);
+            await extractor.Streamer.PushDataPoints(new[] { pusher, pusher2 }, Enumerable.Empty<IPusher>(), tester.Source.Token);
             Assert.Equal(1000, dps.Count);
             Assert.Equal(1000, dps2.Count);
-            Assert.False(result);
 
             Assert.Equal(dps, dps2);
 
             pusher.PushDataPointResult = false;
             extractor.Streamer.Enqueue(toPush);
-            result = await extractor.Streamer.PushDataPoints(new[] { pusher, pusher2 }, Enumerable.Empty<IPusher>(), tester.Source.Token);
+            await extractor.Streamer.PushDataPoints(new[] { pusher, pusher2 }, Enumerable.Empty<IPusher>(), tester.Source.Token);
             Assert.True(pusher.DataFailing);
             Assert.Equal(1000, dps.Count);
             Assert.Equal(2000, dps2.Count);
-            Assert.False(result);
 
             extractor.Streamer.Enqueue(toPush);
-            result = await extractor.Streamer.PushDataPoints(new[] { pusher2 }, new[] { pusher }, tester.Source.Token);
+            await extractor.Streamer.PushDataPoints(new[] { pusher2 }, new[] { pusher }, tester.Source.Token);
             Assert.True(pusher.DataFailing);
             Assert.Equal(1000, dps.Count);
             Assert.Equal(3000, dps2.Count);
-            Assert.False(result);
 
             extractor.Streamer.Enqueue(toPush);
             pusher.PushDataPointResult = true;
-            result = await extractor.Streamer.PushDataPoints(new[] { pusher2, pusher }, Enumerable.Empty<IPusher>(), tester.Source.Token);
+            await extractor.Streamer.PushDataPoints(new[] { pusher2, pusher }, Enumerable.Empty<IPusher>(), tester.Source.Token);
             Assert.False(pusher.DataFailing);
             Assert.Equal(2000, dps.Count);
             Assert.Equal(4000, dps2.Count);
-            Assert.True(result);
         }
         [Fact]
         public async Task TestPushEvents()
@@ -247,39 +243,35 @@ namespace Test.Unit
             extractor.State.SetEmitterState(state);
             var toPush = Enumerable.Range(0, 1000).Select(idx => new UAEvent { Time = start.AddMilliseconds(idx), EmittingNode = id }).ToList();
             extractor.Streamer.Enqueue(toPush);
-            bool result = await extractor.Streamer.PushEvents(new[] { pusher, pusher2 }, Enumerable.Empty<IPusher>(), tester.Source.Token);
+            await extractor.Streamer.PushEvents(new[] { pusher, pusher2 }, Enumerable.Empty<IPusher>(), tester.Source.Token);
 
             var evts = pusher.Events[id];
             var evts2 = pusher2.Events[id];
 
             Assert.Equal(1000, evts.Count);
             Assert.Equal(1000, evts2.Count);
-            Assert.False(result);
 
             Assert.Equal(evts, evts2);
 
             pusher.PushEventResult = false;
             extractor.Streamer.Enqueue(toPush);
-            result = await extractor.Streamer.PushEvents(new[] { pusher, pusher2 }, Enumerable.Empty<IPusher>(), tester.Source.Token);
+            await extractor.Streamer.PushEvents(new[] { pusher, pusher2 }, Enumerable.Empty<IPusher>(), tester.Source.Token);
             Assert.True(pusher.EventsFailing);
             Assert.Equal(1000, evts.Count);
             Assert.Equal(2000, evts2.Count);
-            Assert.False(result);
 
             extractor.Streamer.Enqueue(toPush);
-            result = await extractor.Streamer.PushEvents(new[] { pusher2 }, new[] { pusher }, tester.Source.Token);
+            await extractor.Streamer.PushEvents(new[] { pusher2 }, new[] { pusher }, tester.Source.Token);
             Assert.True(pusher.EventsFailing);
             Assert.Equal(1000, evts.Count);
             Assert.Equal(3000, evts2.Count);
-            Assert.False(result);
 
             extractor.Streamer.Enqueue(toPush);
             pusher.PushEventResult = true;
-            result = await extractor.Streamer.PushEvents(new[] { pusher2, pusher }, Enumerable.Empty<IPusher>(), tester.Source.Token);
+            await extractor.Streamer.PushEvents(new[] { pusher2, pusher }, Enumerable.Empty<IPusher>(), tester.Source.Token);
             Assert.False(pusher.EventsFailing);
             Assert.Equal(2000, evts.Count);
             Assert.Equal(4000, evts2.Count);
-            Assert.True(result);
         }
         [Fact]
         public void TestDataHandler()

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -353,6 +353,7 @@ namespace Test.Unit
             tester.Server.SetServerRedundancyStatus(230, RedundancySupport.Hot);
             tester.Config.Source.Redundancy.MonitorServiceLevel = true;
             tester.Callbacks.Reset();
+            tester.Client.Callbacks = tester.Callbacks;
             var altServer = new ServerController(new[] {
                 PredefinedSetup.Base
             }, tester.Provider, 62300)
@@ -379,7 +380,7 @@ namespace Test.Unit
                 await TestUtils.WaitForCondition(() => sm.CurrentServiceLevel == 230, 10, "Expected session to reconnect to original server");
 
                 Assert.Equal(230, sm.CurrentServiceLevel);
-                Assert.Equal(0, tester.Callbacks.ServiceLevelCbCount);
+                Assert.Equal(1, tester.Callbacks.ServiceLevelCbCount);
                 Assert.Equal(1, tester.Callbacks.LowServiceLevelCbCount);
                 Assert.Equal(1, tester.Callbacks.ReconnectCbCount);
                 Assert.Equal(sm.EndpointUrl, tester.Config.Source.EndpointUrl);
@@ -399,7 +400,7 @@ namespace Test.Unit
 
                 // Set the servicelevel back up, should trigger a callback, but no switch
                 tester.Server.SetServerRedundancyStatus(255, RedundancySupport.Hot);
-                await TestUtils.WaitForCondition(() => tester.Callbacks.ServiceLevelCbCount == 1, 10);
+                await TestUtils.WaitForCondition(() => tester.Callbacks.ServiceLevelCbCount == 2, 10);
                 Assert.Equal(sm.EndpointUrl, tester.Config.Source.EndpointUrl);
                 Assert.Equal(255, sm.CurrentServiceLevel);
             }

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -1019,9 +1019,9 @@ namespace Test.Unit
 
             try
             {
-                await new DataPointSubscriptionTask(handler, nodes.Take(1000)).Run(tester.Logger,
+                await new DataPointSubscriptionTask(handler, nodes.Take(1000), tester.Callbacks).Run(tester.Logger,
                     tester.Client.SessionManager, tester.Config, tester.Client.SubscriptionManager, tester.Source.Token);
-                await new DataPointSubscriptionTask(handler, nodes.Skip(1000)).Run(tester.Logger,
+                await new DataPointSubscriptionTask(handler, nodes.Skip(1000), tester.Callbacks).Run(tester.Logger,
                     tester.Client.SessionManager, tester.Config, tester.Client.SubscriptionManager, tester.Source.Token);
 
                 await TestUtils.WaitForCondition(() => dps.Count == 2000, 5,
@@ -1118,7 +1118,7 @@ namespace Test.Unit
 
             try
             {
-                await new DataPointSubscriptionTask(handler, nodes).Run(tester.Logger,
+                await new DataPointSubscriptionTask(handler, nodes, tester.Callbacks).Run(tester.Logger,
                     tester.Client.SessionManager, tester.Config, tester.Client.SubscriptionManager, tester.Source.Token);
 
                 await TestUtils.WaitForCondition(() => dps.Count == 3, 5,
@@ -1179,9 +1179,9 @@ namespace Test.Unit
             {
                 await tester.Client.TypeManager.Initialize(uaNodeSource, tester.Source.Token);
 
-                await new EventSubscriptionTask(handler, emitters.Take(2), tester.Client.BuildEventFilter(tester.Client.TypeManager.EventFields))
+                await new EventSubscriptionTask(handler, emitters.Take(2), tester.Client.BuildEventFilter(tester.Client.TypeManager.EventFields), tester.Callbacks)
                     .Run(tester.Logger, tester.Client.SessionManager, tester.Config, tester.Client.SubscriptionManager, tester.Source.Token);
-                await new EventSubscriptionTask(handler, emitters.Skip(2), tester.Client.BuildEventFilter(tester.Client.TypeManager.EventFields))
+                await new EventSubscriptionTask(handler, emitters.Skip(2), tester.Client.BuildEventFilter(tester.Client.TypeManager.EventFields), tester.Callbacks)
                     .Run(tester.Logger, tester.Client.SessionManager, tester.Config, tester.Client.SubscriptionManager, tester.Source.Token);
 
                 tester.Server.TriggerEvents(0);
@@ -1227,7 +1227,7 @@ namespace Test.Unit
             try
             {
                 await tester.Client.TypeManager.Initialize(uaNodeSource, tester.Source.Token);
-                await new EventSubscriptionTask(handler, emitters, tester.Client.BuildEventFilter(tester.Client.TypeManager.EventFields))
+                await new EventSubscriptionTask(handler, emitters, tester.Client.BuildEventFilter(tester.Client.TypeManager.EventFields), tester.Callbacks)
                     .Run(tester.Logger, tester.Client.SessionManager, tester.Config, tester.Client.SubscriptionManager, tester.Source.Token);
 
                 tester.Server.TriggerEvents(0);
@@ -1261,7 +1261,7 @@ namespace Test.Unit
 
             try
             {
-                await new AuditSubscriptionTask(handler)
+                await new AuditSubscriptionTask(handler, tester.Callbacks)
                     .Run(tester.Logger, tester.Client.SessionManager, tester.Config, tester.Client.SubscriptionManager, tester.Source.Token);
 
                 tester.Server.DirectGrowth();

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -23,8 +23,10 @@ using Cognite.OpcUa.Subscriptions;
 
 namespace Test.Utils
 {
-    public abstract class BaseExtractorTestFixture : LoggingTestFixture, IAsyncLifetime
+    public abstract class BaseExtractorTestFixture : LoggingTestFixture, IAsyncLifetime, IDisposable
     {
+        private bool disposedValue;
+
         public int Port { get; }
         public NodeIdReference Ids => Server.Ids;
         public UAClient Client { get; private set; }
@@ -303,6 +305,28 @@ namespace Test.Utils
             subscription = Client.SessionManager.Session?.Subscriptions?.FirstOrDefault(sub =>
                 sub.DisplayName.StartsWith(name.Name(), StringComparison.InvariantCulture));
             return subscription != null;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    Source?.Cancel();
+                    Source?.Dispose();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/Test/Utils/DummyClientCallbacks.cs
+++ b/Test/Utils/DummyClientCallbacks.cs
@@ -1,5 +1,7 @@
 ﻿using Cognite.Extractor.Common;
 using Cognite.OpcUa;
+using Cognite.OpcUa.Subscriptions;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +15,7 @@ namespace Test.Utils
         public int LowServiceLevelCbCount { get; set; }
         public int ReconnectCbCount { get; set; }
         public int DisconnectCbCount { get; set; }
+        public HashSet<SubscriptionName> ActivelyFailedSubscriptions { get; } = new();
 
         public DummyClientCallbacks(CancellationToken token)
         {
@@ -51,6 +54,16 @@ namespace Test.Utils
             ReconnectCbCount = 0;
             ServiceLevelCbCount = 0;
             LowServiceLevelCbCount = 0;
+        }
+
+        public void OnSubscriptionFailure(SubscriptionName subscription)
+        {
+            ActivelyFailedSubscriptions.Add(subscription);
+        }
+
+        public void OnCreatedSubscription(SubscriptionName subscription)
+        {
+            ActivelyFailedSubscriptions.Remove(subscription);
         }
     }
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -60,6 +60,12 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.24.2":
+    description: Restart history more consistently and in more cases.
+    changelog:
+      changed:
+        - Restart history when subscriptions are recreated.
+        - Stop history when any condition for not running history is satisfied, then start it once all conditions are satisfied.
   "2.24.1":
     description: Fix Archive Release Builds
     changelog:

--- a/manifest.yml
+++ b/manifest.yml
@@ -60,12 +60,14 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
-  "2.24.2":
-    description: Restart history more consistently and in more cases.
+  "2.25.0":
+    description: Restart history more consistently and in more cases. Add support for azure key vault.
     changelog:
       changed:
         - Restart history when subscriptions are recreated.
         - Stop history when any condition for not running history is satisfied, then start it once all conditions are satisfied.
+      added:
+        - "Support for azure key vault. Secrets are injected by adding a `key-vault` section to the config, and using the !keyvault [secretname] tag"
   "2.24.1":
     description: Fix Archive Release Builds
     changelog:

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 
 set -x -e
 
-dotnet test /p:Exclude="[xunit*]*%2c[Server]*%2c[System*]*" /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput='../coverage.lcov'
+dotnet test /p:Exclude="[xunit*]*%2c[Server]*%2c[System*]*" /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput='../coverage.lcov' -v n -- xUnit.ReporterSwitch=verbose


### PR DESCRIPTION
This is a fairly complex change. The issue with this new feature (title) is that we are already triggering restart of history from multiple different places. This already isn't ideal, since we only really want to run history once in parallel. (At least for the same set of nodes). This moves the logic for handling whether a change in extractor status should lead to a restart of history into HistoryReader, and has everything else just calling simple methods to update the state of the history reader.

Hopefully this works, and doesn't just cause more trouble.