### PR TITLE
Bump utils and SDK

### DIFF
--- a/ConfigurationTool/Checks/History.cs
+++ b/ConfigurationTool/Checks/History.cs
@@ -61,9 +61,7 @@ namespace Cognite.OpcUa.Config
                 return;
             }
 
-            DateTime earliestTime;
-            if (Config.History.StartTime == null) earliestTime = CogniteTime.DateTimeEpoch;
-            else earliestTime = CogniteTime.ParseTimestampString(Config.History.StartTime)!.Value;
+            DateTime earliestTime = Config.History.StartTime?.Get() ?? CogniteTime.DateTimeEpoch;
 
             var details = new ReadRawModifiedDetails
             {

--- a/Extractor/Config/HistoryConfig.cs
+++ b/Extractor/Config/HistoryConfig.cs
@@ -19,6 +19,7 @@ using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using Cognite.Extractor.Common;
+using Cognite.Extractor.Configuration;
 
 namespace Cognite.OpcUa.Config
 {
@@ -89,14 +90,14 @@ namespace Cognite.OpcUa.Config
         /// Alternatively, use syntax N[timeunit](-ago) where timeunit is w, d, h, m, s or ms. In past if -ago is added,
         /// future if not.
         /// </summary>
-        public string? StartTime { get; set; }
+        public TimestampWrapper? StartTime { get; set; }
         /// <summary>
         /// Timestamp to be considered the end of forward history. Only relevant if max-read-length is set.
         /// In milliseconds since 1/1/1970. Default is current time, if this is null.
         /// Alternatively, use syntax N[timeunit](-ago) where timeunit is w, d, h, m, s or ms. In past if -ago is added,
         /// future if not.
         /// </summary>
-        public string? EndTime { get; set; }
+        public TimestampWrapper? EndTime { get; set; }
         public TimeSpanWrapper GranularityValue { get; } = new TimeSpanWrapper(true, "s", "600");
         /// <summary>
         /// Granularity to use when doing historyRead, in seconds. Nodes with last known timestamp within this range of eachother will

--- a/Extractor/Connect/DirectConnectionSource.cs
+++ b/Extractor/Connect/DirectConnectionSource.cs
@@ -72,7 +72,7 @@ namespace Cognite.OpcUa.Connect
             EndpointDescription selectedEndpoint;
             try
             {
-                selectedEndpoint = CoreClientUtils.SelectEndpoint(endpointUrl, config.Secure);
+                selectedEndpoint = CoreClientUtils.SelectEndpoint(appConfig, endpointUrl, config.Secure);
             }
             catch (Exception ex)
             {

--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -13,16 +13,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AdysTech.InfluxDB.Client.Net.Core" Version="0.25.0" />
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.29.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.31.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.375.443" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.443" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.375.443-beta" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.375.457" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.457" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.375.457-beta" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageReference Include="Google.Protobuf" Version="3.29.3" />
+    <PackageReference Include="Google.Protobuf" Version="3.30.1" />
   </ItemGroup>
   <!--ItemGroup>
     <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config\" />

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -208,7 +208,7 @@ namespace Cognite.OpcUa
                 AppConfig.SecurityConfiguration.ApplicationCertificate.SubjectName = certificateSubject;
             }
 
-            bool validAppCert = await application.CheckApplicationInstanceCertificate(false, 0, Config.Source.CertificateExpiry);
+            bool validAppCert = await application.CheckApplicationInstanceCertificates(false, Config.Source.CertificateExpiry, liveToken);
             if (!validAppCert)
             {
                 log.LogWarning("Missing application certificate, using insecure connection.");

--- a/ExtractorLauncher/ExtractorStarter.cs
+++ b/ExtractorLauncher/ExtractorStarter.cs
@@ -71,16 +71,6 @@ namespace Cognite.OpcUa
             if (string.IsNullOrEmpty(config.Extraction.IdPrefix)) log.LogWarning("No id-prefix specified in config file");
             if (config.Cognite == null && config.Influx == null && config.Mqtt == null) log.LogWarning("No destination system specified");
             if (config.Extraction.IdPrefix == "events.") return "Do not use events. as id-prefix, as it is used internally";
-            if (!string.IsNullOrWhiteSpace(config.History?.StartTime))
-            {
-                var parsed = CogniteTime.ParseTimestampString(config.History.StartTime);
-                if (parsed == null) return $"Invalid history start time: {config.History.StartTime}";
-            }
-            if (!string.IsNullOrWhiteSpace(config.History?.EndTime))
-            {
-                var parsed = CogniteTime.ParseTimestampString(config.History.EndTime);
-                if (parsed == null) return $"Invalid history end time: {config.History.EndTime}";
-            }
             if (config.Source.SamplingInterval != null)
             {
                 log.LogWarning("source.sampling-interval is deprecated. Use subscriptions.sampling-interval instead.");

--- a/MQTTCDFBridge/MQTTCDFBridge.csproj
+++ b/MQTTCDFBridge/MQTTCDFBridge.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.29.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.31.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="Google.Protobuf" Version="3.29.3" />

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -10,12 +10,12 @@
     <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.29.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.31.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.443" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.375.443-beta" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.375.443" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.457" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.375.457-beta" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.375.457" />
   </ItemGroup>
 </Project>

--- a/Test/CDFMockHandler.cs
+++ b/Test/CDFMockHandler.cs
@@ -25,6 +25,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -258,6 +259,9 @@ namespace Test
                         case "/streams/test-stream/records":
                             res = HandleIngestRecords(content);
                             break;
+                        case "/api/v1/token/inspect":
+                            res = HandleTokenInspect();
+                            break;
                         default:
                             log.LogWarning("Unknown path: {DummyFactoryUnknownPath}", reqPath);
                             res = new HttpResponseMessage(HttpStatusCode.InternalServerError);
@@ -276,6 +280,25 @@ namespace Test
                 log.Information(contentTask.Result);*/
                 return res;
             }
+        }
+
+        private static HttpResponseMessage HandleTokenInspect()
+        {
+            dynamic res = new ExpandoObject();
+            res.subject = "sub";
+            dynamic project = new ExpandoObject();
+            project.projectUrlName = "test";
+            project.groups = new List<int> { 1, 2, 3 };
+            res.projects = new List<ExpandoObject>
+            {
+                project
+            };
+            res.capabilities = new List<ExpandoObject>();
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(res))
+            };
         }
 
         private HttpResponseMessage HandleAssetsByIds(string content)

--- a/Test/Integration/DataPointTests.cs
+++ b/Test/Integration/DataPointTests.cs
@@ -1,4 +1,5 @@
 ﻿using Cognite.Extractor.Common;
+using Cognite.Extractor.Configuration;
 using Cognite.Extractor.StateStorage;
 using Cognite.Extractor.Testing;
 using Cognite.OpcUa;
@@ -945,7 +946,7 @@ namespace Test.Integration
             tester.Config.History.Backfill = false;
             tester.Config.History.Data = true;
             tester.Config.History.Enabled = true;
-            tester.Config.History.EndTime = startTime.AddSeconds(5).ToUnixTimeMilliseconds().ToString();
+            tester.Config.History.EndTime = new TimestampWrapper(startTime.AddSeconds(5));
             tester.Config.Subscriptions.DataPoints = false;
             tester.Config.Extraction.RootNode = tester.Ids.Base.Root.ToProtoNodeId(tester.Client);
 

--- a/Test/Integration/DataPointTests.cs
+++ b/Test/Integration/DataPointTests.cs
@@ -946,7 +946,7 @@ namespace Test.Integration
             tester.Config.History.Backfill = false;
             tester.Config.History.Data = true;
             tester.Config.History.Enabled = true;
-            tester.Config.History.EndTime = new TimestampWrapper(startTime.AddSeconds(5));
+            tester.Config.History.EndTime = new TimestampWrapper(startTime.AddSeconds(5).ToUnixTimeMilliseconds().ToString());
             tester.Config.Subscriptions.DataPoints = false;
             tester.Config.Extraction.RootNode = tester.Ids.Base.Root.ToProtoNodeId(tester.Client);
 

--- a/Test/Integration/LauncherTests.cs
+++ b/Test/Integration/LauncherTests.cs
@@ -505,13 +505,6 @@ version: 1
                 method.Invoke(typeof(ExtractorStarter), new object[] { log, config, setup, options, "config", services }));
             Assert.Equal("Invalid config: Do not use events. as id-prefix, as it is used internally", exc.InnerException.Message);
 
-            // Invalid history start time
-            config.Extraction.IdPrefix = null;
-            config.History.StartTime = "2d-agoo";
-            exc = Assert.Throws<TargetInvocationException>(() =>
-                method.Invoke(typeof(ExtractorStarter), new object[] { log, config, setup, options, "config", services }));
-            Assert.Equal("Invalid config: Invalid history start time: 2d-agoo", exc.InnerException.Message);
-
             // Missing opc-ua xml config
             config.History.StartTime = null;
             exc = Assert.Throws<TargetInvocationException>(() =>

--- a/Test/Integration/LauncherTests.cs
+++ b/Test/Integration/LauncherTests.cs
@@ -506,7 +506,7 @@ version: 1
             Assert.Equal("Invalid config: Do not use events. as id-prefix, as it is used internally", exc.InnerException.Message);
 
             // Missing opc-ua xml config
-            config.History.StartTime = null;
+            config.Extraction.IdPrefix = null;
             exc = Assert.Throws<TargetInvocationException>(() =>
                 method.Invoke(typeof(ExtractorStarter), new object[] { log, config, setup, options, ".", services }));
             Assert.Equal("Missing opc.ua.net.extractor.Config.xml in config folder .", exc.InnerException.Message);

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cognite.Extractor.Testing" Version="1.29.0" />
+    <PackageReference Include="Cognite.Extractor.Testing" Version="1.31.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Test/Unit/HistoryConsistencyTest.cs
+++ b/Test/Unit/HistoryConsistencyTest.cs
@@ -1,5 +1,6 @@
 ﻿using Cognite.Extensions;
 using Cognite.Extractor.Common;
+using Cognite.Extractor.Configuration;
 using Cognite.OpcUa.Config;
 using Cognite.OpcUa.History;
 using Cognite.OpcUa.Nodes;
@@ -119,7 +120,7 @@ namespace Test.Unit
             var logger = tester.Provider.GetRequiredService<ILogger<HistoryReader>>();
 
             cfg.Throttling.MaxNodeParallelism = nodeParallelism;
-            cfg.StartTime = tester.HistoryStart.AddSeconds(-10).ToUnixTimeMilliseconds().ToString();
+            cfg.StartTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(-10));
 
             tester.Config.History = cfg;
 
@@ -203,7 +204,7 @@ namespace Test.Unit
             tester.Config.Events.History = true;
 
             cfg.Throttling.MaxNodeParallelism = nodeParallelism;
-            cfg.StartTime = tester.HistoryStart.AddSeconds(-10).ToUnixTimeMilliseconds().ToString();
+            cfg.StartTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(-10));
 
             tester.Config.History = cfg;
 

--- a/Test/Unit/HistoryConsistencyTest.cs
+++ b/Test/Unit/HistoryConsistencyTest.cs
@@ -120,7 +120,7 @@ namespace Test.Unit
             var logger = tester.Provider.GetRequiredService<ILogger<HistoryReader>>();
 
             cfg.Throttling.MaxNodeParallelism = nodeParallelism;
-            cfg.StartTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(-10));
+            cfg.StartTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(-10).ToUnixTimeMilliseconds().ToString());
 
             tester.Config.History = cfg;
 
@@ -204,7 +204,7 @@ namespace Test.Unit
             tester.Config.Events.History = true;
 
             cfg.Throttling.MaxNodeParallelism = nodeParallelism;
-            cfg.StartTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(-10));
+            cfg.StartTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(-10).ToUnixTimeMilliseconds().ToString());
 
             tester.Config.History = cfg;
 

--- a/Test/Unit/HistoryReaderTest.cs
+++ b/Test/Unit/HistoryReaderTest.cs
@@ -1,4 +1,5 @@
 ﻿using Cognite.Extractor.Common;
+using Cognite.Extractor.Configuration;
 using Cognite.OpcUa.Config;
 using Cognite.OpcUa.History;
 using Cognite.OpcUa.Nodes;
@@ -927,7 +928,7 @@ namespace Test.Unit
             {
                 Backfill = false,
                 Data = true,
-                EndTime = tester.HistoryStart.AddSeconds(20).ToUnixTimeMilliseconds().ToString()
+                EndTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(20))
             };
 
 
@@ -986,7 +987,7 @@ namespace Test.Unit
             {
                 Backfill = false,
                 Data = true,
-                EndTime = tester.HistoryStart.AddSeconds(20).ToUnixTimeMilliseconds().ToString()
+                EndTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(20))
             };
 
 
@@ -1047,7 +1048,7 @@ namespace Test.Unit
             {
                 Backfill = true,
                 Data = true,
-                StartTime = tester.HistoryStart.AddSeconds(-5).ToUnixTimeMilliseconds().ToString()
+                StartTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(-5))
             };
 
 
@@ -1105,7 +1106,7 @@ namespace Test.Unit
             {
                 Backfill = true,
                 Data = true,
-                EndTime = tester.HistoryStart.AddSeconds(20).ToUnixTimeMilliseconds().ToString(),
+                EndTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(20)),
                 ErrorThreshold = 40
             };
 

--- a/Test/Unit/HistoryReaderTest.cs
+++ b/Test/Unit/HistoryReaderTest.cs
@@ -928,7 +928,7 @@ namespace Test.Unit
             {
                 Backfill = false,
                 Data = true,
-                EndTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(20))
+                EndTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(20).ToUnixTimeMilliseconds().ToString())
             };
 
 
@@ -987,7 +987,7 @@ namespace Test.Unit
             {
                 Backfill = false,
                 Data = true,
-                EndTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(20))
+                EndTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(20).ToUnixTimeMilliseconds().ToString())
             };
 
 
@@ -1048,7 +1048,7 @@ namespace Test.Unit
             {
                 Backfill = true,
                 Data = true,
-                StartTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(-5))
+                StartTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(-5).ToUnixTimeMilliseconds().ToString())
             };
 
 
@@ -1106,7 +1106,7 @@ namespace Test.Unit
             {
                 Backfill = true,
                 Data = true,
-                EndTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(20)),
+                EndTime = new TimestampWrapper(tester.HistoryStart.AddSeconds(20).ToUnixTimeMilliseconds().ToString()),
                 ErrorThreshold = 40
             };
 

--- a/docs/preamble.md
+++ b/docs/preamble.md
@@ -78,3 +78,4 @@ In most places where time intervals are required, you can use a CDF-like syntax 
 
 For history start and end times you can use a similar syntax. `[N][timeunit]` and `[N][timeunit]-ago`. `1d-ago` means 1 day in the past from the time history starts, and `1h` means 1 hour in the future. For instance, you can use this syntax to configure the extractor to read only recent history.
 
+History start and end times can also be set to a specific date on RFC 3339 form, like `2024-01-02T09:27:15Z`, or on a shorter form like `2021-07-23+01:00`. A timezone specifier is necessary, `Z` means UTC.


### PR DESCRIPTION
Also use the new TimestampWrapper type from the utils, which should help simplify config.

Docs are updated to match.