### PR TITLE
Always enable extra data to Raw

### DIFF
--- a/Extractor/Config/ExtractionConfig.cs
+++ b/Extractor/Config/ExtractionConfig.cs
@@ -208,15 +208,6 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public bool NullAsNumeric { get; set; }
         /// <summary>
-        /// Add full JSON node-ids to data pushed to Raw. TypeDefintionId, ParentNodeId, NodeId and DataTypeId.
-        /// </summary>
-        public bool ExpandNodeIds { get; set; }
-        /// <summary>
-        /// Add attributes generally used internally like AccessLevel, Historizing, ArrayDimensions, ValueRank etc.
-        /// to data pushed to Raw.
-        /// </summary>
-        public bool AppendInternalValues { get; set; }
-        /// <summary>
         /// If max-array-size is set, this looks for the MaxArraySize property on each node with one-dimension ValueRank,
         /// if it is not found, it tries to read the value as well, and look at the current size.
         /// ArrayDimensions is still the prefered way to identify array sizes, this is not guaranteed to generate

--- a/Extractor/Types/UAPropertySerializer.cs
+++ b/Extractor/Types/UAPropertySerializer.cs
@@ -549,14 +549,8 @@ namespace Cognite.OpcUa.Types
             }
             writer.WriteStartObject();
             WriteBaseValues(writer, value);
-            if (config.Extraction.DataTypes.ExpandNodeIds)
-            {
-                WriteNodeIds(writer, value, options);
-            }
-            if (config.Extraction.DataTypes.AppendInternalValues)
-            {
-                WriteInternalInfo(writer, value, options);
-            }
+            WriteNodeIds(writer, value, options);
+            WriteInternalInfo(writer, value, options);
             writer.WriteEndObject();
         }
     }

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -893,8 +893,6 @@ namespace Test.Unit
                 Database = "metadata",
                 Enable = true
             };
-            tester.Config.Extraction.DataTypes.ExpandNodeIds = true;
-            tester.Config.Extraction.DataTypes.AppendInternalValues = true;
             tester.Config.Extraction.DataTypes.AllowStringVariables = true;
             tester.Config.Extraction.DataTypes.MaxArraySize = 10;
             tester.Config.Subscriptions.IgnoreAccessLevel = true;
@@ -1011,8 +1009,6 @@ namespace Test.Unit
                     Database = "metadata"
                 }
             };
-            tester.Config.Extraction.DataTypes.ExpandNodeIds = true;
-            tester.Config.Extraction.DataTypes.AppendInternalValues = true;
             tester.Config.Extraction.DataTypes.AllowStringVariables = true;
             tester.Config.Extraction.DataTypes.MaxArraySize = 10;
             tester.Config.Extraction.DataTypes.AutoIdentifyTypes = true;
@@ -1104,8 +1100,6 @@ namespace Test.Unit
                     Database = "metadata"
                 }
             };
-            tester.Config.Extraction.DataTypes.ExpandNodeIds = true;
-            tester.Config.Extraction.DataTypes.AppendInternalValues = true;
             tester.Config.Events.Enabled = true;
             tester.Config.Events.ReadServer = false;
             tester.Config.Subscriptions.DataPoints = true;
@@ -1179,8 +1173,6 @@ namespace Test.Unit
                     AssetsTable = "assets"
                 }
             };
-            tester.Config.Extraction.DataTypes.ExpandNodeIds = true;
-            tester.Config.Extraction.DataTypes.AppendInternalValues = true;
             tester.Config.Events.Enabled = true;
             tester.Config.Events.ReadServer = false;
             tester.Config.Subscriptions.DataPoints = true;

--- a/Test/Unit/StringConversionTest.cs
+++ b/Test/Unit/StringConversionTest.cs
@@ -248,26 +248,31 @@ namespace Test.Unit
                 Assert.Equal(expected, result);
             }
 
-            tester.Config.Extraction.DataTypes.ExpandNodeIds = true;
             var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             TestConvert(node,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""parentExternalId"":null,"
-                + @"""NodeId"":{""idType"":1,""identifier"":""test""}}");
+                + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
+                + @"""InternalInfo"":{""EventNotifier"":0,""ShouldSubscribeEvents"":false,"
+                + @"""ShouldReadHistoryEvents"":false,""NodeClass"":1}}");
 
             node.FullAttributes.TypeDefinition = new UAObjectType(new NodeId("test-type", 0));
             TestConvert(node,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""parentExternalId"":null,"
                 + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
-                + @"""TypeDefinitionId"":{""idType"":1,""identifier"":""test-type""}}");
+                + @"""TypeDefinitionId"":{""idType"":1,""identifier"":""test-type""},"
+                + @"""InternalInfo"":{""EventNotifier"":0,""ShouldSubscribeEvents"":false,"
+                + @"""ShouldReadHistoryEvents"":false,""NodeClass"":1}}");
 
             node = new UAObject(new NodeId("test", 0), "test", null, null, new NodeId("parent", 0), null);
             TestConvert(node,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""parentExternalId"":""gp.base:s=parent"","
                 + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
-                + @"""ParentNodeId"":{""idType"":1,""identifier"":""parent""}}");
+                + @"""ParentNodeId"":{""idType"":1,""identifier"":""parent""},"
+                + @"""InternalInfo"":{""EventNotifier"":0,""ShouldSubscribeEvents"":false,"
+                + @"""ShouldReadHistoryEvents"":false,""NodeClass"":1}}");
 
             options = new JsonSerializerOptions();
             converter.AddConverters(options, ConverterType.Variable);
@@ -280,7 +285,9 @@ namespace Test.Unit
                 + @"""description"":null,""metadata"":null,""assetExternalId"":null,"
                 + @"""isString"":false,""isStep"":true,"
                 + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
-                + @"""DataTypeId"":{""idType"":0,""identifier"":1}}");
+                + @"""DataTypeId"":{""idType"":0,""identifier"":1},"
+                + @"""InternalInfo"":{""NodeClass"":2,""AccessLevel"":0,""Historizing"":false,""ValueRank"":0,"
+                + @"""ShouldSubscribeData"":false,""ShouldReadHistoryData"":false}}");
         }
         [Fact]
         public void TestWriteInternals()
@@ -296,13 +303,13 @@ namespace Test.Unit
                 Assert.Equal(expected, result);
             }
 
-            tester.Config.Extraction.DataTypes.AppendInternalValues = true;
             tester.Config.Events.Enabled = true;
             tester.Config.Events.History = true;
             var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             TestConvert(node,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""parentExternalId"":null,"
+                + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
                 + @"""InternalInfo"":{""EventNotifier"":0,""ShouldSubscribeEvents"":false,"
                 + @"""ShouldReadHistoryEvents"":false,""NodeClass"":1}}");
 
@@ -310,6 +317,7 @@ namespace Test.Unit
             TestConvert(node,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""parentExternalId"":null,"
+                + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
                 + @"""InternalInfo"":{""EventNotifier"":5,""ShouldSubscribeEvents"":true,"
                 + @"""ShouldReadHistoryEvents"":true,""NodeClass"":1}}");
 
@@ -324,6 +332,8 @@ namespace Test.Unit
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""assetExternalId"":null,"
                 + @"""isString"":false,""isStep"":false,"
+                + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
+                + @"""DataTypeId"":{""idType"":0,""identifier"":11},"
                 + @"""InternalInfo"":{""NodeClass"":2,""AccessLevel"":5,"
                 + @"""Historizing"":true,""ValueRank"":-1,""ShouldSubscribeData"":true,""ShouldReadHistoryData"":true}}");
 
@@ -334,6 +344,8 @@ namespace Test.Unit
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
                 + @"""description"":null,""metadata"":null,""assetExternalId"":null,"
                 + @"""isString"":false,""isStep"":false,"
+                + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
+                + @"""DataTypeId"":{""idType"":0,""identifier"":11},"
                 + @"""InternalInfo"":{""NodeClass"":2,""AccessLevel"":5,"
                 + @"""Historizing"":true,""ValueRank"":1,""ShouldSubscribeData"":true,""ShouldReadHistoryData"":true,"
                 + @"""ArrayDimensions"":[5],""Index"":-1,""AsEvents"":true}}"
@@ -349,9 +361,6 @@ namespace Test.Unit
 
             var node = new UAObject(new NodeId("test", 2), "test", null, null, new NodeId("parent", 0), null);
             node.FullAttributes.EventNotifier = 5;
-
-            tester.Config.Extraction.DataTypes.AppendInternalValues = true;
-            tester.Config.Extraction.DataTypes.ExpandNodeIds = true;
 
             SavedNode Convert(BaseUANode node)
             {

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -683,15 +683,6 @@ extraction:
         # Added to metadata, or as a column in Raw.
         delete-marker: "deleted"
 
-    # Configuration for ingesting status codes to CDF timeseries.
-    status-codes:
-        # Which data points to ingest to CDF.
-        # `All` ingests all datapoints, including bad.
-        # `Uncertain` ingests good and uncertain data points.
-        # `GoodOnly` ingest only good datapoints.
-        status-codes-to-ingest: GoodOnly
-        ingest-status-codes: false
-
 subscriptions:
     # Enable subscriptions on data-points.
     data-points: true

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -252,7 +252,6 @@ cognite:
         relationships-table:
 
     # Read from CDF instead of OPC-UA when starting, to speed up start on slow servers.
-    # Requires extraction.data-types.expand-node-ids and append-internal-values to be set to true.
 
     # This should generally be enabled along with metadata-targets.raw
     # If browse-on-empty is set to true, and metadata-targets.raw is configured with the same
@@ -567,13 +566,6 @@ extraction:
 
         # True to treat null nodeIds as numeric instead of string
         null-as-numeric: false
-
-        # Add full JSON node-ids to data pushed to Raw. TypeDefintionId, ParentNodeId, NodeId and DataTypeId.
-        expand-node-ids: false
-
-        # Add attributes generally used internally like AccessLevel, Historizing, ArrayDimensions, ValueRank etc.
-        # to data pushed to Raw.
-        append-internal-values: false
 
         # If max-array-size is set, this looks for the MaxArraySize property on each node with one-dimension ValueRank,
         # if it is not found, it tries to read the value as well, and look at the current size.

--- a/schema/cognite_config.schema.json
+++ b/schema/cognite_config.schema.json
@@ -227,7 +227,7 @@
         },
         "raw-node-buffer": {
             "type": "object",
-            "description": "Read from CDF instead of OPC-UA when starting, to speed up start on slow servers. Requires [`extraction.data-types.expand-node-ids`](#extraction.data-types) and [`extraction.data-types.append-internal-values`](#extraction.data-types) to be set to `true`.\n\nThis should generaly be enabled along with [`metadata-targets.raw`](#cognite.metadata-targets.raw) or with no metadata targets at all.\n\nIf `browse-on-empty` is set to `true` and `metadata-targets.raw` is configured with the same database and tables the extractor will read into raw on first run, then use raw as source for later runs. The Raw database can be deleted, and it will be re-created on extractor restart.",
+            "description": "Read from CDF instead of OPC-UA when starting, to speed up start on slow servers.\n\nThis should generaly be enabled along with [`metadata-targets.raw`](#cognite.metadata-targets.raw) or with no metadata targets at all.\n\nIf `browse-on-empty` is set to `true` and `metadata-targets.raw` is configured with the same database and tables the extractor will read into raw on first run, then use raw as source for later runs. The Raw database can be deleted, and it will be re-created on extractor restart.",
             "unevaluatedProperties": false,
             "required": [
                 "enable",

--- a/schema/extraction_config.schema.json
+++ b/schema/extraction_config.schema.json
@@ -173,28 +173,6 @@
                 }
             }
         },
-        "status-codes": {
-            "type": "object",
-            "unevaluatedProperties": false,
-            "description": "Configuration for ingesting status codes to CDF timeseries.",
-            "properties": {
-                "status-codes-to-ingest": {
-                    "type": "string",
-                    "enum": [
-                        "GoodOnly",
-                        "Uncertain",
-                        "All"
-                    ],
-                    "description": "Which data points to ingest to CDF. `All` ingests all datapoints, including bad. `Uncertain` ingests good and uncertain data points. `GoodOnly` ingest only good datapoints.",
-                    "default": "GoodOnly"
-                },
-                "ingest-status-codes": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Whether to ingest status codes into the time series API."
-                }
-            }
-        },
         "rebrowse-triggers": {
             "type": "object",
             "unevaluatedProperties": false,

--- a/schema/extraction_config.schema.json
+++ b/schema/extraction_config.schema.json
@@ -289,14 +289,6 @@
                     "type": "boolean",
                     "description": "Set this to `true` to treat `null` node IDs as numeric instead of ignoring them. Note that `null` node IDs violate the OPC UA standard."
                 },
-                "expand-node-ids": {
-                    "type": "boolean",
-                    "description": "Add attributes such as `NodeId`, `ParentNodeId`, and `TypeDefinitionId` to nodes written to CDF Raw as full node IDs with reversible encoding."
-                },
-                "append-internal-values": {
-                    "type": "boolean",
-                    "description": "Add attributes generally used internally like `AccessLevel`, `Historizing`, `ArrayDimensions`, and `ValueRank` to data pushed to CDF Raw."
-                },
                 "estimate-array-sizes": {
                     "type": "boolean",
                     "description": "If `max-array-size` is set, this looks for the `MaxArraySize` property on each node with `one-dimensional` ValueRank. If it is not found, the extractor tries to read the value of the node, and look at the current array length.\n\n`ArrayDimensions` is still the preferred way to identify array sizes, this is not guaranteed to generate reasonable or useful values."


### PR DESCRIPTION
This isn't actually that much data, and has no real cost on startup. Including this info makes setting up raw-node-buffer easier, and is one less thing to think about when configuring the extractor.