### PR TITLE
Bump OPC-UA SDK

### DIFF
--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="AdysTech.InfluxDB.Client.Net.Core" Version="0.25.0" />
     <PackageReference Include="Cognite.ExtractorUtils" Version="1.29.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.374.158" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.374.158" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.374.158-beta" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.375.443" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.443" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.375.443-beta" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.374.158" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.374.158-beta" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.374.158" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.443" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.375.443-beta" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.375.443" />
   </ItemGroup>
 </Project>

--- a/Server/ServerController.cs
+++ b/Server/ServerController.cs
@@ -93,7 +93,7 @@ namespace Server
                     cfg.SecurityConfiguration.TrustedPeerCertificates.StorePath = $"{certPath}/pki/trusted";
                     cfg.SecurityConfiguration.RejectedCertificateStore.StorePath = $"{certPath}/pki/rejected";
                 }
-                await app.CheckApplicationInstanceCertificate(false, 0);
+                await app.CheckApplicationInstanceCertificates(false);
                 Server = new TestServer(setups, mqttUrl, provider, logTrace, nodeSetFiles);
                 await Task.Run(async () => await app.Start(Server));
                 log.LogInformation("Server started on address: {Address}", address);

--- a/Server/TestServer.cs
+++ b/Server/TestServer.cs
@@ -147,7 +147,7 @@ namespace Server
             else
             {
                 var validator = new CertificateValidator();
-                validator.Update(fullConfig.SecurityConfiguration);
+                validator.Update(fullConfig);
                 validator.Update(
                     fullConfig.SecurityConfiguration.UserIssuerCertificates,
                     fullConfig.SecurityConfiguration.TrustedUserCertificates,
@@ -224,7 +224,7 @@ namespace Server
             args.Identity.GrantedRoleIds.Add(ObjectIds.WellKnownRole_SecurityAdmin);
         }
 
-        private IEnumerable<NodeSetBundle> BuildNodeSetFiles(ISystemContext context)
+        private IEnumerable<NodeSetBundle> BuildNodeSetFiles(ServerSystemContext context)
         {
             if (nodeSetFiles == null || !nodeSetFiles.Any()) return Enumerable.Empty<NodeSetBundle>();
             var results = new List<NodeSetBundle>();

--- a/Test/Integration/NodeExtractionTests.cs
+++ b/Test/Integration/NodeExtractionTests.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Test.Utils;
 using Xunit;
@@ -1101,13 +1102,15 @@ namespace Test.Integration
             // ... and that the JSON looks right
             var metaElem = root.ToJson(log, extractor.StringConverter, ConverterType.Node);
             var metaString = CommonTestUtils.JsonElementToString(metaElem.RootElement.GetProperty("metadata"));
-            // This wouldn't work in clean, since there is only a single very large metadata field, but it is a much more useful input to Raw.
-            Assert.Equal(@"{""CustomRoot"":{""ChildObject"":null,""ChildObject2"":{""NumericProp"":1234,""StringProp"":""String prop value""},"
+            var refJson = JsonNode.Parse(@"{""CustomRoot"":{""ChildObject"":null,""ChildObject2"":{""NumericProp"":1234,""StringProp"":""String prop value""},"
             + @"""Variable Array"":{""Value"":[0,0,0,0],""EngineeringUnits"":""°C: degree Celsius"",""EURange"":""(0, 100)""},"
             + @"""Variable StringArray"":[""test1"",""test2""],""StringyVar"":null,""IgnoreVar"":null,"
             + @"""MysteryVar"":{""Value"":null,""EngineeringUnits"":""°C: degree Celsius"",""EURange"":""(0, 100)""},"
             + @"""NumberVar"":{""Value"":null,""DeepProp"":{""DeepProp2"":{""val1"":""value 1"",""val2"":""value 2""}}},"
-            + @"""EnumVar1"":""Enum2"",""EnumVar2"":""VEnum2"",""EnumVar3"":[""VEnum2"",""VEnum2"",""VEnum1"",""VEnum2""]}}", metaString);
+            + @"""EnumVar1"":""Enum2"",""EnumVar2"":""VEnum2"",""EnumVar3"":[""VEnum2"",""VEnum2"",""VEnum1"",""VEnum2""]}}");
+            var metaJson = JsonNode.Parse(metaString);
+            // This wouldn't work in clean, since there is only a single very large metadata field, but it is a much more useful input to Raw.
+            Assert.True(JsonNode.DeepEquals(refJson, metaJson));
         }
         [Fact]
         public async Task TestArrayPropertiesWithoutMaxArraySize()
@@ -1149,12 +1152,14 @@ namespace Test.Integration
             var metaElem = root.ToJson(log, extractor.StringConverter, ConverterType.Node);
             var metaString = CommonTestUtils.JsonElementToString(metaElem.RootElement.GetProperty("metadata"));
             // This wouldn't work in clean, since there is only a single very large metadata field, but it is a much more useful input to Raw.
-            Assert.Equal(@"{""CustomRoot"":{""ChildObject"":null,""ChildObject2"":{""NumericProp"":1234,""StringProp"":""String prop value""},"
+            var refJson = JsonNode.Parse(@"{""CustomRoot"":{""ChildObject"":null,""ChildObject2"":{""NumericProp"":1234,""StringProp"":""String prop value""},"
             + @"""Variable Array"":{""Value"":[0,0,0,0],""EngineeringUnits"":""°C: degree Celsius"",""EURange"":""(0, 100)""},"
             + @"""Variable StringArray"":[""test1"",""test2""],""StringyVar"":null,""IgnoreVar"":null,"
             + @"""MysteryVar"":{""Value"":null,""EngineeringUnits"":""°C: degree Celsius"",""EURange"":""(0, 100)""},"
             + @"""NumberVar"":{""Value"":null,""DeepProp"":{""DeepProp2"":{""val1"":""value 1"",""val2"":""value 2""}}},"
-            + @"""EnumVar1"":1,""EnumVar2"":123,""EnumVar3"":[123,123,321,123]}}", metaString);
+            + @"""EnumVar1"":1,""EnumVar2"":123,""EnumVar3"":[123,123,321,123]}}");
+            var metaJson = JsonNode.Parse(metaString);
+            Assert.True(JsonNode.DeepEquals(refJson, metaJson));
         }
         [Fact]
         public async Task TestLateIgnore()

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -92,7 +92,7 @@ namespace Test.Utils
 
         }
 
-        private static void ResetType(object obj, object reference)
+        public static void ResetType(object obj, object reference)
         {
             if (obj == null) return;
             var type = obj.GetType();


### PR DESCRIPTION
Fixes a pair of tests that did raw JSON comparisons. Something changed somewhere, but we should be doing context-aware comparisons for JSON anyway.