### PR TITLE
Fix sanitation of DM external IDs

### DIFF
--- a/Extractor/Pushers/FDM/BaseDataModelDefinitions.cs
+++ b/Extractor/Pushers/FDM/BaseDataModelDefinitions.cs
@@ -161,10 +161,6 @@ namespace Cognite.OpcUa.Pushers.FDM
                         Nullable = false,
                         Name = "TypeHierarchy"
                     } }
-                },
-                Indexes = new Dictionary<string, BaseIndex>
-                {
-                    { "typeHierarchy_index", new BTreeIndex { Properties = new[] { "TypeHierarchy" } } }
                 }
             };
         }

--- a/Extractor/Pushers/FDM/FDMUtils.cs
+++ b/Extractor/Pushers/FDM/FDMUtils.cs
@@ -6,10 +6,16 @@ namespace Cognite.OpcUa.Pushers.FDM
     public static class FDMUtils
     {
         private static readonly Regex extIdRegex = new Regex("^[a-zA-Z]([a-zA-Z0-9_]{0,253}[a-zA-Z0-9])?$", RegexOptions.Compiled);
+        private static readonly Regex illegalSymbol = new Regex("[^a-zA-Z0-9]", RegexOptions.Compiled);
 
         public static string SanitizeExternalId(string raw)
         {
-            var clean = raw.Replace('-', '_').Replace(' ', '_').Replace("<", "").Replace(">", "").Replace("/", "_").Replace("+", "_").Replace(".", "_").Replace("@", "_");
+            var clean = illegalSymbol.Replace(raw, match => match.Value switch
+            {
+                "<" => "",
+                ">" => "",
+                _ => "_"
+            }).TrimEnd('_');
 
             var c0 = clean[0];
             if (!(c0 >= 'a' && c0 <= 'z') && !(c0 >= 'A' && c0 <= 'Z'))

--- a/Test/Unit/FDMTests.cs
+++ b/Test/Unit/FDMTests.cs
@@ -1,5 +1,6 @@
 ﻿using Cognite.Extractor.StateStorage;
 using Cognite.OpcUa.Config;
+using Cognite.OpcUa.Pushers.FDM;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
@@ -211,6 +212,17 @@ namespace Test.Unit
 
             var pubSubDiagnosticsType = handler.Views["PubSubDiagnosticsType"];
             Assert.Equal(10, pubSubDiagnosticsType["properties"].AsObject().Count);
+        }
+
+        [Theory]
+        [InlineData("test", "test")]
+        [InlineData("MyObject#", "MyObject")] // _ is not allowed at the end of a name so we trim them.
+        [InlineData("**ReallyCool_Object**", "opc__ReallyCool_Object")]
+        [InlineData("<CoolPlaceHolder>", "CoolPlaceHolder")] // < and > are used in OPC-UA placeholders, so they are not replaced.
+        [InlineData("ÆÆÆÆÆÆWeirdId", "opc______WeirdId")] // Adds a prefix since _ is not allowed at the start of a name...
+        public void TestSanitizeExternalId(string id, string expected)
+        {
+            Assert.Equal(expected, FDMUtils.SanitizeExternalId(id));
         }
     }
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.33.1":
+    description: Improve sanitation of data modeling external IDs.
+    changelog:
+      fixed:
+        - Fix incomplete sanitation of data modeling external IDs.
   "2.33.0":
     description: Release improvements to connection logic.
     changelog:


### PR DESCRIPTION
The way we did it was dumb and also didn't work for every case. This is a much better way to do it.

Also remove the index on `TypeHierarchy`. I'm reasonably certain this was a breaking change in DM...