### PR TITLE
Add options to adjust MaxNotificationsPerPublish

### DIFF
--- a/Extractor/Config/SubscriptionConfig.cs
+++ b/Extractor/Config/SubscriptionConfig.cs
@@ -108,11 +108,11 @@ namespace Cognite.OpcUa.Config
         public bool RecreateStoppedSubscriptions { get; set; } = true;
 
         /// <summary>
-        /// Maximum number of event notifications per publish.
+        /// Maximum number of datapoint notifications per publish.
         /// This is the maximum number of datapoints that can be sent in a single publish response
         /// from datapoint subscriptions.
         /// </summary>
-        public uint MaxDataNotificationsPerPublish { get; set; } = 0;
+        public uint MaxDatapointNotificationsPerPublish { get; set; } = 0;
 
         /// <summary>
         /// Maximum number of event notifications per publish.

--- a/Extractor/Config/SubscriptionConfig.cs
+++ b/Extractor/Config/SubscriptionConfig.cs
@@ -108,6 +108,20 @@ namespace Cognite.OpcUa.Config
         public bool RecreateStoppedSubscriptions { get; set; } = true;
 
         /// <summary>
+        /// Maximum number of event notifications per publish.
+        /// This is the maximum number of datapoints that can be sent in a single publish response
+        /// from datapoint subscriptions.
+        /// </summary>
+        public uint MaxDataNotificationsPerPublish { get; set; } = 0;
+
+        /// <summary>
+        /// Maximum number of event notifications per publish.
+        /// This is the maximum number of events that can be sent in a single publish response
+        /// from event subscriptions.
+        /// </summary>
+        public uint MaxEventNotificationsPerPublish { get; set; } = 0;
+
+        /// <summary>
         /// Optional grace period for recreating stopped subscriptions.
         /// Defaults to 8 * Publishing interval
         /// </summary>

--- a/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
+++ b/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
@@ -137,11 +137,11 @@ namespace Cognite.OpcUa.Subscriptions
                 }
                 else if (SubscriptionName.IsDataPoints())
                 {
-                    maxNotificationsPerPublish = config.Subscriptions.MaxDataNotificationsPerPublish;
+                    maxNotificationsPerPublish = config.Subscriptions.MaxDatapointNotificationsPerPublish;
                 }
-                // For general subscriptions, the default value of 0 is going to be fine. In practice,
-                // we will never receive that many notifications for those, since they are very limited in size.
 
+                // For other subscriptions, like audit events service level changes, etc. the number of notifications
+                // is going to be quite low, so the default value of 0 is fine.
                 logger.LogInformation("Creating new subscription with name {Name}", SubscriptionName.Name());
                 subscription = new Subscription(session.DefaultSubscription)
                 {

--- a/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
+++ b/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
@@ -130,13 +130,26 @@ namespace Cognite.OpcUa.Subscriptions
 
             if (subscription == null)
             {
+                uint maxNotificationsPerPublish = 0;
+                if (SubscriptionName.IsEvents())
+                {
+                    maxNotificationsPerPublish = config.Subscriptions.MaxEventNotificationsPerPublish;
+                }
+                else if (SubscriptionName.IsDataPoints())
+                {
+                    maxNotificationsPerPublish = config.Subscriptions.MaxDataNotificationsPerPublish;
+                }
+                // For general subscriptions, the default value of 0 is going to be fine. In practice,
+                // we will never receive that many notifications for those, since they are very limited in size.
+
                 logger.LogInformation("Creating new subscription with name {Name}", SubscriptionName.Name());
                 subscription = new Subscription(session.DefaultSubscription)
                 {
                     PublishingInterval = config.Source.PublishingInterval,
                     DisplayName = SubscriptionName.Name(),
                     KeepAliveCount = config.Subscriptions.KeepAliveCount,
-                    LifetimeCount = config.Subscriptions.LifetimeCount
+                    LifetimeCount = config.Subscriptions.LifetimeCount,
+                    MaxNotificationsPerPublish = maxNotificationsPerPublish
                 };
                 subscription.PublishStatusChanged += subManager.OnSubscriptionPublishStatusChange;
             }

--- a/Extractor/Subscriptions/SubscriptionStateCache.cs
+++ b/Extractor/Subscriptions/SubscriptionStateCache.cs
@@ -28,6 +28,16 @@ namespace Cognite.OpcUa.Subscriptions
                 _ => throw new ArgumentException("Subscription name is not valid")
             };
         }
+
+        public static bool IsEvents(this SubscriptionName name)
+        {
+            return name == SubscriptionName.Events;
+        }
+
+        public static bool IsDataPoints(this SubscriptionName name)
+        {
+            return name == SubscriptionName.DataPoints;
+        }
     }
 
     public interface ISubscriptionState

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -873,6 +873,14 @@ subscriptions:
     # If this is negative, default to 8 * publishing-interval.
     # Syntax is N[timeunit] where timeunit is w, d, h, m, s or ms.
     recreate-subscription-grace-period: -1
+    # Maximum number of data points to be sent in each publish request.
+    # Some servers do not properly support this.
+    # The default is 0, which means that the server will decide.
+    max-data-notifications-per-publish: 0
+    # Maximum number of events to be sent in each publish request.
+    # Some servers do not properly support this.
+    # The default is 0, which means that the server will decide.
+    max-event-notifications-per-publish: 0
     # List of alternative subscription configurations.
     # The first entry with a matching filter will be used for each node.
     alternative-configs:

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -876,7 +876,7 @@ subscriptions:
     # Maximum number of data points to be sent in each publish request.
     # Some servers do not properly support this.
     # The default is 0, which means that the server will decide.
-    max-data-notifications-per-publish: 0
+    max-datapoint-notifications-per-publish: 0
     # Maximum number of events to be sent in each publish request.
     # Some servers do not properly support this.
     # The default is 0, which means that the server will decide.

--- a/manifest.yml
+++ b/manifest.yml
@@ -71,7 +71,7 @@ versions:
     description: Add options to configure the maximum number of notifications per publish request.
     changelog:
       added:
-        - Add `max-data-notifications-per-publish` and `max-event-notifications-per-publish` to the subscription config.
+        - Add `max-datapoint-notifications-per-publish` and `max-event-notifications-per-publish` to the subscription config.
   "2.35.2":
     description: No longer require groups:List and projects:List permissions.
     changelog:

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.36.0":
+    description: Add options to configure the maximum number of notifications per publish request.
+    changelog:
+      added:
+        - Add `max-data-notifications-per-publish` and `max-event-notifications-per-publish` to the subscription config.
   "2.35.2":
     description: No longer require groups:List and projects:List permissions.
     changelog:

--- a/schema/subscription_config.schema.json
+++ b/schema/subscription_config.schema.json
@@ -89,9 +89,9 @@
             "default": "-1",
             "description": "Grace period for recreating stopped subscriptions. If this is negative, default to 8 * publishing-interval. Format is as given in [Timestamps and intervals](#timestamps-and-intervals)."
         },
-        "max-data-notifications-per-publish": {
+        "max-datapoint-notifications-per-publish": {
             "type": "integer",
-            "description": "Maximum number of data notifications per publish. Some servers do not properly support this. The default is 0, which means that the server will decide.",
+            "description": "Maximum number of datapoint notifications per publish. Some servers do not properly support this. The default is 0, which means that the server will decide.",
             "default": 0,
             "mimimum": 0
         },

--- a/schema/subscription_config.schema.json
+++ b/schema/subscription_config.schema.json
@@ -89,6 +89,18 @@
             "default": "-1",
             "description": "Grace period for recreating stopped subscriptions. If this is negative, default to 8 * publishing-interval. Format is as given in [Timestamps and intervals](#timestamps-and-intervals)."
         },
+        "max-data-notifications-per-publish": {
+            "type": "integer",
+            "description": "Maximum number of data notifications per publish. Some servers do not properly support this. The default is 0, which means that the server will decide.",
+            "default": 0,
+            "mimimum": 0
+        },
+        "max-event-notifications-per-publish": {
+            "type": "integer",
+            "description": "Maximum number of event notifications per publish. Some servers do not properly support this. The default is 0, which means that the server will decide.",
+            "default": 0,
+            "mimimum": 0
+        },
         "alternative-configs": {
             "type": "array",
             "description": "List of alternative subscription configurations. The first entry with a matching filter will be used for each node.",


### PR DESCRIPTION
This is a server option, in practice, so all we do is send this number to the server. Because the size of datapoint and event notifications can be so different, I added a separate number for the two subscriptions.

We've rarely actually seen an issue with this, servers are free to send however many notifications they want.