### PR TITLE
Set MaxMonitoredItemsPerCall on the client

### DIFF
--- a/Extractor/Connect/DirectConnectionSource.cs
+++ b/Extractor/Connect/DirectConnectionSource.cs
@@ -106,6 +106,12 @@ namespace Cognite.OpcUa.Connect
                     null,
                     token
                 );
+
+                // This is 0 by default, which can cause subscription recreation to fail.
+                // We try to do our own chunking, but the client is rather opaque so it sometimes creates too many items
+                // in a single call, typically exceeding its own encoding limits.
+                session.OperationLimits.MaxMonitoredItemsPerCall = (uint)config.SubscriptionChunk;
+
                 ConnectionUtils.Connects.Inc();
                 session.DeleteSubscriptionsOnClose = true;
                 return new ConnectResult(new Connection(session, endpointUrl), ConnectType.NewSession);

--- a/Extractor/Connect/ReverseConnectionSource.cs
+++ b/Extractor/Connect/ReverseConnectionSource.cs
@@ -123,6 +123,12 @@ namespace Cognite.OpcUa.Connect
                     0,
                     identity,
                     null);
+
+                // This is 0 by default, which can cause subscription recreation to fail.
+                // We try to do our own chunking, but the client is rather opaque so it sometimes creates too many items
+                // in a single call, typically exceeding its own encoding limits.
+                session.OperationLimits.MaxMonitoredItemsPerCall = (uint)config.SubscriptionChunk;
+
                 ConnectionUtils.Connects.Inc();
                 session.DeleteSubscriptionsOnClose = true;
                 return new ConnectResult(new Connection(session, endpointUrl), ConnectType.NewSession);

--- a/Extractor/ServerInfoHelper.cs
+++ b/Extractor/ServerInfoHelper.cs
@@ -99,6 +99,13 @@ namespace Cognite.OpcUa
                 config.History.EventNodesChunk, values[idsToRead[5]], "event history nodes chunk");
             config.Source.AttributesChunk = SafeValue(
                 config.Source.AttributesChunk, values[idsToRead[6]], "attribute read chunk");
+
+            // We generally do our own batching, but for monitored items in particular we should set the limit on the client.
+            // If not the client may in some cases try to create way too many monitored items in a single call.
+            if (client.SessionManager.Session is SessionClientBatched batchedClient)
+            {
+                batchedClient.OperationLimits.MaxMonitoredItemsPerCall = (uint)config.Source.SubscriptionChunk;
+            }
         }
     }
 }


### PR DESCRIPTION
We try to do our own batching here, but the client doesn't expose an interface to allow us to do that. Apparently the current way we do it can fail, or create way too many monitored items to be created at a time. This should hopefully protect against this case.

I still don't know exactly how this can happen, it should be impossible, since we always create monitored items when we add them.