### PR TITLE
Filter should be at the same level as type

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -775,7 +775,7 @@ extraction:
       # Type, either "Ignore", "Property", "DropSubscriptions", "TimeSeries", "AsEvents", or "Include"
       # - type:
       #  NodeFilter. All non-null filters must match each node for the transformation to be applied.
-      #  filter:
+      #   filter:
             # Regex on node DisplayName
             # name:
             # Regex on node Description. If this is set, requires description to be non-null.


### PR DESCRIPTION
User deletes the # and expects ending up with a correct yml file. The issue is that when doing so filter and type were at different levels. This change fixes that.