### PR TITLE
Avoid leaking datapoints in the switchover buffer

### DIFF
--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -87,6 +87,7 @@ namespace Cognite.OpcUa
         public SourceInformation SourceInfo { get; private set; } = SourceInformation.Default();
 
         public SessionContext Context => SessionManager.Context;
+        public int PublishingInterval => Config.Source.PublishingInterval;
 
         /// <summary>
         /// Constructor, does not start the client.

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -68,6 +68,7 @@ namespace Cognite.OpcUa
 
         public TypeManager TypeManager => uaClient.TypeManager;
         public SessionContext Context => uaClient.Context;
+        public int PublishingInterval => Config.Source.PublishingInterval;
 
         private NodeSetNodeSource? nodeSetSource;
 
@@ -1320,5 +1321,6 @@ namespace Cognite.OpcUa
         NamespaceTable? NamespaceTable { get; }
         public SessionContext Context { get; }
         public SourceInformation SourceInfo { get; }
+        public int PublishingInterval { get; }
     }
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.32.1-beta3":
+    description: Fix possible memory leak from live data when history is suspended.
+    changelog:
+      fixed:
+        - Fix possible memory leak related to datapoints being buffered to avoid data loss on history end.
   "2.32.1-beta2":
     description: Fix issue causing the extractor to not properly change redundant server in some cases.
     changelog:


### PR DESCRIPTION
The purpose of this buffer is to avoid data loss on the "switch" from historical to live data. Recent changes have kept us "idle" in the IsFrontfilling state in a way that we never saw earlier. This change should help avoid leaking memory there in that case.

This whole feature can be removed once we make the state store required...