### PR TITLE
Subscription recreation worked by coincidence

### DIFF
--- a/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
+++ b/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
@@ -91,6 +91,8 @@ namespace Cognite.OpcUa.Subscriptions
         {
             var hasSubscription = subscription.MonitoredItems.Select(s => s.ResolvedNodeId).ToHashSet();
             var toAdd = Items.Where(i => !hasSubscription.Contains(i.Key)).ToList();
+
+            logger.LogInformation("{Count}/{Count2} monitored items already exist for subscription {Name}", Items.Count - toAdd.Count, Items.Count, SubscriptionName.Name());
             if (toAdd.Count != 0)
             {
                 logger.LogInformation("Adding {Count} new monitored items to subscription {Name}", toAdd.Count, SubscriptionName.Name());


### PR DESCRIPTION
 - When we were simulating dead subscriptions, we deleted the subscription from the server.
 - This meant that when the extractor tried to recreate that subscription, it first tried to delete, which failed, since the subscription didn't exist.
 - The SDK, in its infinite wisdom, made it so that if a subscription failed to be deleted, it would actually be kept in the clients cache.
 - When we recreated the subscription, it would reuse that old subscription (with all its monitored items).
 - The bug was that recreating subscription wouldn't work _unless_ this unintended behavior occurred.

The reason why we delete it so carefully is that it would be _very_ bad if the SDK decided to try to create a hundred thousand monitored items in a single go, which it would happily do.