### PR TITLE
Enforce start end time

### DIFF
--- a/Extractor/Config/HistoryConfig.cs
+++ b/Extractor/Config/HistoryConfig.cs
@@ -89,10 +89,10 @@ namespace Cognite.OpcUa.Config
         /// Alternatively, use syntax N[timeunit](-ago) where timeunit is w, d, h, m, s or ms. In past if -ago is added,
         /// future if not.
         /// </summary>
-        public string? StartTime { get; set; } = "0";
+        public string? StartTime { get; set; }
         /// <summary>
         /// Timestamp to be considered the end of forward history. Only relevant if max-read-length is set.
-        /// In milliseconds since 1/1/1970. Default is current time, if this is 0.
+        /// In milliseconds since 1/1/1970. Default is current time, if this is null.
         /// Alternatively, use syntax N[timeunit](-ago) where timeunit is w, d, h, m, s or ms. In past if -ago is added,
         /// future if not.
         /// </summary>

--- a/Extractor/History/HistoryScheduler.cs
+++ b/Extractor/History/HistoryScheduler.cs
@@ -132,6 +132,12 @@ namespace Cognite.OpcUa.History
             historyStartTime = GetStartTime(config.History.StartTime);
             if (!string.IsNullOrWhiteSpace(config.History.EndTime)) historyEndTime = CogniteTime.ParseTimestampString(config.History.EndTime)!;
 
+            if (historyStartTime != null && historyEndTime != null && historyStartTime >= historyEndTime)
+            {
+                throw new ConfigurationException(
+                    $"History start time must be less than history end time. Start time is {historyStartTime}, end time is {historyEndTime}");
+            }
+
             historyGranularity = config.History.GranularityValue.Value;
 
             metrics = new HistoryMetrics(type);
@@ -220,6 +226,8 @@ namespace Cognite.OpcUa.History
         {
             HistoryReadDetails details;
             var (min, max) = GetReadRange(nodes);
+            log.LogDebug("Read {Type} history chunk for {Count} nodes from {Min} to {Max}",
+                type, nodes.Count(), min, max);
             switch (type)
             {
                 case HistoryReadType.FrontfillData:

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -181,12 +181,12 @@ history:
     # The earliest timestamp to be read from history on the OPC-UA server, in milliseconds since 1/1/1970.
     # Alternatively, use syntax N[timeunit](-ago) where timeunit is w, d, h, m, s or ms. In past if -ago is added,
     # future if not.
-    start-time: 0
+    start-time: null
     # Timestamp to be considered the end of forward history. Only relevant if max-read-length is set.
-    # In milliseconds since 1/1/1970. Default is current time, if this is 0.
+    # In milliseconds since 1/1/1970. Default is current time, if this is null.
     # Alternatively, use syntax N[timeunit](-ago) where timeunit is w, d, h, m, s or ms. In past if -ago is added,
     # future if not.
-    end-time: 0
+    end-time: null
     # Maximum length of each read of history, in seconds.
     # If this is set greater than zero, history will be read in chunks of maximum this size, until the end.
     # This can potentially take a very long time if end-time is much larger than start-time.

--- a/manifest.yml
+++ b/manifest.yml
@@ -60,6 +60,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.27.1":
+    description: Enforce start-time < end-time when reading history.
+    changelog:
+      changed:
+        - The extractor will now fail on startup if start-time is configured to be greater than end-time.
   "2.27.0":
     description: Alpha support for status codes in time series.
     changelog:

--- a/schema/history_config.schema.json
+++ b/schema/history_config.schema.json
@@ -60,7 +60,7 @@
         },
         "end-time": {
             "type": "string",
-            "description": "The latest timestamp history will be read from. Only relevant if `max-read-length` is set. In milliseconds since 01/01/1970. Default is current time. Alternatively use syntax `N[timeunit](-ago)` where `timeunit` is one of `w`, `d`, `h`, `m`, `s`, or `ms`. `-ago` indicates that this is set in the past, if left out it will be that duration in the future"
+            "description": "The latest timestamp history will be read from. In milliseconds since 01/01/1970. Default is current time. Alternatively use syntax `N[timeunit](-ago)` where `timeunit` is one of `w`, `d`, `h`, `m`, `s`, or `ms`. `-ago` indicates that this is set in the past, if left out it will be that duration in the future"
         },
         "granularity": {
             "type": "string",


### PR DESCRIPTION
The extractor works but behaves very weirdly if this is not true, so it's best to enforce it.

This is not really a breaking change, any deployments with this configuration are fundamentally broken.