### PR TITLE
Async monitor

### DIFF
--- a/Extractor/Browse/BrowseScheduler.cs
+++ b/Extractor/Browse/BrowseScheduler.cs
@@ -100,11 +100,11 @@ namespace Cognite.OpcUa
 
 
 
-        protected override void AbortChunk(IChunk<BrowseNode> chunk, CancellationToken token)
+        protected override async Task AbortChunk(IChunk<BrowseNode> chunk, CancellationToken token)
         {
             try
             {
-                client.AbortBrowse(chunk.Items).Wait(CancellationToken.None);
+                await client.AbortBrowse(chunk.Items);
             }
             catch (Exception e)
             {
@@ -143,7 +143,7 @@ namespace Cognite.OpcUa
             return transformations.ShouldIncludeBasic(displayName, id, typeDefinition, client.NamespaceTable, nc);
         }
 
-        protected override IEnumerable<BrowseNode> HandleTaskResult(IChunk<BrowseNode> chunk, CancellationToken token)
+        protected override async Task<IEnumerable<BrowseNode>> HandleTaskResult(IChunk<BrowseNode> chunk, CancellationToken token)
         {
             var result = new List<BrowseNode>();
 
@@ -152,7 +152,7 @@ namespace Cognite.OpcUa
                 ExtractorUtils.LogException(log, chunk.Exception, $"Unexpected failure during browse{purpose}");
                 failed = true;
                 exceptions.Add(chunk.Exception);
-                AbortChunk(chunk, token);
+                await AbortChunk(chunk, token);
                 return Enumerable.Empty<BrowseNode>();
             }
 

--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="MQTTnet" Version="4.3.3.952" />
     <PackageReference Include="System.Text.Json" Version="8.0.3" />
     <PackageReference Include="Google.Protobuf" Version="3.27.0" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
   </ItemGroup>
   <!--ItemGroup>
     <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config\" />

--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AdysTech.InfluxDB.Client.Net.Core" Version="0.25.0" />
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.23.4" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.24.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.374.36" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.374.36" />

--- a/Extractor/History/HistoryReader.cs
+++ b/Extractor/History/HistoryReader.cs
@@ -34,9 +34,6 @@ using System.Threading.Tasks;
 
 namespace Cognite.OpcUa.History
 {
-
-
-
     public sealed class HistoryReader : IDisposable
     {
         private readonly UAClient uaClient;

--- a/Extractor/History/HistoryScheduler.cs
+++ b/Extractor/History/HistoryScheduler.cs
@@ -177,12 +177,12 @@ namespace Cognite.OpcUa.History
         }
 
 
-        protected override void AbortChunk(IChunk<HistoryReadNode> chunk, CancellationToken token)
+        protected override async Task AbortChunk(IChunk<HistoryReadNode> chunk, CancellationToken token)
         {
             var readChunk = (HistoryReadParams)chunk;
             try
             {
-                uaClient.AbortHistoryRead(readChunk, CancellationToken.None).Wait(CancellationToken.None);
+                await uaClient.AbortHistoryRead(readChunk, CancellationToken.None);
             }
             catch (Exception ex)
             {
@@ -398,7 +398,7 @@ namespace Cognite.OpcUa.History
             log.LogDebug("Finish reading {Type}. Retrieved: {Data}", name, builder);
         }
 
-        protected override IEnumerable<HistoryReadNode> HandleTaskResult(IChunk<HistoryReadNode> chunk, CancellationToken token)
+        protected override async Task<IEnumerable<HistoryReadNode>> HandleTaskResult(IChunk<HistoryReadNode> chunk, CancellationToken token)
         {
             var readChunk = (HistoryReadParams)chunk;
 
@@ -412,7 +412,7 @@ namespace Cognite.OpcUa.History
                 {
                     thresholdManager.Failed(node.Id, chunk.Exception);
                 }
-                AbortChunk(chunk, token);
+                await AbortChunk(chunk, token);
                 return Enumerable.Empty<HistoryReadNode>();
             }
 
@@ -430,11 +430,11 @@ namespace Cognite.OpcUa.History
 
                 if (Data)
                 {
-                    HistoryDataHandler(node);
+                    await HistoryDataHandler(node);
                 }
                 else
                 {
-                    HistoryEventHandler(node, readChunk.Details);
+                    await HistoryEventHandler(node, readChunk.Details);
                 }
 
                 if (Config.IgnoreContinuationPoints)
@@ -468,7 +468,7 @@ namespace Cognite.OpcUa.History
         /// </summary>
         /// <param name="node">Active HistoryReadNode</param>
         /// <returns>Number of points read</returns>
-        private void HistoryDataHandler(HistoryReadNode node)
+        private async Task HistoryDataHandler(HistoryReadNode node)
         {
             var data = node.LastResult as HistoryData;
             node.LastResult = null;
@@ -579,7 +579,7 @@ namespace Cognite.OpcUa.History
                     log.LogTrace("History DataPoint {DataPoint}", buffDp);
                     cnt++;
                 }
-                extractor.Streamer.Enqueue(buffDps);
+                await extractor.Streamer.EnqueueAsync(buffDps);
             }
 
             node.LastRead = cnt;
@@ -592,7 +592,7 @@ namespace Cognite.OpcUa.History
             {
                 log.LogDebug("Read {Count} datapoints from buffer of state {Id}", buffered.Count(), node.State.Id);
                 nodeState.UpdateFromStream(buffered);
-                extractor.Streamer.Enqueue(buffered);
+                await extractor.Streamer.EnqueueAsync(buffered);
             }
         }
 
@@ -617,7 +617,7 @@ namespace Cognite.OpcUa.History
         /// <param name="node">Active HistoryReadNode</param>
         /// <param name="details">History read details used to generate this HistoryRead result</param>
         /// <returns>Number of events read</returns>
-        private void HistoryEventHandler(HistoryReadNode node, HistoryReadDetails details)
+        private async Task HistoryEventHandler(HistoryReadNode node, HistoryReadDetails details)
         {
             var evts = node.LastResult as HistoryEvent;
             node.LastResult = null;
@@ -710,7 +710,7 @@ namespace Cognite.OpcUa.History
                 node.State.UpdateFromBackfill(first, node.Completed);
             }
 
-            extractor.Streamer.Enqueue(createdEvents);
+            await extractor.Streamer.EnqueueAsync(createdEvents);
 
             node.LastRead = createdEvents.Count;
             node.TotalRead += createdEvents.Count;
@@ -725,7 +725,7 @@ namespace Cognite.OpcUa.History
                 var (smin, smax) = buffered.MinMax(dp => dp.Time);
                 emitterState.UpdateFromStream(smin, smax);
                 log.LogDebug("Read {Count} events from buffer of state {Id}", buffered.Count(), node.State.Id);
-                extractor.Streamer.Enqueue(buffered);
+                await extractor.Streamer.EnqueueAsync(buffered);
             }
         }
         #endregion

--- a/Test/Unit/LooperTest.cs
+++ b/Test/Unit/LooperTest.cs
@@ -158,8 +158,8 @@ namespace Test.Unit
             Assert.Empty(evts1);
             Assert.Empty(evts2);
 
-            extractor.Streamer.Enqueue(dps);
-            extractor.Streamer.Enqueue(evts);
+            await extractor.Streamer.EnqueueAsync(dps);
+            await extractor.Streamer.EnqueueAsync(evts);
 
             await extractor.Looper.WaitForNextPush(true);
 
@@ -170,8 +170,8 @@ namespace Test.Unit
 
             // Fail one
 
-            extractor.Streamer.Enqueue(dps);
-            extractor.Streamer.Enqueue(evts);
+            await extractor.Streamer.EnqueueAsync(dps);
+            await extractor.Streamer.EnqueueAsync(evts);
 
             pusher1.PushDataPointResult = false;
             pusher1.PushEventResult = false;
@@ -189,8 +189,8 @@ namespace Test.Unit
 
             // Allow points and events, but continue to fail connection test
 
-            extractor.Streamer.Enqueue(dps);
-            extractor.Streamer.Enqueue(evts);
+            await extractor.Streamer.EnqueueAsync(dps);
+            await extractor.Streamer.EnqueueAsync(evts);
 
             pusher1.PushDataPointResult = true;
             pusher1.PushEventResult = true;
@@ -206,8 +206,8 @@ namespace Test.Unit
 
             pusher1.TestConnectionResult = true;
 
-            extractor.Streamer.Enqueue(dps);
-            extractor.Streamer.Enqueue(evts);
+            await extractor.Streamer.EnqueueAsync(dps);
+            await extractor.Streamer.EnqueueAsync(evts);
 
             await extractor.Looper.WaitForNextPush(true);
 
@@ -254,8 +254,8 @@ namespace Test.Unit
             Assert.Empty(evts2);
             Assert.Empty(evts3);
 
-            extractor.Streamer.Enqueue(dps);
-            extractor.Streamer.Enqueue(evts);
+            await extractor.Streamer.EnqueueAsync(dps);
+            await extractor.Streamer.EnqueueAsync(evts);
 
             extractor.Looper.Run();
             var loopTask = extractor.Looper.Scheduler.WaitForAll();
@@ -300,8 +300,8 @@ namespace Test.Unit
             (pusher1 as IPusher).AddPendingNodes(input, new FullPushResult(), tester.Config);
             (pusher2 as IPusher).AddPendingNodes(input2, new FullPushResult(), tester.Config);
 
-            extractor.Streamer.Enqueue(dps);
-            extractor.Streamer.Enqueue(evts);
+            await extractor.Streamer.EnqueueAsync(dps);
+            await extractor.Streamer.EnqueueAsync(evts);
 
             pusher1.TestConnectionResult = true;
             pusher2.TestConnectionResult = true;


### PR DESCRIPTION
Use an async library for blocking the queue.

While I don't think I've seen anyone hit it, there is a subtle deadlock in the current blocking implementation of the bounded queue. If the queue is blocked on all threads in the thread pool, it's possible a continuation somewhere on the task uploading to CDF is blocked, meaning that we have a deadlock. It's subtle, but I think it is possible.

C# has no async condition variable/monitor, and implementing one is _quite_ hard, so I decided to pick up a solid async library. Honestly this might come in handy a few other places as well.