### PR TITLE
Remove history buffer thingy

### DIFF
--- a/Extractor/History/EventExtractionState.cs
+++ b/Extractor/History/EventExtractionState.cs
@@ -17,9 +17,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
 
 using Cognite.OpcUa.Types;
 using Opc.Ua;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Cognite.OpcUa.History
 {

--- a/Extractor/History/EventExtractionState.cs
+++ b/Extractor/History/EventExtractionState.cs
@@ -30,10 +30,6 @@ namespace Cognite.OpcUa.History
     /// </summary>
     public sealed class EventExtractionState : UAHistoryExtractionState
     {
-        /// <summary>
-        /// Last known timestamp of events from OPC-UA.
-        /// </summary>
-        private IList<UAEvent>? buffer;
         public bool ShouldSubscribe { get; }
 
         public EventExtractionState(
@@ -42,10 +38,6 @@ namespace Cognite.OpcUa.History
             bool frontfill, bool backfill, bool subscription)
             : base(client, emitterId, frontfill, backfill)
         {
-            if (frontfill)
-            {
-                buffer = new List<UAEvent>();
-            }
             ShouldSubscribe = subscription;
         }
 
@@ -57,52 +49,6 @@ namespace Cognite.OpcUa.History
         {
             if (evt == null) return;
             UpdateFromStream(evt.Time, evt.Time);
-            lock (Mutex)
-            {
-                if (IsFrontfilling)
-                {
-                    buffer?.Add(evt);
-                }
-            }
-        }
-        private void RefreshBuffer()
-        {
-            if (buffer == null) return;
-            lock (Mutex)
-            {
-                buffer = buffer.Where(evt => !SourceExtractedRange.Contains(evt.Time)).ToList();
-            }
-        }
-        public override void UpdateFromBackfill(DateTime first, bool final)
-        {
-            base.UpdateFromBackfill(first, final);
-            if (!final)
-            {
-                RefreshBuffer();
-            }
-        }
-
-        public override void UpdateFromFrontfill(DateTime last, bool final)
-        {
-            base.UpdateFromFrontfill(last, final);
-            if (!final)
-            {
-                RefreshBuffer();
-            }
-        }
-        /// <summary>
-        /// Retrieve contents of the buffer after final historyRead iteration
-        /// </summary>
-        /// <returns>The contents of the buffer</returns>
-        public IEnumerable<UAEvent> FlushBuffer()
-        {
-            if (IsFrontfilling || buffer == null || !buffer.Any()) return Array.Empty<UAEvent>();
-            lock (Mutex)
-            {
-                var result = buffer.Where(evt => !SourceExtractedRange.Contains(evt.Time)).ToList();
-                buffer.Clear();
-                return result;
-            }
         }
     }
 }

--- a/Extractor/History/HistoryScheduler.cs
+++ b/Extractor/History/HistoryScheduler.cs
@@ -623,16 +623,6 @@ namespace Cognite.OpcUa.History
 
             node.LastRead = cnt;
             node.TotalRead += cnt;
-
-            if (!node.Completed || !Frontfill) return;
-
-            var buffered = nodeState.FlushBuffer();
-            if (buffered.Any())
-            {
-                log.LogDebug("Read {Count} datapoints from buffer of state {Id}", buffered.Count(), node.State.Id);
-                nodeState.UpdateFromStream(buffered);
-                await extractor.Streamer.EnqueueAsync(buffered);
-            }
         }
 
         private static DateTime? GetTimeAttribute(VariantCollection evt, EventFilter filter)
@@ -731,19 +721,6 @@ namespace Cognite.OpcUa.History
 
             node.LastRead = createdEvents.Count;
             node.TotalRead += createdEvents.Count;
-
-            if (!node.Completed || !Frontfill) return;
-
-            if (node.State is not EventExtractionState emitterState) return;
-
-            var buffered = emitterState.FlushBuffer();
-            if (buffered.Any())
-            {
-                var (smin, smax) = buffered.MinMax(dp => dp.Time);
-                emitterState.UpdateFromStream(smin, smax);
-                log.LogDebug("Read {Count} events from buffer of state {Id}", buffered.Count(), node.State.Id);
-                await extractor.Streamer.EnqueueAsync(buffered);
-            }
         }
         #endregion
     }

--- a/Extractor/History/VariableExtractionState.cs
+++ b/Extractor/History/VariableExtractionState.cs
@@ -45,9 +45,6 @@ namespace Cognite.OpcUa.History
         public string DisplayName { get; }
         public bool AsEvents { get; }
 
-        private readonly int publishingInterval;
-        private readonly List<UADataPoint>? buffer;
-
         [MemberNotNullWhen(true, nameof(ArrayDimensions))]
         public bool IsArray => ArrayDimensions != null && ArrayDimensions.Length == 1 && ArrayDimensions[0] > 0;
 
@@ -63,11 +60,6 @@ namespace Cognite.OpcUa.History
             DisplayName = variable.Name ?? "";
             ShouldSubscribe = subscription;
             AsEvents = variable.AsEvents;
-            publishingInterval = client.PublishingInterval;
-            if (frontfill)
-            {
-                buffer = new List<UADataPoint>();
-            }
         }
         /// <summary>
         /// Update time range and buffer from stream.
@@ -77,64 +69,6 @@ namespace Cognite.OpcUa.History
         {
             if (!points.Any()) return;
             UpdateFromStream(DateTime.MaxValue, points.Max(pt => pt.Timestamp));
-            lock (Mutex)
-            {
-                if (IsFrontfilling && buffer != null)
-                {
-                    // Only keep datapoints with timestamps that are reasonably recent.
-                    var nextThreshold = DateTime.UtcNow - TimeSpan.FromMilliseconds(publishingInterval * 4);
-                    buffer.RemoveAll(dp => dp.Timestamp < nextThreshold);
-                    // Only add datapoints that are outside the current extracted range, others we don't need to buffer.
-                    buffer.AddRange(points.Where(dp => dp.Timestamp >= nextThreshold && !DestinationExtractedRange.Contains(dp.Timestamp)));
-                }
-            }
-        }
-        /// <summary>
-        /// Update last known timestamp from HistoryRead results. Empties the buffer if final is false.
-        /// </summary>
-        /// <param name="last">Latest timestamp in received values</param>
-        /// <param name="final">True if this is the final iteration of history read</param>
-        public override void UpdateFromFrontfill(DateTime last, bool final)
-        {
-            lock (Mutex)
-            {
-                SourceExtractedRange = SourceExtractedRange.Extend(null, last);
-                if (!final)
-                {
-                    buffer?.Clear();
-                }
-                else
-                {
-                    IsFrontfilling = false;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Retrieve the buffer after the final iteration of HistoryRead. Filters out data received before the last known timestamp.
-        /// </summary>
-        /// <returns>The contents of the buffer once called.</returns>
-        public IEnumerable<UADataPoint> FlushBuffer()
-        {
-            if (IsFrontfilling || buffer == null || buffer.Count == 0) return Array.Empty<UADataPoint>();
-            lock (Mutex)
-            {
-                var result = buffer.Where(pt => pt.Timestamp > SourceExtractedRange.Last).ToList();
-                buffer.Clear();
-                return result;
-            }
-        }
-
-        public override void RestartHistory()
-        {
-            base.RestartHistory();
-
-            // We're going to be re-reading history, so clear the buffer
-            // to avoid caching too much data.
-            lock (Mutex)
-            {
-                buffer?.Clear();
-            }
         }
     }
 }

--- a/Test/Unit/HistoryReaderTest.cs
+++ b/Test/Unit/HistoryReaderTest.cs
@@ -159,24 +159,6 @@ namespace Test.Unit
             Assert.Equal(200, queue.Count);
             Assert.True(CommonTestUtils.TestMetricValue("opcua_bad_datapoints", 100));
 
-            // Test flush buffer
-            historyData.DataValues = frontfillDataValues;
-            state1.RestartHistory();
-            await queue.Clear();
-            // Get a datapoint from stream that happened after the last history point was read from the server, but arrived
-            // at the extractor before the history data was parsed. This is an edge-case, but a potential lost datapoint 
-            state1.UpdateFromStream(new[] { new UADataPoint(start.AddSeconds(100), "state1", 1.0, StatusCodes.Good) });
-            node = new HistoryReadNode(HistoryReadType.FrontfillData, new NodeId("state1", 0))
-            {
-                LastResult = historyData,
-                ContinuationPoint = null
-            };
-            historyDataHandler.Invoke(reader, new object[] { node });
-            Assert.Equal(100, node.TotalRead);
-            Assert.False(state1.IsFrontfilling);
-            Assert.Equal(100, queue.Count);
-            Assert.Equal(start.AddSeconds(100), state1.SourceExtractedRange.Last);
-
             // Test termination without cp
             historyData.DataValues = frontfillDataValues;
             state1.RestartHistory();
@@ -320,21 +302,6 @@ namespace Test.Unit
             Assert.True(state.IsFrontfilling);
             Assert.Equal(0, queue.Count);
             Assert.True(CommonTestUtils.TestMetricValue("opcua_bad_events", 100));
-
-            // Test flush buffer
-            historyEvents.Events = frontfillEvents;
-            state.RestartHistory();
-            await queue.Clear();
-            state.UpdateFromStream(new UAEvent { Time = start.AddSeconds(100) });
-            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter", 0))
-            {
-                LastResult = historyEvents
-            };
-            historyEventHandler.Invoke(reader, new object[] { node, details });
-            Assert.Equal(100, node.TotalRead);
-            Assert.False(state.IsFrontfilling);
-            Assert.Equal(100, queue.Count);
-            Assert.Equal(start.AddSeconds(100), state.SourceExtractedRange.Last);
 
             // Test termination without cp
             historyEvents.Events = frontfillEvents;

--- a/Test/Unit/HistoryReaderTest.cs
+++ b/Test/Unit/HistoryReaderTest.cs
@@ -174,7 +174,7 @@ namespace Test.Unit
             historyDataHandler.Invoke(reader, new object[] { node });
             Assert.Equal(100, node.TotalRead);
             Assert.False(state1.IsFrontfilling);
-            Assert.Equal(101, queue.Count);
+            Assert.Equal(100, queue.Count);
             Assert.Equal(start.AddSeconds(100), state1.SourceExtractedRange.Last);
 
             // Test termination without cp
@@ -333,7 +333,7 @@ namespace Test.Unit
             historyEventHandler.Invoke(reader, new object[] { node, details });
             Assert.Equal(100, node.TotalRead);
             Assert.False(state.IsFrontfilling);
-            Assert.Equal(101, queue.Count);
+            Assert.Equal(100, queue.Count);
             Assert.Equal(start.AddSeconds(100), state.SourceExtractedRange.Last);
 
             // Test termination without cp


### PR DESCRIPTION
This was used to bridge the gap between history end and stream start. Now that state store is required when history is enabled, we no longer need this at all.