### PR TITLE
Make update non-optional

### DIFF
--- a/Extractor/Config/ExtractionConfig.cs
+++ b/Extractor/Config/ExtractionConfig.cs
@@ -87,15 +87,6 @@ namespace Cognite.OpcUa.Config
             get => DataPushDelayValue.RawValue; set => DataPushDelayValue.RawValue = value!;
         }
         /// <summary>
-        /// Update data in destinations on rebrowse or restart.
-        /// Set auto-rebrowse-period to some value to do this periodically.
-        /// Context refers to the structure of the node graph in OPC-UA. (assetId and parentId in CDF)
-        /// Metadata refers to any information obtained from OPC-UA properties. (metadata in CDF)
-        /// Enabling anything here will increase the startup- and rebrowse-time of the extractor.
-        /// </summary>
-        public UpdateConfig Update { get => update; set => update = value ?? update; }
-        private UpdateConfig update = new UpdateConfig();
-        /// <summary>
         /// Configuration for handling of data types in OPC-UA.
         /// </summary>
         public DataTypeConfig DataTypes { get => dataTypes; set => dataTypes = value ?? dataTypes; }
@@ -289,41 +280,6 @@ namespace Cognite.OpcUa.Config
         /// To actually get types in the node hierarchy you have to add a root node that they descend from.
         /// </summary>
         public bool AsNodes { get; set; }
-    }
-
-    public class UpdateConfig
-    {
-        public bool AnyUpdate => objects.AnyUpdate || variables.AnyUpdate;
-        /// <summary>
-        /// Configuration for updating objects and object types.
-        /// </summary>
-        public TypeUpdateConfig Objects { get => objects; set => objects = value ?? objects; }
-        private TypeUpdateConfig objects = new TypeUpdateConfig();
-        /// <summary>
-        /// Configuration for updating variables and variable types.
-        /// </summary>
-        public TypeUpdateConfig Variables { get => variables; set => variables = value ?? variables; }
-        private TypeUpdateConfig variables = new TypeUpdateConfig();
-    }
-    public class TypeUpdateConfig
-    {
-        public bool AnyUpdate => Description || Name || Metadata || Context;
-        /// <summary>
-        /// True to update description.
-        /// </summary>
-        public bool Description { get; set; }
-        /// <summary>
-        /// True to update name.
-        /// </summary>
-        public bool Name { get; set; }
-        /// <summary>
-        /// True to update metadata.
-        /// </summary>
-        public bool Metadata { get; set; }
-        /// <summary>
-        /// True to update context, i.e. the position of the node in the node hierarchy.
-        /// </summary>
-        public bool Context { get; set; }
     }
 
     public class DeletesConfig

--- a/Extractor/NodeSources/UANodeSource.cs
+++ b/Extractor/NodeSources/UANodeSource.cs
@@ -89,8 +89,6 @@ namespace Cognite.OpcUa.NodeSources
 
             if (nodeMap.Count != 0) await client.ReadNodeData(nodeMap, token, "new non-hierarchical instances");
 
-            logger.LogDebug("Is mandatory in nodemap? {Yes}", nodeMap.FirstOrDefault(n => n.Id == ObjectIds.ModellingRule_Mandatory));
-
             return TakeResults(false);
         }
 

--- a/Extractor/Nodes/BaseUANode.cs
+++ b/Extractor/Nodes/BaseUANode.cs
@@ -404,45 +404,32 @@ namespace Cognite.OpcUa.Nodes
             return null;
         }
 
-        public virtual int GetUpdateChecksum(TypeUpdateConfig update, bool dataTypeMetadata, bool nodeTypeMetadata)
+        public virtual int GetUpdateChecksum(bool dataTypeMetadata, bool nodeTypeMetadata)
         {
-            if (update == null || !update.AnyUpdate) return 0;
             int checksum = 0;
             unchecked
             {
-                if (update.Context)
+                checksum += (ParentId?.GetHashCode() ?? 0);
+                checksum = checksum * 31 + (Attributes.Description?.GetHashCode(StringComparison.InvariantCulture) ?? 0);
+                checksum = checksum * 31 + (Name?.GetHashCode(StringComparison.InvariantCulture) ?? 0);
+                int metaHash = 0;
+                if (Properties != null)
                 {
-                    checksum += (ParentId?.GetHashCode() ?? 0);
-                }
-                if (update.Description)
-                {
-                    checksum = checksum * 31 + (Attributes.Description?.GetHashCode(StringComparison.InvariantCulture) ?? 0);
-                }
-                if (update.Name)
-                {
-                    checksum = checksum * 31 + (Name?.GetHashCode(StringComparison.InvariantCulture) ?? 0);
-                }
-                if (update.Metadata)
-                {
-                    int metaHash = 0;
-                    if (Properties != null)
+                    foreach (var prop in Properties.OrderBy(prop => prop.Name))
                     {
-                        foreach (var prop in Properties.OrderBy(prop => prop.Name))
+                        metaHash *= 31;
+                        if (prop.Name == null) continue;
+                        if (prop is UAVariable propVariable)
                         {
-                            metaHash *= 31;
-                            if (prop.Name == null) continue;
-                            if (prop is UAVariable propVariable)
-                            {
-                                metaHash += (prop.Name, propVariable.Value?.Value).GetHashCode();
-                            }
-                            if (prop.Properties?.Any() ?? false)
-                            {
-                                metaHash += prop.GetUpdateChecksum(new TypeUpdateConfig { Metadata = true }, false, false);
-                            }
+                            metaHash += (prop.Name, propVariable.Value?.Value).GetHashCode();
+                        }
+                        if (prop.Properties?.Any() ?? false)
+                        {
+                            metaHash += prop.GetUpdateChecksum(false, false);
                         }
                     }
-                    checksum = checksum * 31 + metaHash;
                 }
+                checksum = checksum * 31 + metaHash;
             }
             return checksum;
         }

--- a/Extractor/Nodes/UAObject.cs
+++ b/Extractor/Nodes/UAObject.cs
@@ -115,17 +115,14 @@ namespace Cognite.OpcUa.Nodes
             return null;
         }
 
-        public override int GetUpdateChecksum(TypeUpdateConfig update, bool dataTypeMetadata, bool nodeTypeMetadata)
+        public override int GetUpdateChecksum(bool dataTypeMetadata, bool nodeTypeMetadata)
         {
-            int checksum = base.GetUpdateChecksum(update, dataTypeMetadata, nodeTypeMetadata);
-            if (update.Metadata)
+            int checksum = base.GetUpdateChecksum(dataTypeMetadata, nodeTypeMetadata);
+            unchecked
             {
-                unchecked
+                if (nodeTypeMetadata)
                 {
-                    if (nodeTypeMetadata)
-                    {
-                        checksum = checksum * 31 + (FullAttributes.TypeDefinition?.Id?.GetHashCode() ?? 0);
-                    }
+                    checksum = checksum * 31 + (FullAttributes.TypeDefinition?.Id?.GetHashCode() ?? 0);
                 }
             }
             return checksum;

--- a/Extractor/Nodes/UAVariable.cs
+++ b/Extractor/Nodes/UAVariable.cs
@@ -323,26 +323,24 @@ namespace Cognite.OpcUa.Nodes
             return fields;
         }
 
-        public override int GetUpdateChecksum(TypeUpdateConfig update, bool dataTypeMetadata, bool nodeTypeMetadata)
+        public override int GetUpdateChecksum(bool dataTypeMetadata, bool nodeTypeMetadata)
         {
-            int checksum = base.GetUpdateChecksum(update, dataTypeMetadata, nodeTypeMetadata);
-            if (update.Metadata)
-            {
-                unchecked
-                {
-                    if (dataTypeMetadata)
-                    {
-                        checksum = checksum * 31 + FullAttributes.DataType.Id.GetHashCode();
-                    }
-                    if (NodeClass == NodeClass.VariableType)
-                    {
-                        checksum = checksum * 31 + FullAttributes.Value.GetHashCode();
-                    }
+            int checksum = base.GetUpdateChecksum(dataTypeMetadata, nodeTypeMetadata);
 
-                    if (nodeTypeMetadata)
-                    {
-                        checksum = checksum * 31 + (FullAttributes.TypeDefinition?.Id?.GetHashCode() ?? 0);
-                    }
+            unchecked
+            {
+                if (dataTypeMetadata)
+                {
+                    checksum = checksum * 31 + FullAttributes.DataType.Id.GetHashCode();
+                }
+                if (NodeClass == NodeClass.VariableType)
+                {
+                    checksum = checksum * 31 + FullAttributes.Value.GetHashCode();
+                }
+
+                if (nodeTypeMetadata)
+                {
+                    checksum = checksum * 31 + (FullAttributes.TypeDefinition?.Id?.GetHashCode() ?? 0);
                 }
             }
 
@@ -589,6 +587,7 @@ namespace Cognite.OpcUa.Nodes
         {
             Index = index;
             TSParent = parent;
+            Source = parent.Source;
         }
 
         public override string? GetUniqueId(SessionContext context)

--- a/Extractor/Nodes/UAVariableType.cs
+++ b/Extractor/Nodes/UAVariableType.cs
@@ -158,19 +158,16 @@ namespace Cognite.OpcUa.Nodes
             return fields;
         }
 
-        public override int GetUpdateChecksum(TypeUpdateConfig update, bool dataTypeMetadata, bool nodeTypeMetadata)
+        public override int GetUpdateChecksum(bool dataTypeMetadata, bool nodeTypeMetadata)
         {
-            int checksum = base.GetUpdateChecksum(update, dataTypeMetadata, nodeTypeMetadata);
-            if (update.Metadata)
+            int checksum = base.GetUpdateChecksum(dataTypeMetadata, nodeTypeMetadata);
+            unchecked
             {
-                unchecked
+                if (dataTypeMetadata)
                 {
-                    if (dataTypeMetadata)
-                    {
-                        checksum = checksum * 31 + FullAttributes.DataType.Id.GetHashCode();
-                    }
-                    checksum = checksum * 31 + FullAttributes.Value.GetHashCode();
+                    checksum = checksum * 31 + FullAttributes.DataType.Id.GetHashCode();
                 }
+                checksum = checksum * 31 + FullAttributes.Value.GetHashCode();
             }
             return checksum;
         }

--- a/Extractor/Pushers/CDFPusher.cs
+++ b/Extractor/Pushers/CDFPusher.cs
@@ -237,11 +237,10 @@ namespace Cognite.OpcUa.Pushers
         /// <param name="objects">List of objects to be synchronized</param>
         /// <param name="variables">List of variables to be synchronized</param>
         /// <param name="references"> List of references to be synchronized</param>
-        /// <param name="update">Configuration of what fields, if any, should be updated.</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>True if no operation failed unexpectedly</returns>
         public async Task<PushResult> PushNodes(IEnumerable<BaseUANode> objects,
-                IEnumerable<UAVariable> variables, IEnumerable<UAReference> references, UpdateConfig update, CancellationToken token)
+                IEnumerable<UAVariable> variables, IEnumerable<UAReference> references, CancellationToken token)
         {
             var result = new PushResult();
             var report = new BrowseReport
@@ -291,7 +290,6 @@ namespace Cognite.OpcUa.Pushers
                 variables,
                 references,
                 report,
-                update,
                 result,
                 Extractor,
                 token

--- a/Extractor/Pushers/IPusher.cs
+++ b/Extractor/Pushers/IPusher.cs
@@ -16,7 +16,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. */
 
 using Cognite.OpcUa.Config;
-using Cognite.OpcUa.History;
 using Cognite.OpcUa.Nodes;
 using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.Types;
@@ -77,7 +76,6 @@ namespace Cognite.OpcUa
             IEnumerable<BaseUANode> objects,
             IEnumerable<UAVariable> variables,
             IEnumerable<UAReference> references,
-            UpdateConfig update,
             CancellationToken token)
         {
             return Task.FromResult(new PushResult());

--- a/Extractor/Pushers/PusherUtils.cs
+++ b/Extractor/Pushers/PusherUtils.cs
@@ -80,9 +80,10 @@ namespace Cognite.OpcUa.Pushers
         /// <summary>
         /// Create timeseries update from existing timeseries and new OPC-UA variable.
         /// </summary>
+        /// <param name="config">Extractor configuration object.</param>
+        /// <param name="client">Interface for generating unique IDs using the client context.</param>
         /// <param name="old">Existing timeseries</param>
         /// <param name="newTs">New OPC-UA variable</param>
-        /// <param name="update">Configuration for which fields to update</param>
         /// <param name="nodeToAssetIds">Map from NodeIds to assetIds, necessary for setting parents</param>
         /// <returns>Update object, or null if updating was unnecessary</returns>
         public static TimeSeriesUpdate? GetTSUpdate(
@@ -132,10 +133,10 @@ namespace Cognite.OpcUa.Pushers
         /// <summary>
         /// Create asset update from existing asset and new OPC-UA node.
         /// </summary>
-        /// <param name="extractor">Active extractor, used for building metadata</param>
+        /// <param name="config">Extractor config.</param>
         /// <param name="old">Existing asset</param>
         /// <param name="newAsset">New OPC-UA node</param>
-        /// <param name="update">Configuration for which fields to update</param>
+        /// <param name="extractor">Active extractor, used for building metadata</param>
         /// <returns>Update object, or null if updating was unnecessary</returns>
         public static AssetUpdate? GetAssetUpdate(
             FullConfig config,

--- a/Extractor/Pushers/PusherUtils.cs
+++ b/Extractor/Pushers/PusherUtils.cs
@@ -60,32 +60,6 @@ namespace Cognite.OpcUa.Pushers
             }
         }
 
-        public static JsonElement? CreateRawUpdate(
-            ILogger log,
-            StringConverter converter,
-            BaseUANode node,
-            RawRow<Dictionary<string, JsonElement>>? raw,
-            ConverterType type)
-        {
-            if (node == null) return null;
-            var newObj = node.ToJson(log, converter, type);
-
-            if (newObj == null || newObj.RootElement.ValueKind != JsonValueKind.Object) return null;
-            if (raw == null) return newObj.RootElement;
-
-            var fields = new HashSet<string>();
-            foreach (var row in newObj.RootElement.EnumerateObject())
-            {
-                if (!raw.Columns.TryGetValue(row.Name, out JsonElement value) || value.ToString() != row.Value.ToString())
-                {
-                    return newObj.RootElement;
-                }
-                fields.Add(row.Name);
-            }
-            if (raw.Columns.Any(kvp => !fields.Contains(kvp.Key))) return newObj.RootElement;
-            return null;
-        }
-
         private static bool ShouldSetNewMetadata(FullConfig config, Dictionary<string, string> newMetadata, Dictionary<string, string>? oldMetadata)
         {
             if (newMetadata.Count != 0)
@@ -116,46 +90,40 @@ namespace Cognite.OpcUa.Pushers
             IUAClientAccess client,
             TimeSeries old,
             UAVariable newTs,
-            TypeUpdateConfig update,
             IDictionary<NodeId, long> nodeToAssetIds)
         {
-            if (update == null || newTs == null || nodeToAssetIds == null || old == null) return null;
+            if (newTs == null || nodeToAssetIds == null || old == null) return null;
             var tsUpdate = new TimeSeriesUpdate();
-            if (update.Context)
+
+            if (!newTs.ParentId.IsNullNodeId && nodeToAssetIds.TryGetValue(newTs.ParentId, out long assetId))
             {
-                if (!newTs.ParentId.IsNullNodeId && nodeToAssetIds.TryGetValue(newTs.ParentId, out long assetId))
+                if (assetId != old.AssetId && assetId > 0)
                 {
-                    if (assetId != old.AssetId && assetId > 0)
-                    {
-                        tsUpdate.AssetId = new UpdateNullable<long?>(assetId);
-                    }
+                    tsUpdate.AssetId = new UpdateNullable<long?>(assetId);
                 }
             }
 
             var newDesc = Sanitation.Truncate(newTs.FullAttributes.Description, Sanitation.TimeSeriesDescriptionMax);
-            if (update.Description && !string.IsNullOrEmpty(newDesc) && newDesc != old.Description)
+            if (!string.IsNullOrEmpty(newDesc) && newDesc != old.Description)
                 tsUpdate.Description = new UpdateNullable<string>(newDesc);
 
             var newName = Sanitation.Truncate(newTs.Name, Sanitation.TimeSeriesNameMax);
-            if (update.Name && !string.IsNullOrEmpty(newName) && newName != old.Name)
+            if (!string.IsNullOrEmpty(newName) && newName != old.Name)
                 tsUpdate.Name = new UpdateNullable<string>(newName);
 
-            if (update.Metadata)
-            {
-                var newMetadata = newTs.BuildMetadata(config, client, true)
-                    .Where(kvp => !string.IsNullOrEmpty(kvp.Value))
-                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
-                    .SanitizeMetadata(
-                        Sanitation.TimeSeriesMetadataMaxPerKey,
-                        Sanitation.TimeSeriesMetadataMaxPairs,
-                        Sanitation.TimeSeriesMetadataMaxPerValue,
-                        Sanitation.TimeSeriesMetadataMaxBytes,
-                        out _);
+            var newMetadata = newTs.BuildMetadata(config, client, true)
+                .Where(kvp => !string.IsNullOrEmpty(kvp.Value))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+                .SanitizeMetadata(
+                    Sanitation.TimeSeriesMetadataMaxPerKey,
+                    Sanitation.TimeSeriesMetadataMaxPairs,
+                    Sanitation.TimeSeriesMetadataMaxPerValue,
+                    Sanitation.TimeSeriesMetadataMaxBytes,
+                    out _);
 
-                if (ShouldSetNewMetadata(config, newMetadata, old.Metadata))
-                {
-                    tsUpdate.Metadata = new UpdateDictionary<string>(newMetadata);
-                }
+            if (ShouldSetNewMetadata(config, newMetadata, old.Metadata))
+            {
+                tsUpdate.Metadata = new UpdateDictionary<string>(newMetadata);
             }
 
             return tsUpdate;
@@ -173,12 +141,11 @@ namespace Cognite.OpcUa.Pushers
             FullConfig config,
             Asset old,
             BaseUANode newAsset,
-            UAExtractor extractor,
-            TypeUpdateConfig update)
+            UAExtractor extractor)
         {
-            if (old == null || newAsset == null || extractor == null || update == null) return null;
+            if (old == null || newAsset == null || extractor == null) return null;
             var assetUpdate = new AssetUpdate();
-            if (update.Context && !newAsset.ParentId.IsNullNodeId)
+            if (!newAsset.ParentId.IsNullNodeId)
             {
                 var parentId = extractor.GetUniqueId(newAsset.ParentId);
                 // Do not move an asset from root to non-root or the other way around.
@@ -190,28 +157,25 @@ namespace Cognite.OpcUa.Pushers
                 }
             }
 
-            if (update.Description && !string.IsNullOrEmpty(newAsset.Attributes.Description) && newAsset.Attributes.Description != old.Description)
+            if (!string.IsNullOrEmpty(newAsset.Attributes.Description) && newAsset.Attributes.Description != old.Description)
                 assetUpdate.Description = new UpdateNullable<string>(newAsset.Attributes.Description.Truncate(Sanitation.AssetDescriptionMax)!);
 
-            if (update.Name && !string.IsNullOrEmpty(newAsset.Name) && newAsset.Name != old.Name)
+            if (!string.IsNullOrEmpty(newAsset.Name) && newAsset.Name != old.Name)
                 assetUpdate.Name = new UpdateNullable<string>(newAsset.Name.Truncate(Sanitation.AssetNameMax)!);
 
-            if (update.Metadata)
-            {
-                var newMetadata = newAsset.BuildMetadata(config, extractor, true)
-                    .Where(kvp => !string.IsNullOrEmpty(kvp.Value))
-                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
-                    .SanitizeMetadata(
-                        Sanitation.AssetMetadataMaxPerKey,
-                        Sanitation.AssetMetadataMaxPairs,
-                        Sanitation.AssetMetadataMaxPerValue,
-                        Sanitation.AssetMetadataMaxBytes,
-                        out _);
+            var newMetadata = newAsset.BuildMetadata(config, extractor, true)
+                .Where(kvp => !string.IsNullOrEmpty(kvp.Value))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+                .SanitizeMetadata(
+                    Sanitation.AssetMetadataMaxPerKey,
+                    Sanitation.AssetMetadataMaxPairs,
+                    Sanitation.AssetMetadataMaxPerValue,
+                    Sanitation.AssetMetadataMaxBytes,
+                    out _);
 
-                if (ShouldSetNewMetadata(config, newMetadata, old.Metadata))
-                {
-                    assetUpdate.Metadata = new UpdateDictionary<string>(newMetadata);
-                }
+            if (ShouldSetNewMetadata(config, newMetadata, old.Metadata))
+            {
+                assetUpdate.Metadata = new UpdateDictionary<string>(newMetadata);
             }
             return assetUpdate;
         }

--- a/Extractor/Pushers/Writers/BaseTimeseriesWriter.cs
+++ b/Extractor/Pushers/Writers/BaseTimeseriesWriter.cs
@@ -44,7 +44,6 @@ namespace Cognite.OpcUa.Pushers.Writers
             IDictionary<string, UAVariable> timeseriesMap,
             IDictionary<NodeId, long> nodeToAssetIds,
             HashSet<string> mismatchedTimeseries,
-            TypeUpdateConfig update,
             BrowseReport report,
             CancellationToken token)
         {
@@ -64,9 +63,9 @@ namespace Cognite.OpcUa.Pushers.Writers
                     .Where(kvp => kvp.Value.Source != NodeSource.CDF)
                     .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-                if (update.AnyUpdate && toPushMeta.Count != 0)
+                if (toPushMeta.Count != 0)
                 {
-                    await UpdateTimeseries(extractor, toPushMeta, timeseries, nodeToAssetIds, update, result, token);
+                    await UpdateTimeseries(extractor, toPushMeta, timeseries, nodeToAssetIds, result, token);
                 }
                 if (this is MinimalTimeseriesWriter)
                 {
@@ -158,7 +157,6 @@ namespace Cognite.OpcUa.Pushers.Writers
             IDictionary<string, UAVariable> tsMap,
             IEnumerable<TimeSeries> timeseries,
             IDictionary<NodeId, long> nodeToAssetIds,
-            TypeUpdateConfig update,
             Result result,
             CancellationToken token);
 

--- a/Extractor/Pushers/Writers/BaseTimeseriesWriter.cs
+++ b/Extractor/Pushers/Writers/BaseTimeseriesWriter.cs
@@ -36,7 +36,7 @@ namespace Cognite.OpcUa.Pushers.Writers
         /// <param name="timeseriesMap">Dictionary of mapping of variables to keys</param>
         /// <param name="nodeToAssetIds">Node to assets to ids</param>
         /// <param name="mismatchedTimeseries">Mismatched timeseries</param>
-        /// <param name="update">Type update configuration</param>
+        /// <param name="report">Metrics about pushed variables</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>Operation result</returns>
         public async Task<bool> PushVariables(
@@ -93,8 +93,6 @@ namespace Cognite.OpcUa.Pushers.Writers
         /// <param name="nodeToAssetIds">Node to assets to ids</param>
         /// <param name="mismatchedTimeseries">Mismatched timeseries</param>
         /// <param name="result">Operation result</param>
-        /// <param name="update">Type update configuration</param>
-        /// <param name="createMinimalTimeseries">Indicate if to create minimal timeseries</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>Operation result</returns>
         private async Task<IEnumerable<TimeSeries>> CreateTimeseries(

--- a/Extractor/Pushers/Writers/CDFWriter.cs
+++ b/Extractor/Pushers/Writers/CDFWriter.cs
@@ -50,7 +50,6 @@ namespace Cognite.OpcUa.Pushers.Writers
             IEnumerable<UAVariable> variables,
             IEnumerable<UAReference> references,
             BrowseReport report,
-            UpdateConfig update,
             PushResult result,
             UAExtractor extractor,
             CancellationToken token)
@@ -80,14 +79,14 @@ namespace Cognite.OpcUa.Pushers.Writers
             if (clean != null && clean.Assets)
             {
                 result.Objects &= await clean.PushAssets(extractor, assetMap, NodeToAssetIds,
-                    update.Objects, report, token);
+                    report, token);
             }
 
             // Next, push timeseries. If we're pushing to FDM, this happens later.
             if (timeseries != null)
             {
                 result.Variables &= await timeseries.PushVariables(extractor, timeseriesMap, NodeToAssetIds,
-                    MismatchedTimeseries, update.Variables, report, token);
+                    MismatchedTimeseries, report, token);
             }
 
             // Finally, push the various other resources as needed.
@@ -124,14 +123,14 @@ namespace Cognite.OpcUa.Pushers.Writers
             {
                 tasks.Add(Task.Run(async () =>
                 {
-                    result.RawObjects &= await raw.PushAssets(extractor, assetMap, update.Objects, report, token);
+                    result.RawObjects &= await raw.PushAssets(extractor, assetMap, report, token);
                 }, token));
             }
             if (assetMap.Count != 0 && idm != null && idm.Assets)
             {
                 tasks.Add(Task.Run(async () =>
                 {
-                    result.Objects &= await idm.PushAssets(extractor, assetMap, update.Objects, report, token);
+                    result.Objects &= await idm.PushAssets(extractor, assetMap, report, token);
                 }, token));
             }
 
@@ -139,7 +138,7 @@ namespace Cognite.OpcUa.Pushers.Writers
             {
                 tasks.Add(Task.Run(async () =>
                 {
-                    result.RawVariables &= await raw.PushTimeseries(extractor, timeseriesMap, update.Variables, report, token);
+                    result.RawVariables &= await raw.PushTimeseries(extractor, timeseriesMap, report, token);
                 }, token));
             }
             if (timeseriesMap.Count != 0 && idm != null)

--- a/Extractor/Pushers/Writers/CleanWriter.cs
+++ b/Extractor/Pushers/Writers/CleanWriter.cs
@@ -66,7 +66,6 @@ namespace Cognite.OpcUa.Pushers.Writers
             UAExtractor extractor,
             IDictionary<string, BaseUANode> nodes,
             IDictionary<NodeId, long> nodeToAssetIds,
-            TypeUpdateConfig update,
             BrowseReport report,
             CancellationToken token)
         {
@@ -76,11 +75,7 @@ namespace Cognite.OpcUa.Pushers.Writers
             {
                 var result = new Result { Created = 0, Updated = 0 };
                 var assets = await CreateAssets(extractor, nodes, nodeToAssetIds, result, token);
-
-                if (update.AnyUpdate)
-                {
-                    await UpdateAssets(extractor, nodes, assets, update, result, token);
-                }
+                await UpdateAssets(extractor, nodes, assets, result, token);
 
                 report.AssetsUpdated += result.Updated;
                 report.AssetsCreated += result.Created;
@@ -195,7 +190,7 @@ namespace Cognite.OpcUa.Pushers.Writers
         /// <param name="token">Cancellation token</param>
         /// <returns>Future list of assets</returns>
         private async Task UpdateAssets(UAExtractor extractor, IDictionary<string, BaseUANode> assetMap,
-                IEnumerable<Asset> assets, TypeUpdateConfig update, Result result, CancellationToken token)
+                IEnumerable<Asset> assets, Result result, CancellationToken token)
         {
             var updates = new List<AssetUpdateItem>();
             var existing = assets.ToDictionary(asset => asset.ExternalId);
@@ -203,7 +198,7 @@ namespace Cognite.OpcUa.Pushers.Writers
             {
                 if (existing.TryGetValue(kvp.Key, out var asset))
                 {
-                    var assetUpdate = PusherUtils.GetAssetUpdate(config, asset, kvp.Value, extractor, update);
+                    var assetUpdate = PusherUtils.GetAssetUpdate(config, asset, kvp.Value, extractor);
 
                     if (assetUpdate == null)
                         continue;

--- a/Extractor/Pushers/Writers/CleanWriter.cs
+++ b/Extractor/Pushers/Writers/CleanWriter.cs
@@ -59,7 +59,7 @@ namespace Cognite.OpcUa.Pushers.Writers
         /// <param name="extractor">UAExtractor instance<param>
         /// <param name="nodes">Dictionary of mapping of variables to keys</param>
         /// <param name="nodeToAssetIds">Node to assets to ids</param>
-        /// <param name="update">Type update configuration</param>
+        /// <param name="report">Metrics about assets created and updated</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>Operation result</returns>
         public async Task<bool> PushAssets(
@@ -185,7 +185,6 @@ namespace Cognite.OpcUa.Pushers.Writers
         /// <param name="extractor">UAExtractor instance<param>
         /// <param name="assetMap">Dictionary of mapping of variables to keys</param>
         /// <param name="assets">List of assets</param>
-        /// <param name="update">Type update configuration</param>
         /// <param name="result">Operation result</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>Future list of assets</returns>

--- a/Extractor/Pushers/Writers/IdmWriter.cs
+++ b/Extractor/Pushers/Writers/IdmWriter.cs
@@ -105,7 +105,6 @@ namespace Cognite.OpcUa.Pushers.Writers
         public Task<bool> PushAssets(
             IUAClientAccess client,
             IDictionary<string, BaseUANode> nodes,
-            TypeUpdateConfig update,
             BrowseReport report,
             CancellationToken token
         )

--- a/Extractor/Pushers/Writers/MinimalTimeseriesWriter.cs
+++ b/Extractor/Pushers/Writers/MinimalTimeseriesWriter.cs
@@ -49,7 +49,7 @@ namespace Cognite.OpcUa.Pushers.Writers
         }
 
         protected override Task UpdateTimeseries(UAExtractor extractor, IDictionary<string, UAVariable> tsMap,
-                IEnumerable<TimeSeries> timeseries, IDictionary<NodeId, long> nodeToAssetIds, TypeUpdateConfig update, Result result, CancellationToken token)
+                IEnumerable<TimeSeries> timeseries, IDictionary<NodeId, long> nodeToAssetIds, Result result, CancellationToken token)
         {
             return Task.CompletedTask;
         }

--- a/Extractor/Pushers/Writers/RawWriter.cs
+++ b/Extractor/Pushers/Writers/RawWriter.cs
@@ -149,7 +149,6 @@ namespace Cognite.OpcUa.Pushers.Writers
         /// <param name="table">Name of metadata table in CDF</param>
         /// <param name="rows">Dictionary map of BaseUANode of their keys</param>
         /// <param name="converter">Converter</param>
-        /// <param name="shouldUpdate">Indicates if it is an update operation</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>Operation result</returns>
         private async Task<Result> PushRows<T>(UAExtractor extractor, string database, string table,
@@ -157,12 +156,12 @@ namespace Cognite.OpcUa.Pushers.Writers
         {
             var result = new Result { Created = 0, Updated = 0 };
 
-            await CreateRows(extractor, database, table, rows, converter, result, token);
+            await UpsertRows(extractor, database, table, rows, converter, result, token);
             return result;
         }
 
         /// <summary>
-        /// Creates all BaseUANode to CDF raw
+        /// Creates or updates the given BaseUANodes in CDF Raw.
         /// </summary>
         /// <param name="extractor">UAExtractor instance<param>
         /// <param name="database">Name of metadata database in CDF</param>
@@ -170,10 +169,9 @@ namespace Cognite.OpcUa.Pushers.Writers
         /// <param name="dataSet">Dictionary map of BaseUANode of their keys</param>
         /// <param name="converter">Converter</param>
         /// <param name="result">Operation result</param>
-        /// <param name="shouldUpdate">Indicates if it is an update operation</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>Task</returns>
-        private async Task CreateRows<T>(UAExtractor extractor, string database, string table,
+        private async Task UpsertRows<T>(UAExtractor extractor, string database, string table,
                 IDictionary<string, T> dataMap, ConverterType converter, Result result, CancellationToken token) where T : BaseUANode
         {
             var json = dataMap

--- a/Extractor/Pushers/Writers/TimeseriesWriter.cs
+++ b/Extractor/Pushers/Writers/TimeseriesWriter.cs
@@ -71,7 +71,7 @@ namespace Cognite.OpcUa.Pushers.Writers
         /// <param name="token">Cancellation token</param>
         /// <returns>Operation result</returns>
         protected override async Task UpdateTimeseries(UAExtractor extractor, IDictionary<string, UAVariable> tsMap,
-                IEnumerable<TimeSeries> timeseries, IDictionary<NodeId, long> nodeToAssetIds, TypeUpdateConfig update, Result result, CancellationToken token)
+                IEnumerable<TimeSeries> timeseries, IDictionary<NodeId, long> nodeToAssetIds, Result result, CancellationToken token)
         {
             var updates = new List<TimeSeriesUpdateItem>();
             var existing = timeseries.ToDictionary(asset => asset.ExternalId);
@@ -79,7 +79,7 @@ namespace Cognite.OpcUa.Pushers.Writers
             {
                 if (existing.TryGetValue(kvp.Key, out var ts))
                 {
-                    var tsUpdate = PusherUtils.GetTSUpdate(config, extractor, ts, kvp.Value, update, nodeToAssetIds);
+                    var tsUpdate = PusherUtils.GetTSUpdate(config, extractor, ts, kvp.Value, nodeToAssetIds);
                     if (tsUpdate == null) continue;
                     if (tsUpdate.AssetId != null || tsUpdate.Description != null
                         || tsUpdate.Name != null || tsUpdate.Metadata != null)

--- a/Extractor/Pushers/Writers/TimeseriesWriter.cs
+++ b/Extractor/Pushers/Writers/TimeseriesWriter.cs
@@ -65,8 +65,8 @@ namespace Cognite.OpcUa.Pushers.Writers
         /// </summary>
         /// <param name="extractor">UAExtractor instance<param>
         /// <param name="tsMap">Dictionary of mapping of variables to keys</param>
+        /// <param name="timeseries">Existing timeseries</param>
         /// <param name="nodeToAssetIds">Node to assets to ids</param>
-        /// <param name="update">Type update configuration</param>
         /// <param name="result">Operation result</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>Operation result</returns>

--- a/Extractor/State.cs
+++ b/Extractor/State.cs
@@ -152,9 +152,9 @@ namespace Cognite.OpcUa
         /// Add node to overview of known mapped nodes
         /// </summary>
         /// <param name="node">Node to add</param>
-        public void AddActiveNode(BaseUANode node, TypeUpdateConfig update, bool dataTypeMetadata, bool nodeTypeMetadata)
+        public void AddActiveNode(BaseUANode node, bool dataTypeMetadata, bool nodeTypeMetadata)
         {
-            mappedNodes[node.Id] = new MappedNode(node, update, dataTypeMetadata, nodeTypeMetadata);
+            mappedNodes[node.Id] = new MappedNode(node, dataTypeMetadata, nodeTypeMetadata);
         }
         /// <summary>
         /// Get node checksum by NodeId and index if it exists

--- a/Extractor/Types/MappedNode.cs
+++ b/Extractor/Types/MappedNode.cs
@@ -29,10 +29,10 @@ namespace Cognite.OpcUa.Types
         public bool IsObject { get; }
         public NodeClass NodeClass { get; }
 
-        public MappedNode(BaseUANode node, TypeUpdateConfig update, bool dataTypeMetadata, bool nodeTypeMetadata)
+        public MappedNode(BaseUANode node, bool dataTypeMetadata, bool nodeTypeMetadata)
         {
             Id = node.Id;
-            Checksum = node.GetUpdateChecksum(update, dataTypeMetadata, nodeTypeMetadata);
+            Checksum = node.GetUpdateChecksum(dataTypeMetadata, nodeTypeMetadata);
             IsProperty = node.IsProperty;
             IsObject = node is not UAVariable variable || variable.IsObject;
         }

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -896,7 +896,7 @@ namespace Cognite.OpcUa
 
             if (input.Objects.Any() || input.Variables.Any() || input.References.Any())
             {
-                var pushResult = await pusher.PushNodes(input.Objects, input.Variables, input.References, Config.Extraction.Update, Source.Token);
+                var pushResult = await pusher.PushNodes(input.Objects, input.Variables, input.References, Source.Token);
                 result.Apply(pushResult);
                 if (!result.Variables || !result.Objects || !result.References)
                 {

--- a/Test/CommonTestUtils.cs
+++ b/Test/CommonTestUtils.cs
@@ -204,14 +204,12 @@ namespace Test
         public static void VerifyStartingConditions(
             Dictionary<string, AssetDummy> assets,
             Dictionary<string, TimeseriesDummy> timeseries,
-            UpdateConfig upd,
             IUAClientAccess client,
             CustomNodeReference ids,
             bool raw)
         {
             ArgumentNullException.ThrowIfNull(assets);
             ArgumentNullException.ThrowIfNull(timeseries);
-            upd ??= new UpdateConfig();
             ArgumentNullException.ThrowIfNull(client);
             ArgumentNullException.ThrowIfNull(ids);
             Assert.Equal(6, assets.Count);
@@ -223,23 +221,23 @@ namespace Test
             var stringyId = client.GetUniqueId(ids.StringyVar);
             var mysteryId = client.GetUniqueId(ids.MysteryVar);
 
-            if (!upd.Objects.Name) Assert.Equal("CustomRoot", assets[rootId].name);
-            if (!upd.Objects.Description) Assert.True(string.IsNullOrEmpty(assets[rootId].description));
+            Assert.Equal("CustomRoot", assets[rootId].name);
+            Assert.True(string.IsNullOrEmpty(assets[rootId].description));
 
 
-            if (!upd.Variables.Name) Assert.Equal("StringyVar", timeseries[stringyId].name);
-            if (!upd.Variables.Description) Assert.True(string.IsNullOrEmpty(timeseries[stringyId].description));
+            Assert.Equal("StringyVar", timeseries[stringyId].name);
+            Assert.True(string.IsNullOrEmpty(timeseries[stringyId].description));
 
             if (raw)
             {
-                if (!upd.Variables.Context) Assert.Equal(rootId, (timeseries[stringyId] as StatelessTimeseriesDummy).assetExternalId);
+                Assert.Equal(rootId, (timeseries[stringyId] as StatelessTimeseriesDummy).assetExternalId);
             }
             else
             {
-                if (!upd.Variables.Context) Assert.Equal(assets[rootId].id, timeseries[stringyId].assetId);
+                Assert.Equal(assets[rootId].id, timeseries[stringyId].assetId);
             }
 
-            if (!upd.Objects.Context) Assert.Equal(rootId, assets[obj2Id].parentExternalId);
+            Assert.Equal(rootId, assets[obj2Id].parentExternalId);
 
             Dictionary<string, string> obj1Meta, obj2Meta, stringyMeta, mysteryMeta;
 
@@ -258,32 +256,25 @@ namespace Test
                 mysteryMeta = timeseries[mysteryId].metadata;
             }
 
-            if (!upd.Objects.Metadata)
-            {
-                Assert.True(obj1Meta == null || obj1Meta.Count == 0);
-                Assert.Equal(2, obj2Meta.Count);
-                Assert.Equal("1234", obj2Meta["NumericProp"]);
-            }
-            if (!upd.Variables.Metadata)
-            {
-                Assert.True(stringyMeta == null || stringyMeta.Count == 0);
-                Assert.Equal(2, mysteryMeta.Count);
-                Assert.Equal("(0, 100)", mysteryMeta["EURange"]);
-            }
 
+            Assert.True(obj1Meta == null || obj1Meta.Count == 0);
+            Assert.Equal(2, obj2Meta.Count);
+            Assert.Equal("1234", obj2Meta["NumericProp"]);
+
+            Assert.True(stringyMeta == null || stringyMeta.Count == 0);
+            Assert.Equal(2, mysteryMeta.Count);
+            Assert.Equal("(0, 100)", mysteryMeta["EURange"]);
         }
 
         public static void VerifyModified(
             Dictionary<string, AssetDummy> assets,
             Dictionary<string, TimeseriesDummy> timeseries,
-            UpdateConfig upd,
             IUAClientAccess client,
             CustomNodeReference ids,
             bool raw)
         {
             ArgumentNullException.ThrowIfNull(assets);
             ArgumentNullException.ThrowIfNull(timeseries);
-            upd ??= new UpdateConfig();
             ArgumentNullException.ThrowIfNull(client);
             ArgumentNullException.ThrowIfNull(ids);
             Assert.Equal(6, assets.Count);
@@ -295,20 +286,20 @@ namespace Test
             var stringyId = client.GetUniqueId(ids.StringyVar);
             var mysteryId = client.GetUniqueId(ids.MysteryVar);
 
-            if (upd.Objects.Name) Assert.Equal("CustomRoot updated", assets[rootId].name);
-            if (upd.Objects.Description) Assert.Equal("custom root description", assets[rootId].description);
+            Assert.Equal("CustomRoot updated", assets[rootId].name);
+            Assert.Equal("custom root description", assets[rootId].description);
 
-            if (upd.Variables.Name) Assert.Equal("StringyVar updated", timeseries[stringyId].name);
-            if (upd.Variables.Description) Assert.Equal("Stringy var description", timeseries[stringyId].description);
+            Assert.Equal("StringyVar updated", timeseries[stringyId].name);
+            Assert.Equal("Stringy var description", timeseries[stringyId].description);
             if (raw)
             {
-                if (upd.Objects.Context) Assert.Equal(obj1Id, assets[obj2Id].parentExternalId);
-                if (upd.Variables.Context) Assert.Equal(obj1Id, (timeseries[stringyId] as StatelessTimeseriesDummy).assetExternalId);
+                Assert.Equal(obj1Id, assets[obj2Id].parentExternalId);
+                Assert.Equal(obj1Id, (timeseries[stringyId] as StatelessTimeseriesDummy).assetExternalId);
             }
             else
             {
-                if (upd.Objects.Context) Assert.Equal(obj1Id, assets[obj2Id].parentExternalId);
-                if (upd.Variables.Context) Assert.Equal(assets[obj1Id].id, timeseries[stringyId].assetId);
+                Assert.Equal(obj1Id, assets[obj2Id].parentExternalId);
+                Assert.Equal(assets[obj1Id].id, timeseries[stringyId].assetId);
             }
 
             Dictionary<string, string> obj1Meta, obj2Meta, stringyMeta, mysteryMeta;
@@ -328,22 +319,16 @@ namespace Test
                 mysteryMeta = timeseries[mysteryId].metadata;
             }
 
+            Assert.Single(obj1Meta);
+            Assert.Equal("New asset prop value", obj1Meta["NewAssetProp"]);
+            Assert.Equal(2, obj2Meta.Count);
+            Assert.Equal("4321", obj2Meta["NumericProp"]);
+            Assert.True(obj2Meta.ContainsKey("StringProp updated"));
 
-            if (upd.Objects.Metadata)
-            {
-                Assert.Single(obj1Meta);
-                Assert.Equal("New asset prop value", obj1Meta["NewAssetProp"]);
-                Assert.Equal(2, obj2Meta.Count);
-                Assert.Equal("4321", obj2Meta["NumericProp"]);
-                Assert.True(obj2Meta.ContainsKey("StringProp updated"));
-            }
-            if (upd.Variables.Metadata)
-            {
-                Assert.Single(stringyMeta);
-                Assert.Equal("New prop value", stringyMeta["NewProp"]);
-                Assert.Equal(2, mysteryMeta.Count);
-                Assert.Equal("(0, 200)", mysteryMeta["EURange"]);
-            }
+            Assert.Single(stringyMeta);
+            Assert.Equal("New prop value", stringyMeta["NewProp"]);
+            Assert.Equal(2, mysteryMeta.Count);
+            Assert.Equal("(0, 200)", mysteryMeta["EURange"]);
         }
 
         private static readonly JsonSerializerOptions jsonOptions = new JsonSerializerOptions

--- a/Test/Unit/TypesTest.cs
+++ b/Test/Unit/TypesTest.cs
@@ -32,45 +32,19 @@ namespace Test.Unit
         }
         #region uanode
         [Theory]
-        [InlineData(true, true, true, true, true)]
-        [InlineData(true, true, true, true, false)]
-        [InlineData(true, true, true, false, false)]
-        [InlineData(true, true, false, false, false)]
-        [InlineData(true, false, false, false, false)]
-        [InlineData(false, true, false, false, false)]
-        [InlineData(false, false, true, false, false)]
-        [InlineData(false, false, false, true, true)]
-        [InlineData(false, false, false, false, false)]
-        [InlineData(true, false, true, false, true)]
-        public void TestChecksum(bool context, bool description, bool name, bool metadata, bool ntMeta)
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TestChecksum(bool ntMeta)
         {
-            var update = new TypeUpdateConfig
-            {
-                Context = context,
-                Description = description,
-                Name = name,
-                Metadata = metadata
-            };
             int csA, csB;
-            void AssertNotEqualIf(bool cond)
-            {
-                if (cond)
-                {
-                    Assert.NotEqual(csA, csB);
-                }
-                else
-                {
-                    Assert.Equal(csA, csB);
-                }
-            }
 
             var nodeA = new UAObject(new NodeId("node", 0), null, null, null, NodeId.Null, null);
             var nodeB = new UAObject(new NodeId("node", 0), null, null, null, NodeId.Null, null);
 
             (int, int) Update(BaseUANode nodeA, BaseUANode nodeB)
             {
-                int csA = nodeA.GetUpdateChecksum(update, false, ntMeta);
-                int csB = nodeB.GetUpdateChecksum(update, false, ntMeta);
+                int csA = nodeA.GetUpdateChecksum(false, ntMeta);
+                int csB = nodeB.GetUpdateChecksum(false, ntMeta);
                 return (csA, csB);
             }
 
@@ -81,7 +55,7 @@ namespace Test.Unit
             // Test name
             nodeA = new UAObject(new NodeId("node", 0), "name", null, null, NodeId.Null, null);
             (csA, csB) = Update(nodeA, nodeB);
-            AssertNotEqualIf(update.Name);
+            Assert.NotEqual(csA, csB);
             nodeB = new UAObject(new NodeId("node", 0), "name", null, null, NodeId.Null, null);
             (csA, csB) = Update(nodeA, nodeB);
             Assert.Equal(csA, csB);
@@ -89,7 +63,7 @@ namespace Test.Unit
             // Test context
             nodeA = new UAObject(new NodeId("node", 0), "name", null, null, new NodeId("parent", 0), null);
             (csA, csB) = Update(nodeA, nodeB);
-            AssertNotEqualIf(update.Context);
+            Assert.NotEqual(csA, csB);
             nodeB = new UAObject(new NodeId("node", 0), "name", null, null, new NodeId("parent", 0), null);
             (csA, csB) = Update(nodeA, nodeB);
             Assert.Equal(csA, csB);
@@ -98,7 +72,7 @@ namespace Test.Unit
             nodeA.Attributes.Description = "description";
             nodeB.Attributes.Description = "otherDesc";
             (csA, csB) = Update(nodeA, nodeB);
-            AssertNotEqualIf(update.Description);
+            Assert.NotEqual(csA, csB);
             nodeB.Attributes.Description = "description";
             (csA, csB) = Update(nodeA, nodeB);
             Assert.Equal(csA, csB);
@@ -125,7 +99,7 @@ namespace Test.Unit
                 propC, propD
             };
             (csA, csB) = Update(nodeA, nodeB);
-            AssertNotEqualIf(update.Metadata);
+            Assert.NotEqual(csA, csB);
             (nodeB.Attributes.Properties[1] as UAVariable).FullAttributes.Value = new Variant("valueB");
             (csA, csB) = Update(nodeA, nodeB);
             Assert.Equal(csA, csB);
@@ -134,7 +108,14 @@ namespace Test.Unit
             nodeA.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type", 0));
             nodeB.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type2", 0));
             (csA, csB) = Update(nodeA, nodeB);
-            AssertNotEqualIf(ntMeta && update.Metadata);
+            if (ntMeta)
+            {
+                Assert.NotEqual(csA, csB);
+            }
+            else
+            {
+                Assert.Equal(csA, csB);
+            }
             nodeB.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("type", 0));
             (csA, csB) = Update(nodeA, nodeB);
             Assert.Equal(csA, csB);
@@ -149,7 +130,7 @@ namespace Test.Unit
             nodeB.Attributes.AddProperty(nestProp2);
 
             (csA, csB) = Update(nodeA, nodeB);
-            AssertNotEqualIf(update.Metadata);
+            Assert.NotEqual(csA, csB);
             nestProp2.Attributes.Properties = nestProp.Attributes.Properties;
             (csA, csB) = Update(nodeA, nodeB);
             Assert.Equal(csA, csB);
@@ -162,7 +143,7 @@ namespace Test.Unit
             typeB.FullAttributes.DataType = pdt;
             typeB.FullAttributes.Value = new Variant("value2");
             (csA, csB) = Update(typeA, typeB);
-            AssertNotEqualIf(update.Metadata);
+            Assert.NotEqual(csA, csB);
             typeB.FullAttributes.Value = new Variant("value1");
             (csA, csB) = Update(typeA, typeB);
             Assert.Equal(csA, csB);

--- a/Test/Unit/UAExtractorTest.cs
+++ b/Test/Unit/UAExtractorTest.cs
@@ -78,6 +78,7 @@ namespace Test.Unit
             await extractor.WaitForSubscription(SubscriptionName.DataPoints);
             Assert.NotEmpty(pusher.PushedNodes);
             pusher.PushedNodes.Clear();
+            extractor.State.Clear();
             await extractor.OnServerReconnect(tester.Client);
 
             Assert.True(pusher.OnReset.WaitOne(10000));

--- a/Test/Utils/DummyPusher.cs
+++ b/Test/Utils/DummyPusher.cs
@@ -75,7 +75,6 @@ namespace Test.Utils
             IEnumerable<BaseUANode> objects,
             IEnumerable<UAVariable> variables,
             IEnumerable<UAReference> references,
-            UpdateConfig update,
             CancellationToken token)
         {
             var result = new PushResult

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -594,23 +594,6 @@ extraction:
     # events on the server node. These will be used to add new nodes automatically, by recursively browsing from each given ParentId.
     enable-audit-discovery:
 
-    # Update data in destinations on rebrowse or restart.
-    # Set auto-rebrowse-period to some value to do this periodically.
-    # Context refers to the structure of the node graph in OPC-UA. (assetId and parentId in CDF)
-    # Metadata refers to any information obtained from OPC-UA properties. (metadata in CDF)
-    # Enabling anything here will increase the startup- and rebrowse-time of the extractor. Enabling metadata will increase it more.
-    update:
-        objects:
-            name: false
-            description: false
-            context: false
-            metadata: false
-        variables:
-            name: false
-            description: false
-            context: false
-            metadata: false
-
     # Map OPC-UA non-hierarchical references to relationships in CDF.
     # The generated relationships will have external-id
     # [prefix][reference type name (or inverse-name)];[namespace source][id source];[namespace target][id target]

--- a/schema/extraction_config.schema.json
+++ b/schema/extraction_config.schema.json
@@ -72,21 +72,6 @@
             "description": "Time between each push to destinations. Format is as given in [Timestamps and intervals](#timestamps-and-intervals).",
             "default": "1s"
         },
-        "update": {
-            "type": "object",
-            "description": "Update data in destinations on re-browse or restart. Set `auto-rebrowse-period` to do this periodically.",
-            "unevaluatedProperties": false,
-            "properties": {
-                "objects": {
-                    "$ref": "type-update-config",
-                    "description": "Configuration for updating objects and object types."
-                },
-                "variables": {
-                    "$ref": "type-update-config",
-                    "description": "Configuration for updating variables and variable types."
-                }
-            }
-        },
         "data-types": {
             "$ref": "data-type-config"
         },
@@ -232,29 +217,6 @@
         }
     },
     "$defs": {
-        "type-update-config": {
-            "type": "object",
-            "$id": "type-update-config",
-            "unevaluatedProperties": false,
-            "properties": {
-                "description": {
-                    "type": "boolean",
-                    "description": "Set to `true` to update description"
-                },
-                "context": {
-                    "type": "boolean",
-                    "description": "Set to `true` to update context, i.e. the position of the node in the node hierarchy"
-                },
-                "metadata": {
-                    "type": "boolean",
-                    "description": "Set to `true` to update metadata, including fields like `unit`."
-                },
-                "name": {
-                    "type": "boolean",
-                    "description": "Set to `true` to update name."
-                }
-            }
-        },
         "proto-data-type": {
             "type": "object",
             "$id": "proto-data-type",


### PR DESCRIPTION
When we added support for "updating" metadata in CDF, it was done in a very flexible way.

Now that we write to DM more, it really makes a lot less sense, since depending on where you write there is no way to _not_ update. We had some absolutely insane code to enable "updates" to Raw that can also be removed (no other extractors do anything like that).

In general, making updates non-optional greatly simplifies the extractor, and is almost certainly what pretty much every user wants.

Also identifies and fixes a bug related to the `Source` of arrays, this was never caught due to a hole in a test.