### PR TITLE
Log errors that occur when creating connection parameters

### DIFF
--- a/Extractor/Connect/ConnectionUtils.cs
+++ b/Extractor/Connect/ConnectionUtils.cs
@@ -52,7 +52,7 @@ namespace Cognite.OpcUa.Connect
                 {
                     return await method();
                 }
-                catch
+                catch (Exception e)
                 {
                     iter++;
                     iter = Math.Min(iter, maxBackoff);
@@ -63,7 +63,9 @@ namespace Cognite.OpcUa.Connect
                         throw;
                     }
                     if (!token.IsCancellationRequested)
-                        log.LogWarning("Failed to connect, retrying in {Backoff}", backoff);
+                    {
+                        log.LogWarning("Failed to connect: {Error}, retrying in {Backoff}", e.Message, backoff);
+                    }
                     try { await Task.Delay(backoff, token); } catch (TaskCanceledException) { }
                 }
             }

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.36.1":
+    description: Log errors that occur when failing to create connection parameters for connecting to the server.
+    changelog:
+      fixed:
+        - Log errors that occur when failing to create connection parameters for connecting to the server.
   "2.36.0":
     description: Add options to configure the maximum number of notifications per publish request.
     changelog:


### PR DESCRIPTION
I think something goes wrong for a user when loading the x509 certificate. This may help.