### PR TITLE
Fix batching in the failure buffer

### DIFF
--- a/Extractor/Config/FailureBufferConfig.cs
+++ b/Extractor/Config/FailureBufferConfig.cs
@@ -47,6 +47,15 @@ namespace Cognite.OpcUa.Config
         /// </summary>
         public string? EventPath { get; set; }
         public long MaxBufferSize { get; set; }
+
+        /// <summary>
+        /// Number of datapoints per batch to read from the failure buffer and send to CDF.
+        /// </summary>
+        public int DatapointsBatch { get; set; } = 1_000_000;
+        /// <summary>
+        /// Number of events per batch to read from the failure buffer and send to CDF.
+        /// </summary>
+        public int EventsBatch { get; set; } = 10_000;
     }
 
 }

--- a/Extractor/FailureBuffer.cs
+++ b/Extractor/FailureBuffer.cs
@@ -216,7 +216,7 @@ namespace Cognite.OpcUa
             if (points == null || !points.Any() || pointRanges == null || !pointRanges.Any() || fullConfig.DryRun) return true;
 
             points = points.GroupBy(pt => pt.Id)
-                .Where(group => !extractor.State.GetNodeState(group.Key)?.FrontfillEnabled ?? false)
+                .Where(group => extractor.State.GetNodeState(group.Key)?.FrontfillEnabled == false)
                 .SelectMany(group => group)
                 .ToList();
 
@@ -431,8 +431,7 @@ namespace Cognite.OpcUa
                 {
                     var points = new List<UADataPoint>();
 
-                    int count = 0;
-                    while (!token.IsCancellationRequested && count < 1_000_000)
+                    while (!token.IsCancellationRequested && points.Count < config.DatapointsBatch)
                     {
                         var dp = UADataPoint.FromStream(stream);
                         if (dp == null)
@@ -498,8 +497,7 @@ namespace Cognite.OpcUa
                 {
                     var events = new List<UAEvent>();
 
-                    int count = 0;
-                    while (!token.IsCancellationRequested && count < 10_000)
+                    while (!token.IsCancellationRequested && events.Count < config.EventsBatch)
                     {
                         var evt = UAEvent.FromStream(stream, extractor, log);
                         if (evt == null)

--- a/ExtractorLauncher/ExtractorStarter.cs
+++ b/ExtractorLauncher/ExtractorStarter.cs
@@ -198,6 +198,15 @@ namespace Cognite.OpcUa
                 }
             }
 
+            if (config.FailureBuffer?.EventsBatch <= 0)
+            {
+                return "events-batch must be greater than 0";
+            }
+            if (config.FailureBuffer?.DatapointsBatch <= 0)
+            {
+                return "datapoints-batch must be greater than 0";
+            }
+
             return null;
         }
 

--- a/Test/Utils/DummyPusher.cs
+++ b/Test/Utils/DummyPusher.cs
@@ -61,6 +61,9 @@ namespace Test.Utils
 
         public PusherInput PendingNodes { get; set; }
 
+        public int DataPointsPushCount { get; private set; }
+        public int EventsPushCount { get; private set; }
+
         public DummyPusher(DummyPusherConfig config)
         {
             this.config = config;
@@ -194,6 +197,7 @@ namespace Test.Utils
 
         public Task<bool?> PushEvents(IEnumerable<UAEvent> events, CancellationToken token)
         {
+            EventsPushCount += 1;
             if (!PushEventResult ?? false) return Task.FromResult(PushEventResult);
             if (events == null || !events.Any()) return Task.FromResult<bool?>(null);
             lock (eventLock)
@@ -215,6 +219,7 @@ namespace Test.Utils
 
         public Task<bool?> PushDataPoints(IEnumerable<UADataPoint> points, CancellationToken token)
         {
+            DataPointsPushCount += 1;
             if (!PushDataPointResult ?? false) return Task.FromResult(PushDataPointResult);
             if (points == null || !points.Any()) return Task.FromResult<bool?>(null);
             lock (dpLock)

--- a/manifest.yml
+++ b/manifest.yml
@@ -72,6 +72,7 @@ versions:
     changelog:
       fixed:
         - Fix batching of datapoints and events from the failure buffer.
+        - Fix bug causing ID and type definition ID based filtering to not work properly.
       added:
         - Add configuration options for batch size of events and datapoints in the failure buffer.
   "2.34.0":

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,13 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.35.0":
+    description: Fix batching of datapoints and events from the failure buffer, and make batch sizes configurable.
+    changelog:
+      fixed:
+        - Fix batching of datapoints and events from the failure buffer.
+      added:
+        - Add configuration options for batch size of events and datapoints in the failure buffer.
   "2.34.0":
     description: New syntax for start and end time, and some minor fixes.
     changelog:

--- a/schema/failure_buffer_config.schema.json
+++ b/schema/failure_buffer_config.schema.json
@@ -34,6 +34,18 @@
             "type": "boolean",
             "description": "Set to `true` to enable buffering data in InfluxDB. This requires a configured influx pusher. See [`influx`](#influx). This serves as an alternative to a local file, but should only be used if pushing to InfluxDB is already an requirement.",
             "default": false
+        },
+        "datapoints-batch": {
+            "type": "integer",
+            "description": "Maximum number of datapoints to read from the buffer and write to CDF in a single batch.",
+            "default": 1000000,
+            "minimum": 1
+        },
+        "events-batch": {
+            "type": "integer",
+            "description": "Maximum number of events to read from the buffer and write to CDF in a single batch.",
+            "default": 10000,
+            "minimum": 1
         }
     }
 }


### PR DESCRIPTION
Also makes it configurable, which is easy to do in this case. I wrote a couple of tests to verify that we actually batch.