### PR TITLE
Set return bounds to false

### DIFF
--- a/Extractor/History/HistoryScheduler.cs
+++ b/Extractor/History/HistoryScheduler.cs
@@ -266,7 +266,8 @@ namespace Cognite.OpcUa.History
                         IsReadModified = false,
                         StartTime = min,
                         EndTime = max,
-                        NumValuesPerNode = (uint)Config.DataChunk
+                        NumValuesPerNode = (uint)Config.DataChunk,
+                        ReturnBounds = false,
                     };
                     break;
                 case HistoryReadType.BackfillData:
@@ -275,7 +276,8 @@ namespace Cognite.OpcUa.History
                         IsReadModified = false,
                         StartTime = min,
                         EndTime = max,
-                        NumValuesPerNode = (uint)Config.DataChunk
+                        NumValuesPerNode = (uint)Config.DataChunk,
+                        ReturnBounds = false,
                     };
                     break;
                 case HistoryReadType.FrontfillEvents:
@@ -284,7 +286,7 @@ namespace Cognite.OpcUa.History
                         StartTime = min,
                         EndTime = max,
                         NumValuesPerNode = (uint)Config.EventChunk,
-                        Filter = uaClient.BuildEventFilter(typeManager.EventFields)
+                        Filter = uaClient.BuildEventFilter(typeManager.EventFields),
                     };
                     break;
                 case HistoryReadType.BackfillEvents:

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.30.2":
+    description: Set `ReturnBounds` to false in history read requests.
+    changelog:
+      fixed:
+        - No longer accidentally set `ReturnBounds` to true in history read raw requests.
   "2.30.1":
     description: Always set history end time.
     changelog:


### PR DESCRIPTION
This stupid SDK sets random defaults in the worst possible way.