### PR TITLE
Make status codes enabled always

### DIFF
--- a/Extractor/Config/CogniteConfig.cs
+++ b/Extractor/Config/CogniteConfig.cs
@@ -55,16 +55,6 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public CDFNodeSourceConfig? RawNodeBuffer { get; set; }
         /// <summary>
-        /// Replacement for NaN values.
-        /// </summary>
-        public double? NonFiniteReplacement
-        {
-            get => NanReplacement;
-            set => NanReplacement = value == null || double.IsFinite(value.Value)
-                && value.Value > CogniteUtils.NumericValueMin
-                && value.Value < CogniteUtils.NumericValueMax ? value : null;
-        }
-        /// <summary>
         /// There is no good way to mark relationships as deleted, so they are hard-deleted.
         /// This has to be enabled to delete relationships deleted from OPC-UA. This requires extraction.deletes to be enabled.
         /// Alternatively, use Raw, where relationships can be marked as deleted.

--- a/Extractor/Config/Common.cs
+++ b/Extractor/Config/Common.cs
@@ -71,9 +71,5 @@ namespace Cognite.OpcUa.Config
     }
     public interface IPusherConfig
     {
-        /// <summary>
-        /// Replacement for NaN values.
-        /// </summary>
-        public double? NonFiniteReplacement { get; set; }
     }
 }

--- a/Extractor/Config/ExtractionConfig.cs
+++ b/Extractor/Config/ExtractionConfig.cs
@@ -155,9 +155,6 @@ namespace Cognite.OpcUa.Config
         /// Server namespace nodes the should be subscribed to a rebrowse upon changes to their values.
         /// </summary>
         public RebrowseTriggersConfig? RebrowseTriggers { get; set; }
-
-        private StatusConfig statusCodes = new StatusConfig();
-        public StatusConfig StatusCodes { get => statusCodes; set => statusCodes = value ?? statusCodes; }
     }
     public class DataTypeConfig
     {
@@ -677,22 +674,5 @@ namespace Cognite.OpcUa.Config
         /// NodeFilter. All non-null filters must match each node for the transformation to be applied.
         /// </summary>
         public NodeFilter? Filter { get; set; }
-    }
-
-    public enum StatusCodeMode
-    {
-        GoodOnly,
-        Uncertain,
-        All
-    }
-
-    public class StatusConfig
-    {
-        /// <summary>
-        /// Default behavior, ignore bad data points.
-        /// </summary>
-        public StatusCodeMode StatusCodesToIngest { get; set; } = StatusCodeMode.GoodOnly;
-
-        public bool IngestStatusCodes { get; set; }
     }
 }

--- a/Extractor/History/HistoryScheduler.cs
+++ b/Extractor/History/HistoryScheduler.cs
@@ -584,20 +584,6 @@ namespace Cognite.OpcUa.History
                             log.LogTrace("Bad history datapoint: {BadDatapointExternalId} {SourceTimestamp}. Value: {Value}, Status: {Status}",
                                 node.State.Id, dp.SourceTimestamp, dp.Value, ExtractorUtils.GetStatusCodeName((uint)dp.StatusCode));
                         }
-
-                        switch (fullConfig.Extraction.StatusCodes.StatusCodesToIngest)
-                        {
-                            case StatusCodeMode.All:
-                                break;
-                            case StatusCodeMode.Uncertain:
-                                if (!StatusCode.IsUncertain(dp.StatusCode))
-                                {
-                                    continue;
-                                }
-                                break;
-                            case StatusCodeMode.GoodOnly:
-                                continue;
-                        }
                     }
                     dataPoints.Add(dp);
                 }

--- a/Extractor/Pushers/CDFPusher.cs
+++ b/Extractor/Pushers/CDFPusher.cs
@@ -140,7 +140,7 @@ namespace Cognite.OpcUa.Pushers
             {
                 var inserts = dataPointList.ToDictionary(
                     kvp => Identity.Create(new InstanceIdentifier(config.MetadataTargets.Clean.Space, kvp.Key)),
-                    kvp => kvp.Value.SelectNonNull(dp => dp.ToCDFDataPoint(fullConfig.Extraction.StatusCodes.IngestStatusCodes, log))
+                    kvp => kvp.Value.SelectNonNull(dp => dp.ToCDFDataPoint(log))
                 );
                 return await PushDataPointsIdm(inserts, count, token);
             }
@@ -148,7 +148,7 @@ namespace Cognite.OpcUa.Pushers
             {
                 var inserts = dataPointList.ToDictionary(
                     kvp => Identity.Create(kvp.Key),
-                    kvp => kvp.Value.SelectNonNull(dp => dp.ToCDFDataPoint(fullConfig.Extraction.StatusCodes.IngestStatusCodes, log))
+                    kvp => kvp.Value.SelectNonNull(dp => dp.ToCDFDataPoint(log))
                 );
                 return await PushDataPointsClassic(inserts, count, token);
             }

--- a/Extractor/Streamer.cs
+++ b/Extractor/Streamer.cs
@@ -357,20 +357,6 @@ namespace Cognite.OpcUa
                     log.LogDebug("Bad streaming datapoint: {BadDatapointExternalId} {SourceTimestamp}. Value: {Value}, Status: {Status}",
                         node.Id, datapoint.SourceTimestamp, datapoint.Value, ExtractorUtils.GetStatusCodeName((uint)datapoint.StatusCode));
                 }
-
-                switch (config.Extraction.StatusCodes.StatusCodesToIngest)
-                {
-                    case StatusCodeMode.All:
-                        break;
-                    case StatusCodeMode.Uncertain:
-                        if (!StatusCode.IsUncertain(datapoint.StatusCode))
-                        {
-                            return;
-                        }
-                        break;
-                    case StatusCodeMode.GoodOnly:
-                        return;
-                }
             }
 
             timeToExtractorDps.Observe((DateTime.UtcNow - datapoint.SourceTimestamp).TotalSeconds);
@@ -389,10 +375,6 @@ namespace Cognite.OpcUa
             {
                 node.UpdateFromStream(buffDps);
             }
-
-            if ((extractor.StateStorage == null || config.StateStorage.IntervalValue.Value == Timeout.InfiniteTimeSpan)
-                 && (node.IsFrontfilling && datapoint.SourceTimestamp > node.SourceExtractedRange.Last
-                    || node.IsBackfilling && datapoint.SourceTimestamp < node.SourceExtractedRange.First)) return;
 
             foreach (var buffDp in buffDps)
             {

--- a/Extractor/Types/UADataPoint.cs
+++ b/Extractor/Types/UADataPoint.cs
@@ -104,17 +104,14 @@ namespace Cognite.OpcUa.Types
         }
 
 
-        public Datapoint? ToCDFDataPoint(bool includeStatusCodes, ILogger logger)
+        public Datapoint? ToCDFDataPoint(ILogger logger)
         {
             CogniteSdk.StatusCode? status = null;
-            if (includeStatusCodes)
+            var res = CogniteSdk.StatusCode.TryCreate(Status.Code, out status);
+            if (res != null)
             {
-                var res = CogniteSdk.StatusCode.TryCreate(Status.Code, out status);
-                if (res != null)
-                {
-                    logger.LogWarning("Invalid status code, skipping data point: {Status}", res);
-                    return null;
-                }
+                logger.LogWarning("Invalid status code, skipping data point: {Status}", res);
+                return null;
             }
 
             if (!IsString)

--- a/Test/Integration/DataPointTests.cs
+++ b/Test/Integration/DataPointTests.cs
@@ -358,9 +358,6 @@ namespace Test.Integration
         [Fact]
         public async Task TestIngestDataPointsWithStatus()
         {
-            tester.Config.Extraction.StatusCodes.IngestStatusCodes = true;
-            tester.Config.Extraction.StatusCodes.StatusCodesToIngest = StatusCodeMode.All;
-
             using var pusher = new DummyPusher(new DummyPusherConfig());
             using var extractor = tester.BuildExtractor(pusher);
 
@@ -957,7 +954,9 @@ namespace Test.Integration
             pusher.PushDataPointResult = DataPushResult.Success;
             pusher.TestConnectionResult = true;
 
-            await TestUtils.WaitForCondition(() => pusher.DataPoints[(ids.DoubleVar1, -1)].Count >= 1002, 10);
+            tester.Server.UpdateNode(ids.DoubleVar2, 3);
+            await TestUtils.WaitForCondition(() => pusher.DataPoints[(ids.DoubleVar1, -1)].Count >= 1002, 10,
+                () => $"Expected at least 1002 points to arrive in buffer, got {pusher.DataPoints[(ids.DoubleVar1, -1)].Count}");
 
             Assert.Equal(1002, pusher.DataPoints[(ids.DoubleVar1, -1)].DistinctBy(dp => dp.Timestamp).Count());
             Assert.True(pusher.DataPoints[(ids.DoubleVar2, -1)].Count >= 2);

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -194,8 +194,6 @@ namespace Test.Unit
         [Fact]
         public async Task TestPushDataPointsWithStatus()
         {
-            tester.Config.Extraction.StatusCodes.IngestStatusCodes = true;
-
             handler.MockTimeseries("test-ts-double");
 
             var dps = new[] {
@@ -221,8 +219,6 @@ namespace Test.Unit
         [Fact]
         public async Task TestPushDataPointsNull()
         {
-            tester.Config.Extraction.StatusCodes.IngestStatusCodes = true;
-
             handler.MockTimeseries("test-ts-double");
 
             var start = DateTime.UnixEpoch;

--- a/Test/Unit/HistoryReaderTest.cs
+++ b/Test/Unit/HistoryReaderTest.cs
@@ -153,10 +153,10 @@ namespace Test.Unit
                 ContinuationPoint = new byte[] { 1, 2, 3 }
             };
             historyDataHandler.Invoke(reader, new object[] { node });
-            Assert.Equal(100, node.TotalRead);
+            Assert.Equal(200, node.TotalRead);
             Assert.Equal(start.AddSeconds(99), state1.SourceExtractedRange.Last);
             Assert.True(state1.IsFrontfilling);
-            Assert.Equal(100, queue.Count);
+            Assert.Equal(200, queue.Count);
             Assert.True(CommonTestUtils.TestMetricValue("opcua_bad_datapoints", 100));
 
             // Test flush buffer

--- a/Test/Unit/StreamerTest.cs
+++ b/Test/Unit/StreamerTest.cs
@@ -303,10 +303,10 @@ namespace Test.Unit
             var item = new MonitoredItem() { StartNodeId = new NodeId("id", 0), CacheQueueSize = 10 };
             var values = new[]
             {
-                (DateTime.UtcNow, 100.0, StatusCodes.Good), // OK value
-                (DateTime.UtcNow, 100.0, StatusCodes.Bad), // Bad value
-                (DateTime.UtcNow.AddDays(1), -100.0, StatusCodes.Good), // Too late
-                (DateTime.UtcNow.Subtract(TimeSpan.FromDays(1)), -100.0, StatusCodes.Good) // Too early
+                (DateTime.UtcNow, 100.0, StatusCodes.Good),
+                (DateTime.UtcNow, 100.0, StatusCodes.Bad),
+                (DateTime.UtcNow.AddDays(1), -100.0, StatusCodes.Good),
+                (DateTime.UtcNow.Subtract(TimeSpan.FromDays(1)), -100.0, StatusCodes.Good)
             };
             var notifications = values.Select(val => new MonitoredItemNotification
             {
@@ -315,19 +315,19 @@ namespace Test.Unit
             foreach (var not in notifications) item.SaveValueInCache(not);
             extractor.Streamer.DataSubscriptionHandler(item, null);
 
-            Assert.Equal(1, queue.Count);
+            Assert.Equal(4, queue.Count);
 
             node.UpdateFromFrontfill(DateTime.MinValue, true);
             foreach (var not in notifications) item.SaveValueInCache(not);
             extractor.Streamer.DataSubscriptionHandler(item, null);
 
-            Assert.Equal(3, queue.Count); // 2 more this time
+            Assert.Equal(8, queue.Count); // Another 4
 
             node.UpdateFromBackfill(DateTime.MaxValue, true);
             foreach (var not in notifications) item.SaveValueInCache(not);
             extractor.Streamer.DataSubscriptionHandler(item, null);
 
-            Assert.Equal(6, queue.Count);
+            Assert.Equal(12, queue.Count);
 
             Assert.True(CommonTestUtils.TestMetricValue("opcua_bad_datapoints", 3));
 
@@ -335,7 +335,7 @@ namespace Test.Unit
             foreach (var not in notifications) item2.SaveValueInCache(not);
             extractor.Streamer.DataSubscriptionHandler(item2, null);
 
-            Assert.Equal(6, queue.Count);
+            Assert.Equal(12, queue.Count);
         }
         [Fact]
         public void TestToDataPoint()

--- a/Test/Utils/DummyPusher.cs
+++ b/Test/Utils/DummyPusher.cs
@@ -15,7 +15,6 @@ namespace Test.Utils
 {
     public class DummyPusherConfig : IPusherConfig
     {
-        public double? NonFiniteReplacement { get; set; }
     }
     public sealed class DummyPusher : IPusher
     {

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -221,8 +221,6 @@ cognite:
     project:
     # Cognite service url
     host: "https://api.cognitedata.com"
-    # Replace all instances of NaN with this floating point number. If left empty, ignore instead.
-    nan-replacement:
     # Data set to use for new objects. Existing objects will not be updated
     data-set:
         # Data set internal id.


### PR DESCRIPTION
Also removes `NonFiniteReplacement` which no longer does anything.

This should be a relatively clean removal.