### PR TITLE
Bump SDKs, use the new scheduler exit timeout

### DIFF
--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AdysTech.InfluxDB.Client.Net.Core" Version="0.25.0" />
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.32.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.34.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.375.457" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.457" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.375.457-beta" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.376.213" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.376.213" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.376.213-beta" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />

--- a/Extractor/PubSub/PubSubManager.cs
+++ b/Extractor/PubSub/PubSubManager.cs
@@ -141,7 +141,7 @@ namespace Cognite.OpcUa.PubSub
                 log.LogTrace("UADP Network DataSetMessage ({DataSets} DataSets): Source={Source}, SequenceNumber={SequenceNumber}",
                         e.NetworkMessage.DataSetMessages.Count, e.Source, uadpMessage.SequenceNumber);
             }
-            else if (e.NetworkMessage is JsonNetworkMessage jsonMessage)
+            else if (e.NetworkMessage is Opc.Ua.PubSub.Encoding.JsonNetworkMessage jsonMessage)
             {
                 log.LogTrace("JSON Network DataSetMessage ({DataSets} DataSets): Source={Source}, MessageId={MessageId}",
                         e.NetworkMessage.DataSetMessages.Count, e.Source, jsonMessage.MessageId);

--- a/Extractor/Types/UAPropertySerializer.cs
+++ b/Extractor/Types/UAPropertySerializer.cs
@@ -86,6 +86,10 @@ namespace Cognite.OpcUa.Types
         {
             if (mode == StringConverterMode.ReversibleJson && uaClient != null && value is Variant variant)
             {
+                if (variant == Variant.Null)
+                {
+                    return "null";
+                }
                 using var encoder = new JsonEncoder(uaClient.MessageContext, true, null, false);
                 encoder.WriteVariant(null, variant);
                 var result = encoder.CloseAndReturnText();

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -126,6 +126,9 @@ namespace Cognite.OpcUa
             this.uaClient = uaClient;
             this.pushers = pushers.Where(pusher => pusher != null).ToList();
             this.uaClient.Callbacks = this;
+            // Scheduler timeout is 30 seconds. It should never take this long to shut down, so if we get here
+            // we're fine with erroring out, better than getting stuck.
+            SchedulerExitTimeoutMs = 60000;
             log = provider.GetRequiredService<ILogger<UAExtractor>>();
 
             log.LogDebug("Config:{NewLine}{Config}", Environment.NewLine, ExtractorUtils.ConfigToString(Config));

--- a/MQTTCDFBridge/MQTTCDFBridge.csproj
+++ b/MQTTCDFBridge/MQTTCDFBridge.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.32.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.34.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />

--- a/Server/DebugMasterNodeManager.cs
+++ b/Server/DebugMasterNodeManager.cs
@@ -73,14 +73,15 @@ namespace Server
             IList<MonitoredItemCreateRequest> itemsToCreate,
             IList<ServiceResult> errors,
             IList<MonitoringFilterResult> filterResults,
-            IList<IMonitoredItem> monitoredItems)
+            IList<IMonitoredItem> monitoredItems,
+            bool createDurable)
         {
             ArgumentNullException.ThrowIfNull(itemsToCreate);
             ArgumentNullException.ThrowIfNull(errors);
 
             Callbacks.OnCreateMonitoredItems(context, subscriptionId, itemsToCreate);
 
-            base.CreateMonitoredItems(context, subscriptionId, publishingInterval, timestampsToReturn, itemsToCreate, errors, filterResults, monitoredItems);
+            base.CreateMonitoredItems(context, subscriptionId, publishingInterval, timestampsToReturn, itemsToCreate, errors, filterResults, monitoredItems, createDurable);
         }
 
         public override void HistoryRead(

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -10,12 +10,12 @@
     <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.32.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.34.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.457" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.375.457-beta" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.375.457" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.376.213" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.PubSub" Version="1.5.376.213-beta" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.376.213" />
   </ItemGroup>
 </Project>

--- a/Test/Integration/NodeExtractionTests.cs
+++ b/Test/Integration/NodeExtractionTests.cs
@@ -1247,7 +1247,7 @@ namespace Test.Integration
             extraction.DataTypes.AutoIdentifyTypes = true;
             await extractor.RunExtractor(true);
 
-            Assert.Equal(884, pusher.PushedNodes.Count);
+            Assert.Equal(913, pusher.PushedNodes.Count);
             Assert.Equal(2, pusher.PushedVariables.Count);
             var customVarType = pusher.PushedNodes[tester.Server.Ids.Custom.VariableType] as UAVariableType;
             Assert.Equal("CustomVariableType", customVarType.Name);
@@ -1275,9 +1275,9 @@ namespace Test.Integration
             extraction.Relationships.Hierarchical = false;
             await extractor.RunExtractor(true);
 
-            Assert.Equal(884, pusher.PushedNodes.Count);
+            Assert.Equal(913, pusher.PushedNodes.Count);
             Assert.Equal(2, pusher.PushedVariables.Count);
-            Assert.Equal(409, pusher.PushedReferences.Count);
+            Assert.Equal(419, pusher.PushedReferences.Count);
         }
         #endregion
 

--- a/Test/Unit/StringConversionTest.cs
+++ b/Test/Unit/StringConversionTest.cs
@@ -52,7 +52,7 @@ namespace Test.Unit
                 Value = new NodeId("abc", 2)
             }));
             var readValueId = new ReadValueId { AttributeId = Attributes.Value, NodeId = new NodeId("test", 0) };
-            var readValueIdStr = @"{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13}";
+            var readValueIdStr = @"{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13,""DataEncoding"":{}}";
             Assert.Equal(readValueIdStr, converter.ConvertToString(new Variant(readValueId)));
             var ids = new ReadValueIdCollection { readValueId, readValueId };
             // Results in Variant(ExtensionObject[])
@@ -395,6 +395,13 @@ namespace Test.Unit
             saved = Convert(variable);
             Assert.Equal(variable.ArrayDimensions, saved.InternalInfo.ArrayDimensions);
             Assert.Equal(variable.ValueRank, saved.InternalInfo.ValueRank);
+        }
+
+        [Fact]
+        public void TestReversibleJsonNullVariant()
+        {
+            var converter = tester.Client.StringConverter;
+            Assert.Equal("null", converter.ConvertToString(Variant.Null, null, null, StringConverterMode.ReversibleJson));
         }
     }
 }

--- a/Test/Unit/TypesTest.cs
+++ b/Test/Unit/TypesTest.cs
@@ -456,7 +456,7 @@ namespace Test.Unit
             prop.FullAttributes.Value = new Variant(value);
             node.Attributes.AddProperty(prop);
 
-            Assert.Equal(@"{""readvalueid"":{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13}}",
+            Assert.Equal(@"{""readvalueid"":{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13,""DataEncoding"":{}}}",
                 MetadataToJson(log, node, extractor));
 
             // Test nested
@@ -464,14 +464,14 @@ namespace Test.Unit
             var outerProp = new UAObject(new NodeId("outer", 0), "outer", null, null, NodeId.Null, null);
             outerProp.Attributes.AddProperty(prop);
             node.Attributes.AddProperty(outerProp);
-            Assert.Equal(@"{""outer"":{""readvalueid"":{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13}}}",
+            Assert.Equal(@"{""outer"":{""readvalueid"":{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13,""DataEncoding"":{}}}}",
                 MetadataToJson(log, node, extractor));
 
             // Test array
             prop.FullAttributes.Value = new Variant(new ReadValueIdCollection(new[] { value, value }));
             Assert.Equal(@"{""outer"":{""readvalueid"":["
-            + @"{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13},"
-            + @"{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13}]}}",
+            + @"{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13,""DataEncoding"":{}},"
+            + @"{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13,""DataEncoding"":{}}]}}",
                 MetadataToJson(log, node, extractor));
         }
         #endregion
@@ -936,7 +936,7 @@ namespace Test.Unit
             var value = new Variant(new ReadValueId { AttributeId = Attributes.Value, NodeId = new NodeId("test", 0) });
             dp = dt.ToDataPoint(extractor, value, now, "id", StatusCodes.Good);
             Assert.Equal("id", dp.Id);
-            Assert.Equal(@"{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13}", dp.StringValue);
+            Assert.Equal(@"{""NodeId"":{""IdType"":1,""Id"":""test""},""AttributeId"":13,""DataEncoding"":{}}", dp.StringValue);
             Assert.Equal(now, dp.Timestamp);
         }
         [Fact]
@@ -1244,8 +1244,8 @@ namespace Test.Unit
 
             Assert.Equal(3, meta.Count);
             Assert.Equal("gp.base:s=test", meta["test-simple"]);
-            Assert.Equal(@"{""NodeId"":{""IdType"":1,""Id"":""test2""},""AttributeId"":1}", meta["test-complex"]);
-            Assert.Equal(@"{""deep-2"":{""deep-simple"":123.123,""deep-complex"":{""NodeId"":{""IdType"":1,""Id"":""test2""},""AttributeId"":1},"
+            Assert.Equal(@"{""NodeId"":{""IdType"":1,""Id"":""test2""},""AttributeId"":1,""DataEncoding"":{}}", meta["test-complex"]);
+            Assert.Equal(@"{""deep-2"":{""deep-simple"":123.123,""deep-complex"":{""NodeId"":{""IdType"":1,""Id"":""test2""},""AttributeId"":1,""DataEncoding"":{}},"
                 + @"""Value1"":123.321,""Value"":[1,2,3,4]}}", meta["deep"]);
 
         }

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -646,7 +646,7 @@ namespace Test.Unit
             var distinctNodes = nodes.SelectMany(kvp => kvp.Value).GroupBy(rd => rd.NodeId);
 
             Assert.Equal(distinctNodes.Count(), nodes.Sum(kvp => kvp.Value.Count));
-            Assert.Equal(3117, nodes.Sum(kvp => kvp.Value.Count));
+            Assert.Equal(3233, nodes.Sum(kvp => kvp.Value.Count));
             Assert.True(CommonTestUtils.TestMetricValue("opcua_browse_operations", 11));
             Assert.True(CommonTestUtils.TestMetricValue("opcua_tree_depth", 11));
         }

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.35.1":
+    description: Add timeout to extractor shutdown.
+    changelog:
+      changed:
+        - Add a timeout to the extractor shutdown process to avoid hanging indefinitely.
   "2.35.0":
     description: Fix batching of datapoints and events from the failure buffer, and make batch sizes configurable.
     changelog:


### PR DESCRIPTION
Bumps the .NET utils and OPC-UA SDK. Also uses the new scheduler exit timeout, which may help with an issue in the extractor.