### PR TITLE
Remove publish to GCR

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -239,9 +239,7 @@ jobs:
 
         - id: image_tags
           run: |
-            echo extractor="eu.gcr.io/cognite-registry/opcua-extractor-net:${{ needs.prerequisites.outputs.version }}" >> "$GITHUB_OUTPUT"
             echo extractor_dockerhub="cognite/opcua-extractor-net:${{ needs.prerequisites.outputs.version }}" >> "$GITHUB_OUTPUT"
-            echo bridge="eu.gcr.io/cognite-registry/mqtt-cdf-bridge:${{ needs.prerequisites.outputs.version }}" >> "$GITHUB_OUTPUT"
             echo bridge_dockerhub="cognite/mqtt-cdf-bridge:${{ needs.prerequisites.outputs.version }}" >> "$GITHUB_OUTPUT"
             echo desc="$(git describe --tags --dirty) $(git log -1  --format=%ai)" >> "$GITHUB_OUTPUT"
 
@@ -251,8 +249,7 @@ jobs:
             id=$(docker create $image)
             docker cp $id:/build/deploy .
             docker rm -v $id
-            docker build -t ${{ steps.image_tags.outputs.extractor }} .
-            docker tag ${{ steps.image_tags.outputs.extractor }} ${{ steps.image_tags.outputs.extractor_dockerhub }}
+            docker build -t ${{ steps.image_tags.outputs.extractor_dockerhub }} .
 
         - name: Build bridge image
           run: |
@@ -260,16 +257,7 @@ jobs:
             id=$(docker create $image)
             docker cp $id:/build/deploy .
             docker rm -v $id
-            docker build -f Dockerfile.bridge -t ${{ steps.image_tags.outputs.bridge }} .
-            docker tag ${{ steps.image_tags.outputs.bridge }} ${{ steps.image_tags.outputs.bridge_dockerhub }}
-
-        - name: Push images
-          if: ${{ needs.prerequisites.outputs.should-release == 0 && needs.prerequisites.outputs.branch == 'master' }}
-          run: |
-            echo "Images being pushed as ${{ steps.image_tags.outputs.extractor }}, ${{ steps.image_tags.outputs.bridge }}"
-            echo ${{ secrets.COGNITE_REGISTRY_KEY }} | base64 -d | docker login -u _json_key --password-stdin https://eu.gcr.io
-            docker push ${{ steps.image_tags.outputs.extractor }}
-            docker push ${{ steps.image_tags.outputs.bridge }}
+            docker build -f Dockerfile.bridge -t ${{ steps.image_tags.outputs.bridge_dockerhub }} .
 
         - name: "Log in to the Dockerhub"
           if: ${{ needs.prerequisites.outputs.should-release == 0 && needs.prerequisites.outputs.branch == 'master' }}

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ See the [example configuration](config/config.example.yml) for a config template
 
 ### Using Docker
 
-There are docker images of each release at eu.gcr.io/cognite-registry/opcua-extractor-net.
+There are docker images of each release at dockerhub: opcua-extractor-net.
 
 Config, both opcua config `opc.ua.extractor.Config.xml` and `config.yml` are located in a volume /config and certificates are located in subfolders of the volume /certificates. Example:
 
-`docker run -v "$(pwd)/config:/config" -v "$(pwd)/certificates:/certificates eu.gcr.io/cognite-registry/opcua-extractor-net:tag`
+`docker run -v "$(pwd)/config:/config" -v "$(pwd)/certificates:/certificates opcua-extractor-net:tag`
 
 which would run the build tagged with `tag` using config stored in `current_dir/config`.
 
@@ -94,7 +94,7 @@ During development it is perfectly fine to just run a subset of the tests using 
 ### Releasing
 
 Update `manifest.yaml` with the new release`. Merging to master will automatically
-deploy binaries to github releases and docker images to eu.gcr.io/cognite-registry/. For
+deploy binaries to github releases and docker images to dockerhub. For
 the MSI to build, the version must be simple, i.e. on the form "a.b.c".
 
 ## Contributing


### PR DESCRIPTION
Since GCR is being deprecated and we publish to dockerhub there's no real point in maintaining the old images. Those were for backward compatibility anyway.