### PR TITLE
Set event ID on records

### DIFF
--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -13,15 +13,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AdysTech.InfluxDB.Client.Net.Core" Version="0.25.0" />
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.31.0" />
-    <PackageReference Include="CogniteSdk" Version="4.15.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.32.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.375.457" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.457" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.375.457-beta" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="Google.Protobuf" Version="3.30.1" />
   </ItemGroup>

--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AdysTech.InfluxDB.Client.Net.Core" Version="0.25.0" />
     <PackageReference Include="Cognite.ExtractorUtils" Version="1.31.0" />
+    <PackageReference Include="CogniteSdk" Version="4.15.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.375.457" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.457" />

--- a/Extractor/Pushers/Records/EventContainer.cs
+++ b/Extractor/Pushers/Records/EventContainer.cs
@@ -96,6 +96,7 @@ namespace Cognite.OpcUa.Pushers.Records
 
             return new StreamRecordWrite
             {
+                ExternalId = evt.EventId,
                 Space = space,
                 Sources = sources
             };

--- a/MQTTCDFBridge/MQTTCDFBridge.csproj
+++ b/MQTTCDFBridge/MQTTCDFBridge.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.31.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.32.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="Google.Protobuf" Version="3.29.3" />

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -10,7 +10,7 @@
     <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.31.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.32.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />

--- a/Test/CDFMockHandler.cs
+++ b/Test/CDFMockHandler.cs
@@ -1317,6 +1317,7 @@ namespace Test
     public class DynamicRecord
     {
         public string Space { get; set; }
+        public string ExternalId { get; set; }
         public IEnumerable<DynamicRecordSource> Sources { get; set; }
     }
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cognite.Extractor.Testing" Version="1.31.0" />
+    <PackageReference Include="Cognite.Extractor.Testing" Version="1.32.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -1427,6 +1427,7 @@ namespace Test.Unit
             var evt = new UAEvent();
             evt.Time = new DateTime(2024, 01, 01, 00, 00, 00, DateTimeKind.Utc);
             evt.EventType = customEventType;
+            evt.EventId = "Event1";
             evt.SetMetadata(extractor.StringConverter, new[] {
                 new EventFieldValue(fieldsByName["Message"], new LocalizedText("Some message")),
                 new EventFieldValue(fieldsByName["EventType"], customEventType.Id),
@@ -1448,6 +1449,7 @@ namespace Test.Unit
             Assert.Single(handler.Records);
 
             var record = handler.Records[0];
+            Assert.Equal("Event1", record.ExternalId);
 
             Assert.Equal(2, record.Sources.Count());
             var baseData = record.Sources.Last().Properties;
@@ -1497,6 +1499,7 @@ namespace Test.Unit
             var evt = new UAEvent();
             evt.Time = new DateTime(2024, 01, 01, 00, 00, 00, DateTimeKind.Utc);
             evt.EventType = customEventType;
+            evt.EventId = "Event1";
             evt.SetMetadata(extractor.StringConverter, new[] {
                 new EventFieldValue(fieldsByName["Message"], new LocalizedText("Some message")),
                 new EventFieldValue(fieldsByName["EventType"], customEventType.Id),
@@ -1518,6 +1521,7 @@ namespace Test.Unit
             Assert.Single(handler.Records);
 
             var record = handler.Records[0];
+            Assert.Equal("Event1", record.ExternalId);
 
             Assert.Equal(2, record.Sources.Count());
             var baseData = record.Sources.Last().Properties;
@@ -1567,6 +1571,7 @@ namespace Test.Unit
             var evt = new UAEvent();
             evt.Time = new DateTime(2024, 01, 01, 00, 00, 00, DateTimeKind.Utc);
             evt.EventType = customEventType;
+            evt.EventId = "Event1";
             evt.SetMetadata(extractor.StringConverter, new[] {
                 new EventFieldValue(fieldsByName["Message"], new LocalizedText("Some message")),
                 new EventFieldValue(fieldsByName["EventType"], customEventType.Id),
@@ -1588,6 +1593,7 @@ namespace Test.Unit
             Assert.Single(handler.Records);
 
             var record = handler.Records[0];
+            Assert.Equal("Event1", record.ExternalId);
 
             Assert.Equal(2, record.Sources.Count());
             var baseData = record.Sources.Last().Properties;


### PR DESCRIPTION
External ID is now required, make sure to set it on new records.

Like legacy events, just use the event ID.