### PR TITLE
Always enable data-type-metadata

### DIFF
--- a/Extractor/Config/ExtractionConfig.cs
+++ b/Extractor/Config/ExtractionConfig.cs
@@ -200,10 +200,6 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public bool EnumsAsStrings { get; set; }
         /// <summary>
-        /// Add a metadata property dataType which contains the id of the OPC-UA datatype.
-        /// </summary>
-        public bool DataTypeMetadata { get; set; }
-        /// <summary>
         /// True to treat null nodeIds as numeric instead of string
         /// </summary>
         public bool NullAsNumeric { get; set; }

--- a/Extractor/NodeSources/NodeHierarchyBuilder.cs
+++ b/Extractor/NodeSources/NodeHierarchyBuilder.cs
@@ -235,13 +235,11 @@ namespace Cognite.OpcUa.NodeSources
             extractor.State.RegisterNode(node.Id, node.GetUniqueId(client.Context));
             extractor.State.AddActiveNode(
                 node,
-                config.Extraction.DataTypes.DataTypeMetadata,
                 config.Extraction.NodeTypes.Metadata);
             foreach (var prop in node.GetAllProperties())
             {
                 extractor.State.AddActiveNode(
                 prop,
-                config.Extraction.DataTypes.DataTypeMetadata,
                 config.Extraction.NodeTypes.Metadata);
             }
         }
@@ -392,7 +390,6 @@ namespace Cognite.OpcUa.NodeSources
                 if (oldChecksum != null)
                 {
                     node.Changed |= oldChecksum != node.GetUpdateChecksum(
-                        config.Extraction.DataTypes.DataTypeMetadata,
                         config.Extraction.NodeTypes.Metadata);
                     return node.Changed;
                 }

--- a/Extractor/Nodes/BaseUANode.cs
+++ b/Extractor/Nodes/BaseUANode.cs
@@ -404,12 +404,12 @@ namespace Cognite.OpcUa.Nodes
             return null;
         }
 
-        public virtual int GetUpdateChecksum(bool dataTypeMetadata, bool nodeTypeMetadata)
+        public virtual int GetUpdateChecksum(bool nodeTypeMetadata)
         {
             int checksum = 0;
             unchecked
             {
-                checksum += (ParentId?.GetHashCode() ?? 0);
+                checksum += ParentId?.GetHashCode() ?? 0;
                 checksum = checksum * 31 + (Attributes.Description?.GetHashCode(StringComparison.InvariantCulture) ?? 0);
                 checksum = checksum * 31 + (Name?.GetHashCode(StringComparison.InvariantCulture) ?? 0);
                 int metaHash = 0;
@@ -425,7 +425,7 @@ namespace Cognite.OpcUa.Nodes
                         }
                         if (prop.Properties?.Any() ?? false)
                         {
-                            metaHash += prop.GetUpdateChecksum(false, false);
+                            metaHash += prop.GetUpdateChecksum(false);
                         }
                     }
                 }

--- a/Extractor/Nodes/UAObject.cs
+++ b/Extractor/Nodes/UAObject.cs
@@ -115,9 +115,9 @@ namespace Cognite.OpcUa.Nodes
             return null;
         }
 
-        public override int GetUpdateChecksum(bool dataTypeMetadata, bool nodeTypeMetadata)
+        public override int GetUpdateChecksum(bool nodeTypeMetadata)
         {
-            int checksum = base.GetUpdateChecksum(dataTypeMetadata, nodeTypeMetadata);
+            int checksum = base.GetUpdateChecksum(nodeTypeMetadata);
             unchecked
             {
                 if (nodeTypeMetadata)

--- a/Extractor/Nodes/UAVariable.cs
+++ b/Extractor/Nodes/UAVariable.cs
@@ -308,31 +308,25 @@ namespace Cognite.OpcUa.Nodes
                     fields[kvp.Key.ToString(CultureInfo.InvariantCulture)] = kvp.Value;
                 }
             }
-            if (config.Extraction.DataTypes.DataTypeMetadata)
+            fields ??= new Dictionary<string, string>();
+            if (dt.Id.NamespaceIndex == 0)
             {
-                fields ??= new Dictionary<string, string>();
-                if (dt.Id.NamespaceIndex == 0)
-                {
-                    fields["dataType"] = DataTypes.GetBuiltInType(dt.Id).ToString();
-                }
-                else
-                {
-                    fields["dataType"] = dt.Name ?? dt.GetUniqueId(context) ?? "null";
-                }
+                fields["dataType"] = DataTypes.GetBuiltInType(dt.Id).ToString();
+            }
+            else
+            {
+                fields["dataType"] = dt.Name ?? dt.GetUniqueId(context) ?? "null";
             }
             return fields;
         }
 
-        public override int GetUpdateChecksum(bool dataTypeMetadata, bool nodeTypeMetadata)
+        public override int GetUpdateChecksum(bool nodeTypeMetadata)
         {
-            int checksum = base.GetUpdateChecksum(dataTypeMetadata, nodeTypeMetadata);
+            int checksum = base.GetUpdateChecksum(nodeTypeMetadata);
 
             unchecked
             {
-                if (dataTypeMetadata)
-                {
-                    checksum = checksum * 31 + FullAttributes.DataType.Id.GetHashCode();
-                }
+                checksum = checksum * 31 + FullAttributes.DataType.Id.GetHashCode();
                 if (NodeClass == NodeClass.VariableType)
                 {
                     checksum = checksum * 31 + FullAttributes.Value.GetHashCode();

--- a/Extractor/Nodes/UAVariableType.cs
+++ b/Extractor/Nodes/UAVariableType.cs
@@ -142,31 +142,25 @@ namespace Cognite.OpcUa.Nodes
                     fields[kvp.Key.ToString(CultureInfo.InvariantCulture)] = kvp.Value;
                 }
             }
-            if (config.Extraction.DataTypes.DataTypeMetadata)
+            if (dt.Id.NamespaceIndex == 0)
             {
-                if (dt.Id.NamespaceIndex == 0)
-                {
-                    fields["dataType"] = DataTypes.GetBuiltInType(dt.Id).ToString();
-                }
-                else
-                {
-                    fields["dataType"] = dt.Name ?? dt.GetUniqueId(context) ?? "null";
-                }
+                fields["dataType"] = DataTypes.GetBuiltInType(dt.Id).ToString();
+            }
+            else
+            {
+                fields["dataType"] = dt.Name ?? dt.GetUniqueId(context) ?? "null";
             }
             fields["Value"] = converter.ConvertToString(FullAttributes.Value, dt.EnumValues);
 
             return fields;
         }
 
-        public override int GetUpdateChecksum(bool dataTypeMetadata, bool nodeTypeMetadata)
+        public override int GetUpdateChecksum(bool nodeTypeMetadata)
         {
-            int checksum = base.GetUpdateChecksum(dataTypeMetadata, nodeTypeMetadata);
+            int checksum = base.GetUpdateChecksum(nodeTypeMetadata);
             unchecked
             {
-                if (dataTypeMetadata)
-                {
-                    checksum = checksum * 31 + FullAttributes.DataType.Id.GetHashCode();
-                }
+                checksum = checksum * 31 + FullAttributes.DataType.Id.GetHashCode();
                 checksum = checksum * 31 + FullAttributes.Value.GetHashCode();
             }
             return checksum;

--- a/Extractor/State.cs
+++ b/Extractor/State.cs
@@ -152,9 +152,9 @@ namespace Cognite.OpcUa
         /// Add node to overview of known mapped nodes
         /// </summary>
         /// <param name="node">Node to add</param>
-        public void AddActiveNode(BaseUANode node, bool dataTypeMetadata, bool nodeTypeMetadata)
+        public void AddActiveNode(BaseUANode node, bool nodeTypeMetadata)
         {
-            mappedNodes[node.Id] = new MappedNode(node, dataTypeMetadata, nodeTypeMetadata);
+            mappedNodes[node.Id] = new MappedNode(node, nodeTypeMetadata);
         }
         /// <summary>
         /// Get node checksum by NodeId and index if it exists

--- a/Extractor/TypeCollectors/TypeManager.cs
+++ b/Extractor/TypeCollectors/TypeManager.cs
@@ -130,8 +130,6 @@ namespace Cognite.OpcUa.TypeCollectors
                 if (tp.NodeClass == NodeClass.ObjectType && !config.Extraction.NodeTypes.Metadata
                     && (tp is not UAObjectType otp || !otp.IsEventType())) continue;
                 if (tp.NodeClass == NodeClass.VariableType && !config.Extraction.NodeTypes.Metadata) continue;
-                if (tp.NodeClass == NodeClass.DataType && !config.Extraction.DataTypes.DataTypeMetadata
-                    && !config.Extraction.DataTypes.AutoIdentifyTypes) continue;
                 if (tp.NodeClass == NodeClass.ReferenceType && !config.Extraction.Relationships.Enabled) continue;
                 toRead.Add(tp);
             }

--- a/Extractor/Types/MappedNode.cs
+++ b/Extractor/Types/MappedNode.cs
@@ -29,10 +29,10 @@ namespace Cognite.OpcUa.Types
         public bool IsObject { get; }
         public NodeClass NodeClass { get; }
 
-        public MappedNode(BaseUANode node, bool dataTypeMetadata, bool nodeTypeMetadata)
+        public MappedNode(BaseUANode node, bool nodeTypeMetadata)
         {
             Id = node.Id;
-            Checksum = node.GetUpdateChecksum(dataTypeMetadata, nodeTypeMetadata);
+            Checksum = node.GetUpdateChecksum(nodeTypeMetadata);
             IsProperty = node.IsProperty;
             IsObject = node is not UAVariable variable || variable.IsObject;
         }

--- a/Test/CommonTestUtils.cs
+++ b/Test/CommonTestUtils.cs
@@ -261,8 +261,8 @@ namespace Test
             Assert.Equal(2, obj2Meta.Count);
             Assert.Equal("1234", obj2Meta["NumericProp"]);
 
-            Assert.True(stringyMeta == null || stringyMeta.Count == 0);
-            Assert.Equal(2, mysteryMeta.Count);
+            Assert.True(stringyMeta.Count == 1);
+            Assert.Equal(3, mysteryMeta.Count);
             Assert.Equal("(0, 100)", mysteryMeta["EURange"]);
         }
 
@@ -325,9 +325,9 @@ namespace Test
             Assert.Equal("4321", obj2Meta["NumericProp"]);
             Assert.True(obj2Meta.ContainsKey("StringProp updated"));
 
-            Assert.Single(stringyMeta);
+            Assert.Equal(2, stringyMeta.Count);
             Assert.Equal("New prop value", stringyMeta["NewProp"]);
-            Assert.Equal(2, mysteryMeta.Count);
+            Assert.Equal(3, mysteryMeta.Count);
             Assert.Equal("(0, 200)", mysteryMeta["EURange"]);
         }
 

--- a/Test/Integration/NodeExtractionTests.cs
+++ b/Test/Integration/NodeExtractionTests.cs
@@ -476,7 +476,6 @@ namespace Test.Integration
             extraction.DataTypes.AllowStringVariables = true;
             extraction.DataTypes.MaxArraySize = -1;
             extraction.DataTypes.AutoIdentifyTypes = true;
-            extraction.DataTypes.DataTypeMetadata = true;
             extraction.NodeTypes.Metadata = true;
 
             await extractor.RunExtractor(true);
@@ -1073,7 +1072,6 @@ namespace Test.Integration
             extraction.RootNode = CommonTestUtils.ToProtoNodeId(tester.Ids.Custom.Root, tester.Client);
             extraction.DataTypes.AllowStringVariables = true;
             extraction.DataTypes.MaxArraySize = 4;
-            extraction.DataTypes.DataTypeMetadata = true;
             extraction.NodeTypes.Metadata = true;
 
             tester.Config.History.Enabled = true;

--- a/Test/Integration/NodeExtractionTests.cs
+++ b/Test/Integration/NodeExtractionTests.cs
@@ -1031,8 +1031,9 @@ namespace Test.Integration
 
             Assert.Equal(NodeClass.VariableType, customVarType.NodeClass);
             var meta = customVarType.BuildMetadata(tester.Config, extractor, true);
-            Assert.Single(meta);
+            Assert.Equal(2, meta.Count);
             Assert.Equal("123.123", meta["Value"]);
+            Assert.Equal("Double", meta["dataType"]);
             var customObjType = pusher.PushedNodes[tester.Server.Ids.Custom.ObjectType];
             Assert.Equal("CustomObjectType", customObjType.Name);
             Assert.Equal(NodeClass.ObjectType, customObjType.NodeClass);

--- a/Test/Unit/PusherUtilsTest.cs
+++ b/Test/Unit/PusherUtilsTest.cs
@@ -85,6 +85,7 @@ namespace Test.Unit
                 Description = "description",
                 Metadata = new Dictionary<string, string>
                 {
+                    { "dataType", "Boolean" },
                     { "prop1", "value1" },
                     { "prop2", "value2" },
                     { "prop3", "value3" },
@@ -119,7 +120,7 @@ namespace Test.Unit
             Assert.Equal("description2", result.Description.Set);
             Assert.Equal("test2", result.Name.Set);
             Assert.Equal(222, result.AssetId.Set);
-            Assert.Equal(4, result.Metadata.Set.Count);
+            Assert.Equal(5, result.Metadata.Set.Count);
             Assert.Equal("value1", result.Metadata.Set["prop1"]);
             Assert.False(result.Metadata.Set.ContainsKey("prop2"));
             Assert.Equal("value3", result.Metadata.Set["prop3"]);
@@ -133,7 +134,7 @@ namespace Test.Unit
             result = PusherUtils.GetTSUpdate(tester.Config, extractor, ts, node, nodeToAssetIds);
             Assert.Null(result.AssetId);
             Assert.Null(result.Description);
-            Assert.Null(result.Metadata);
+            Assert.Single(result.Metadata.Set);
             Assert.Null(result.Name);
         }
         [Fact]

--- a/Test/Unit/StringConversionTest.cs
+++ b/Test/Unit/StringConversionTest.cs
@@ -282,7 +282,7 @@ namespace Test.Unit
 
             TestConvert(variable,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
-                + @"""description"":null,""metadata"":null,""assetExternalId"":null,"
+                + @"""description"":null,""metadata"":{""dataType"":""Boolean""},""assetExternalId"":null,"
                 + @"""isString"":false,""isStep"":true,"
                 + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
                 + @"""DataTypeId"":{""idType"":0,""identifier"":1},"
@@ -330,7 +330,7 @@ namespace Test.Unit
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             TestConvert(variable,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
-                + @"""description"":null,""metadata"":null,""assetExternalId"":null,"
+                + @"""description"":null,""metadata"":{""dataType"":""Double""},""assetExternalId"":null,"
                 + @"""isString"":false,""isStep"":false,"
                 + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
                 + @"""DataTypeId"":{""idType"":0,""identifier"":11},"
@@ -342,7 +342,7 @@ namespace Test.Unit
             variable.AsEvents = true;
             TestConvert(variable,
                 @"{""externalId"":""gp.base:s=test"",""name"":""test"","
-                + @"""description"":null,""metadata"":null,""assetExternalId"":null,"
+                + @"""description"":null,""metadata"":{""dataType"":""Double""},""assetExternalId"":null,"
                 + @"""isString"":false,""isStep"":false,"
                 + @"""NodeId"":{""idType"":1,""identifier"":""test""},"
                 + @"""DataTypeId"":{""idType"":0,""identifier"":11},"

--- a/Test/Unit/TypesTest.cs
+++ b/Test/Unit/TypesTest.cs
@@ -43,8 +43,8 @@ namespace Test.Unit
 
             (int, int) Update(BaseUANode nodeA, BaseUANode nodeB)
             {
-                int csA = nodeA.GetUpdateChecksum(false, ntMeta);
-                int csB = nodeB.GetUpdateChecksum(false, ntMeta);
+                int csA = nodeA.GetUpdateChecksum(ntMeta);
+                int csB = nodeB.GetUpdateChecksum(ntMeta);
                 return (csA, csB);
             }
 
@@ -623,7 +623,7 @@ namespace Test.Unit
             Assert.Equal("gp.base:s=parent", ts.AssetExternalId);
             Assert.True(ts.IsStep);
             Assert.False(ts.IsString);
-            Assert.Equal(4, ts.Metadata.Count);
+            Assert.Equal(5, ts.Metadata.Count);
             for (int i = 1; i <= 4; i++) Assert.Equal($"value{i}", ts.Metadata[$"prop{i}"]);
             Assert.Null(ts.Unit);
             Assert.Equal("description", ts.Description);
@@ -644,7 +644,7 @@ namespace Test.Unit
             Assert.Equal("value4", ts.AssetExternalId);
             Assert.True(ts.IsStep);
             Assert.False(ts.IsString);
-            Assert.Equal(4, ts.Metadata.Count);
+            Assert.Equal(5, ts.Metadata.Count);
             for (int i = 1; i <= 4; i++) Assert.Equal($"value{i}", ts.Metadata[$"prop{i}"]);
             Assert.Equal("value1", ts.Description);
             Assert.Equal("value3", ts.Unit);
@@ -684,7 +684,7 @@ namespace Test.Unit
             Assert.Equal(111, ts.AssetId);
             Assert.True(ts.IsStep);
             Assert.False(ts.IsString);
-            Assert.Equal(4, ts.Metadata.Count);
+            Assert.Equal(5, ts.Metadata.Count);
             Assert.Null(ts.Unit);
             Assert.Equal("description", ts.Description);
 
@@ -711,7 +711,7 @@ namespace Test.Unit
             Assert.Equal(222, ts.AssetId);
             Assert.True(ts.IsStep);
             Assert.False(ts.IsString);
-            Assert.Equal(4, ts.Metadata.Count);
+            Assert.Equal(5, ts.Metadata.Count);
             Assert.Equal("value1", ts.Description);
             Assert.Equal("value3", ts.Unit);
         }

--- a/Test/Unit/UAExtractorTest.cs
+++ b/Test/Unit/UAExtractorTest.cs
@@ -170,7 +170,6 @@ namespace Test.Unit
         {
             using var extractor = tester.BuildExtractor();
 
-            tester.Config.Extraction.DataTypes.DataTypeMetadata = true;
             var variable = new UAVariable(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
             var fields = variable.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
@@ -184,7 +183,6 @@ namespace Test.Unit
             Assert.Single(fields);
             Assert.Equal("SomeType", fields["TypeDefinition"]);
 
-            tester.Config.Extraction.DataTypes.DataTypeMetadata = false;
             tester.Config.Extraction.NodeTypes.Metadata = false;
 
             tester.Config.Extraction.NodeTypes.AsNodes = true;
@@ -192,8 +190,9 @@ namespace Test.Unit
             type.FullAttributes.DataType = new UADataType(DataTypeIds.String);
             type.FullAttributes.Value = new Variant("value");
             fields = type.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
-            Assert.Single(fields);
+            Assert.Equal(2, fields.Count);
             Assert.Equal("value", fields["Value"]);
+            Assert.Equal("String", fields["dataType"]);
         }
         [Fact]
         public void TestNodeMapping()

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -561,9 +561,6 @@ extraction:
         # equal to mapped label values.
         enums-as-strings: false
 
-        # Add a metadata property dataType which contains the id of the OPC-UA datatype.
-        data-type-metadata: false
-
         # True to treat null nodeIds as numeric instead of string
         null-as-numeric: false
 

--- a/schema/extraction_config.schema.json
+++ b/schema/extraction_config.schema.json
@@ -259,10 +259,6 @@
                     "type": "boolean",
                     "description": "If this is `false` and `auto-identify-types` is `true`, or there are manually added enums in `custom-numeric-types`, enums will be mapped to numeric time series, and labels are added as metadata fields.\n\nIf this is `true`, labels are not mapped to metadata, and enums will be mapped to string time series with values equal to mapped label values."
                 },
-                "data-type-metadata": {
-                    "type": "boolean",
-                    "description": "Add a metadata property `dataType`, which contains the node ID of the OPC-UA data type."
-                },
                 "null-as-numeric": {
                     "type": "boolean",
                     "description": "Set this to `true` to treat `null` node IDs as numeric instead of ignoring them. Note that `null` node IDs violate the OPC UA standard."


### PR DESCRIPTION
This feature adds a metadata field `dataType` to timeseries.

This is something users are extremely likely to want, and the theoretical cost is tiny (if any). It makes sense to enable by default.

For risk review: We are making a batch of breaking changes to the OPC-UA extractor on a feature branch. These are intended to simplify the extractor, in order to make it easier to use and more maintainable. This is the latest in a series of PRs that enable some config options by default.