### PR TITLE
[SEC-3551] Update version of the code-sign-action

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -99,7 +99,8 @@ jobs:
                 CERTIFICATE_SHA1_HASH: ${{ secrets.CODE_SIGNING_CERT_SHA1_HASH }}
                 CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
                 CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-            uses: cognitedata/code-sign-action/@v2
+                KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+            uses: cognitedata/code-sign-action/@v3
             with:
                 path-to-binary: .\extractorbuild\OpcuaExtractor.exe
 
@@ -119,7 +120,8 @@ jobs:
                 CERTIFICATE_SHA1_HASH: ${{ secrets.CODE_SIGNING_CERT_SHA1_HASH }}
                 CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
                 CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-            uses: cognitedata/code-sign-action/@v2
+                KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+            uses: cognitedata/code-sign-action/@v3
             with:
                 path-to-binary: .\managerbuild\OpcUaServiceManager.exe
 
@@ -138,7 +140,8 @@ jobs:
                 CERTIFICATE_SHA1_HASH: ${{ secrets.CODE_SIGNING_CERT_SHA1_HASH }}
                 CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
                 CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-            uses: cognitedata/code-sign-action/@v2
+                KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+            uses: cognitedata/code-sign-action/@v3
             with:
                 path-to-binary: .\OpcUaExtractorSetup\bin\Release\OpcUaExtractorSetup.msi
 


### PR DESCRIPTION
Update version of the code-sign-action before upcoming signing key rotation.

Changes:
 * Bump version of the code-sign-action.
 * Add keypair alias variable which was hardcoded in the previous versions.
