### PR TITLE
Cap the amount of data buffered in the queues.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.28.0":
+    description: Limit the number of nodes and edges the extractor will buffer at a time.
+    changelog:
+      changed:
+        - The extractor will now never buffer more than 1 million datapoints, or 100 000 events.
   "2.27.6":
     description: Fixes edge-case caused by writing to FDM and clean at the same time.
     changelog:


### PR DESCRIPTION
This should prevent issues if the network to CDF is down while the extractor is reading history, somehow.

Technically this could cause issues if the queue is being flooded by historical data to such a degree that live data is blocked and lost, but in general we should never even encounter this case at all, so I think that's a fair tradeoff. If the network is that flaky and wrong you can't expect everything to go well. In the end we still track ranges, so we shouldn't lose data.