### PR TITLE
Patch for memory leak on event buffer

### DIFF
--- a/Extractor/Streamer.cs
+++ b/Extractor/Streamer.cs
@@ -488,10 +488,13 @@ namespace Cognite.OpcUa
 
                 timeToExtractorEvents.Observe((DateTime.UtcNow - buffEvent.Time).TotalSeconds);
 
-                eventState.UpdateFromStream(buffEvent);
+                // The event buffer is deprecated and will be removed soon.
+                // Until it is, it only does anything useful if writing to influxdb is enabled.
+                eventState.UpdateFromStream(buffEvent, config.Influx != null);
 
                 // Either backfill/frontfill is done, or we are not outside of each respective bound
                 if ((extractor.StateStorage == null || config.StateStorage.IntervalValue.Value == Timeout.InfiniteTimeSpan)
+                    && config.Influx != null
                     && (eventState.IsFrontfilling && buffEvent.Time > eventState.SourceExtractedRange.Last
                         || eventState.IsBackfilling && buffEvent.Time < eventState.SourceExtractedRange.First)) continue;
 

--- a/Test/Unit/HistoryReaderTest.cs
+++ b/Test/Unit/HistoryReaderTest.cs
@@ -321,21 +321,6 @@ namespace Test.Unit
             Assert.Equal(0, queue.Count);
             Assert.True(CommonTestUtils.TestMetricValue("opcua_bad_events", 100));
 
-            // Test flush buffer
-            historyEvents.Events = frontfillEvents;
-            state.RestartHistory();
-            await queue.Clear();
-            state.UpdateFromStream(new UAEvent { Time = start.AddSeconds(100) });
-            node = new HistoryReadNode(HistoryReadType.FrontfillEvents, new NodeId("emitter", 0))
-            {
-                LastResult = historyEvents
-            };
-            historyEventHandler.Invoke(reader, new object[] { node, details });
-            Assert.Equal(100, node.TotalRead);
-            Assert.False(state.IsFrontfilling);
-            Assert.Equal(101, queue.Count);
-            Assert.Equal(start.AddSeconds(100), state.SourceExtractedRange.Last);
-
             // Test termination without cp
             historyEvents.Events = frontfillEvents;
             state.RestartHistory();

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.33.2":
+    description: Fix possible memory leak from live events being buffered.
+    changelog:
+      fixed:
+        - Fix possible memory leak related to events being buffered to avoid data loss on history end.
   "2.33.1":
     description: Improve sanitation of data modeling external IDs.
     changelog:


### PR DESCRIPTION
This is the same issue as the other memory leak, except caused by the buffer for events instead of the one for datapoints...

The patch is even a little hackier, but I also realized that this feature only actually does _anything_ if influxdb is enabled (since that is the only target where we use the state of the target as state for events).

Keep in mind that this entire feature is being removed completely in v3. To avoid breaking existing deployments I'm keeping it, ref discussion when we did this for the data point buffer, but I'm disabling it for deployments without influx, since it never worked for those.