### PR TITLE
No longer require groups:List and projects:List

### DIFF
--- a/Extractor/Pushers/CDFPusher.cs
+++ b/Extractor/Pushers/CDFPusher.cs
@@ -446,7 +446,7 @@ namespace Cognite.OpcUa.Pushers
 
             try
             {
-                await destination.TestCogniteConfig(token);
+                await destination.CogniteClient.TestCogniteConfig(config.Project!, token, checkProjectOwnership: false);
             }
             catch (Exception ex)
             {

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.35.2":
+    description: No longer require groups:List and projects:List permissions.
+    changelog:
+      changed:
+        - The extractor no longer requires groups:List and projects:List permissions to run.
   "2.35.1":
     description: Add timeout to extractor shutdown.
     changelog:


### PR DESCRIPTION
We don't technically need these, and they have caused confusion in the past, especially now that they are only used if we _lose_ connection to CDF.

For V3 we are likely dropping this entirely in the utils. Since this is purely making the extractor require _fewer_ ACLs, it is a non-breaking change.