### PR TITLE
Reduce default concurrency in config.example.yml

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -386,7 +386,7 @@ cognite:
         # Maximum number of parallel requests per timeseries operation
         time-series: 20
         # Maximum number of parallel requests per assets operation
-        assets: 20
+        assets: 1
         # Maximum number of parallel requests per datapoints operation
         data-points: 10
         # Maximum number of parallel requests per raw operation
@@ -394,9 +394,9 @@ cognite:
         # Maximum number of parallel requests per get first/last datapoint operation
         ranges: 20
         # Maximum number of parallel requests per events operation
-        events: 20
+        events: 1
         # Maximum number of parallel requests per data modeling instances operation
-        instances: 4
+        instances: 1
         # Maximum number of parallel requests per data modeling records operation
         stream-records: 4
     # Configure if the SDK should do logging of requests


### PR DESCRIPTION
The default concurrency settings should be conservative and increased when there's a need rather than be high by default and scaled down when they cause problems.