### PR TITLE
Refactor string converter

### DIFF
--- a/ConfigurationTool/ToolUtil.cs
+++ b/ConfigurationTool/ToolUtil.cs
@@ -150,14 +150,14 @@ namespace Cognite.OpcUa.Config
                     log.LogDebug("Bad array datapoint: {BadPointName} {BadPointValue}", variable.Id, value.Value.ToString());
                     return Enumerable.Empty<UADataPoint>();
                 }
-                var values = client.StringConverter.ExtractVariantArray(value);
+                var values = client.TypeConverter.ExtractVariantArray(value);
                 for (int i = 0; i < Math.Min(variable.ArrayDimensions[0], values.Length); i++)
                 {
                     var dp = variable.DataType.IsString
                         ? new UADataPoint(
                             value.SourceTimestamp,
                             $"{variable.Id}[{i}]",
-                            client.StringConverter.ConvertToString(values[i]),
+                            client.TypeConverter.ConvertToString(values[i]),
                             value.StatusCode)
                         : new UADataPoint(
                             value.SourceTimestamp,
@@ -172,7 +172,7 @@ namespace Cognite.OpcUa.Config
                 ? new UADataPoint(
                     value.SourceTimestamp,
                     variable.Id,
-                    client.StringConverter.ConvertToString(value.WrappedValue),
+                    client.TypeConverter.ConvertToString(value.WrappedValue),
                     value.StatusCode)
                 : new UADataPoint(
                     value.SourceTimestamp,

--- a/ConfigurationTool/ToolUtil.cs
+++ b/ConfigurationTool/ToolUtil.cs
@@ -150,19 +150,19 @@ namespace Cognite.OpcUa.Config
                     log.LogDebug("Bad array datapoint: {BadPointName} {BadPointValue}", variable.Id, value.Value.ToString());
                     return Enumerable.Empty<UADataPoint>();
                 }
-                var values = (Array)value.Value;
+                var values = client.StringConverter.ExtractVariantArray(value);
                 for (int i = 0; i < Math.Min(variable.ArrayDimensions[0], values.Length); i++)
                 {
                     var dp = variable.DataType.IsString
                         ? new UADataPoint(
                             value.SourceTimestamp,
                             $"{variable.Id}[{i}]",
-                            client.StringConverter.ConvertToString(values.GetValue(i)),
+                            client.StringConverter.ConvertToString(values[i]),
                             value.StatusCode)
                         : new UADataPoint(
                             value.SourceTimestamp,
                             $"{variable.Id}[{i}]",
-                            UAClient.ConvertToDouble(values.GetValue(i)),
+                            UAClient.ConvertToDouble(values[i]),
                             value.StatusCode);
                     ret.Add(dp);
                 }
@@ -172,7 +172,7 @@ namespace Cognite.OpcUa.Config
                 ? new UADataPoint(
                     value.SourceTimestamp,
                     variable.Id,
-                    client.StringConverter.ConvertToString(value.Value),
+                    client.StringConverter.ConvertToString(value.WrappedValue),
                     value.StatusCode)
                 : new UADataPoint(
                     value.SourceTimestamp,

--- a/Extractor/NodeSources/CDFNodeSource.cs
+++ b/Extractor/NodeSources/CDFNodeSource.cs
@@ -88,7 +88,7 @@ namespace Cognite.OpcUa.NodeSources
         {
             // Ignores nodesToBrowse, nothing really to do with that here
             var options = new JsonSerializerOptions();
-            extractor.StringConverter.AddConverters(options, ConverterType.Node);
+            extractor.TypeConverter.AddConverters(options, ConverterType.Node);
 
             var nodeSet = new HashSet<NodeId>();
 

--- a/Extractor/Nodes/BaseUANode.cs
+++ b/Extractor/Nodes/BaseUANode.cs
@@ -492,7 +492,7 @@ namespace Cognite.OpcUa.Nodes
                     if (metaMap.TryGetValue(prop.Name ?? "", out var mapped))
                     {
                         if (propVar.Value == null) continue;
-                        var value = client.StringConverter.ConvertToString(propVar.Value.Value, propVar.FullAttributes.DataType.EnumValues);
+                        var value = client.TypeConverter.ConvertToString(propVar.Value.Value, propVar.FullAttributes.DataType.EnumValues);
                         if (string.IsNullOrWhiteSpace(value)) continue;
                         switch (mapped)
                         {
@@ -510,7 +510,7 @@ namespace Cognite.OpcUa.Nodes
         /// </summary>
         /// <param name="config">Active configuration object</param>
         /// <param name="client">Access to OPC-UA session</param>
-        /// <param name="converter">StringConverter for converting fields</param>
+        /// <param name="converter">TypeConverter for converting fields</param>
         /// <param name="dataSetId">Optional dataSetId</param>
         /// <param name="metaMap">Map from metadata to asset attributes.</param>
         /// <returns></returns>
@@ -544,7 +544,7 @@ namespace Cognite.OpcUa.Nodes
                         }
                         else
                         {
-                            result[prop.Name] = client.StringConverter.ConvertToString(variable.Value.Value, variable.FullAttributes.DataType?.EnumValues)
+                            result[prop.Name] = client.TypeConverter.ConvertToString(variable.Value.Value, variable.FullAttributes.DataType?.EnumValues)
                                 ?? variable.Value.ToString();
                         }
                     }
@@ -568,7 +568,7 @@ namespace Cognite.OpcUa.Nodes
         /// </summary>
         /// <param name="config">Extraction config object</param>
         /// <param name="manager">DataTypeManager used to get information about the datatype</param>
-        /// <param name="converter">StringConverter used for building metadata</param>
+        /// <param name="converter">TypeConverter used for building metadata</param>
         /// <param name="getExtras">True to get extra metadata</param>
         /// <returns>Created metadata dictionary.</returns>
         public Dictionary<string, string> BuildMetadata(FullConfig config, IUAClientAccess client, bool getExtras)
@@ -576,7 +576,7 @@ namespace Cognite.OpcUa.Nodes
             Dictionary<string, string>? extras = null;
             if (getExtras)
             {
-                extras = GetExtraMetadata(config, client.Context, client.StringConverter);
+                extras = GetExtraMetadata(config, client.Context, client.TypeConverter);
             }
             return BuildMetadataBase(extras, client);
         }

--- a/Extractor/Nodes/UADataType.cs
+++ b/Extractor/Nodes/UADataType.cs
@@ -174,10 +174,10 @@ namespace Cognite.OpcUa.Nodes
         /// <param name="stringOverride">True to override the IsString parameter of this datatype, converting
         /// numerical datavalues to string as well.</param>
         /// <returns>Created UADataPoint</returns>
-        public UADataPoint ToDataPoint(IUAClientAccess client, object value, DateTime timestamp, string id, StatusCode status, bool stringOverride = false)
+        public UADataPoint ToDataPoint(IUAClientAccess client, Variant value, DateTime timestamp, string id, StatusCode status, bool stringOverride = false)
         {
             if (timestamp == DateTime.MinValue) timestamp = DateTime.UtcNow;
-            if (value is null)
+            if (value.Value is null)
             {
                 return new UADataPoint(timestamp, id, IsString, status);
             }

--- a/Extractor/Nodes/UADataType.cs
+++ b/Extractor/Nodes/UADataType.cs
@@ -184,7 +184,7 @@ namespace Cognite.OpcUa.Nodes
 
             if (IsString || stringOverride)
             {
-                return new UADataPoint(timestamp, id, client.StringConverter.ConvertToString(value, EnumValues), status);
+                return new UADataPoint(timestamp, id, client.TypeConverter.ConvertToString(value, EnumValues), status);
             }
             return new UADataPoint(timestamp, id, UAClient.ConvertToDouble(value), status);
         }

--- a/Extractor/Nodes/UAObject.cs
+++ b/Extractor/Nodes/UAObject.cs
@@ -106,7 +106,7 @@ namespace Cognite.OpcUa.Nodes
 
         public override NodeId? TypeDefinition => FullAttributes.TypeDefinition?.Id;
 
-        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, SessionContext context, StringConverter converter)
+        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, SessionContext context, TypeConverter converter)
         {
             if (config.Extraction.NodeTypes.Metadata && FullAttributes.TypeDefinition?.Name != null)
             {

--- a/Extractor/Nodes/UAVariable.cs
+++ b/Extractor/Nodes/UAVariable.cs
@@ -451,7 +451,7 @@ namespace Cognite.OpcUa.Nodes
                 Metadata = BuildMetadata(config, client, true)
             };
 
-            HandleMetaMap(metaMap, writePoco, value => writePoco.AssetExternalId = value, client.StringConverter);
+            HandleMetaMap(metaMap, writePoco, value => writePoco.AssetExternalId = value, client.TypeConverter);
 
             return writePoco;
         }
@@ -498,7 +498,7 @@ namespace Cognite.OpcUa.Nodes
                 {
                     writePoco.AssetId = assetId;
                 }
-            }, extractor.StringConverter);
+            }, extractor.TypeConverter);
 
             return writePoco;
         }
@@ -554,7 +554,7 @@ namespace Cognite.OpcUa.Nodes
                     if (metaMap.TryGetValue(prop.Name ?? "", out var mapped))
                     {
                         if (propVar.Value == null) continue;
-                        var value = client.StringConverter.ConvertToString(propVar.Value.Value, propVar.FullAttributes.DataType.EnumValues);
+                        var value = client.TypeConverter.ConvertToString(propVar.Value.Value, propVar.FullAttributes.DataType.EnumValues);
                         if (string.IsNullOrWhiteSpace(value)) continue;
                         switch (mapped)
                         {

--- a/Extractor/Nodes/UAVariable.cs
+++ b/Extractor/Nodes/UAVariable.cs
@@ -290,7 +290,7 @@ namespace Cognite.OpcUa.Nodes
             return (Id, -1);
         }
 
-        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, SessionContext context, StringConverter converter)
+        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, SessionContext context, TypeConverter converter)
         {
             Dictionary<string, string>? fields = null;
             if (config.Extraction.NodeTypes.Metadata && FullAttributes.TypeDefinition?.Name != null)
@@ -402,7 +402,7 @@ namespace Cognite.OpcUa.Nodes
             Dictionary<string, string>? metaMap,
             TimeSeriesCreate writePoco,
             Action<string> parentIdHandler,
-            StringConverter converter)
+            TypeConverter converter)
         {
             if (Properties == null || !Properties.Any() || metaMap == null || metaMap.Count == 0) return;
             foreach (var prop in Properties)
@@ -410,7 +410,8 @@ namespace Cognite.OpcUa.Nodes
                 if (prop is not UAVariable propVar) continue;
                 if (metaMap.TryGetValue(prop.Name ?? "", out var mapped))
                 {
-                    var value = converter.ConvertToString(propVar.Value, propVar.FullAttributes.DataType.EnumValues);
+                    if (propVar.Value == null) continue;
+                    var value = converter.ConvertToString(propVar.Value.Value, propVar.FullAttributes.DataType.EnumValues);
                     if (string.IsNullOrWhiteSpace(value)) continue;
                     switch (mapped)
                     {
@@ -552,7 +553,8 @@ namespace Cognite.OpcUa.Nodes
                     if (prop is not UAVariable propVar) continue;
                     if (metaMap.TryGetValue(prop.Name ?? "", out var mapped))
                     {
-                        var value = client.StringConverter.ConvertToString(propVar.Value, propVar.FullAttributes.DataType.EnumValues);
+                        if (propVar.Value == null) continue;
+                        var value = client.StringConverter.ConvertToString(propVar.Value.Value, propVar.FullAttributes.DataType.EnumValues);
                         if (string.IsNullOrWhiteSpace(value)) continue;
                         switch (mapped)
                         {

--- a/Extractor/Nodes/UAVariableType.cs
+++ b/Extractor/Nodes/UAVariableType.cs
@@ -131,7 +131,7 @@ namespace Cognite.OpcUa.Nodes
                 && FullAttributes.DataType.AllowValueRead(this, FullAttributes.ArrayDimensions, FullAttributes.ValueRank, logger, config, ignoreDimension);
         }
 
-        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, SessionContext context, StringConverter converter)
+        public override Dictionary<string, string>? GetExtraMetadata(FullConfig config, SessionContext context, TypeConverter converter)
         {
             Dictionary<string, string>? fields = new Dictionary<string, string>();
             var dt = FullAttributes.DataType;
@@ -153,7 +153,10 @@ namespace Cognite.OpcUa.Nodes
                     fields["dataType"] = dt.Name ?? dt.GetUniqueId(context) ?? "null";
                 }
             }
-            fields["Value"] = converter.ConvertToString(FullAttributes.Value, dt.EnumValues);
+            if (FullAttributes.Value != null)
+            {
+                fields["Value"] = converter.ConvertToString(FullAttributes.Value.Value, dt.EnumValues);
+            }
 
             return fields;
         }

--- a/Extractor/Nodes/UAVariableType.cs
+++ b/Extractor/Nodes/UAVariableType.cs
@@ -157,6 +157,10 @@ namespace Cognite.OpcUa.Nodes
             {
                 fields["Value"] = converter.ConvertToString(FullAttributes.Value.Value, dt.EnumValues);
             }
+            else
+            {
+                fields["Value"] = string.Empty;
+            }
 
             return fields;
         }

--- a/Extractor/Pushers/FDM/FDMWriter.cs
+++ b/Extractor/Pushers/FDM/FDMWriter.cs
@@ -278,7 +278,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             await InitializeSpaceAndServer(token);
             context = await SyncServerMeta(extractor.NamespaceTable!, token);
 
-            var converter = new DMSValueConverter(extractor.StringConverter, modelInfo.InstanceSpace);
+            var converter = new DMSValueConverter(extractor.TypeConverter, modelInfo.InstanceSpace);
             var builder = new TypeHierarchyBuilder(log, converter, config, modelInfo, context);
 
             // First, collect all nodes, including properties.

--- a/Extractor/Pushers/FDM/InstanceBuilder.cs
+++ b/Extractor/Pushers/FDM/InstanceBuilder.cs
@@ -455,14 +455,7 @@ namespace Cognite.OpcUa.Pushers.FDM
         {
             if (variable.IsProperty && variable.Value != null)
             {
-                var json = converter.Converter.ConvertToJson(variable.Value.Value, null, null, JsonMode.ReversibleJson);
-                if (json is not null && json is not JsonObject)
-                {
-                    json = new JsonObject
-                    {
-                        ["Value"] = json
-                    };
-                }
+                var json = converter.Converter.ConvertToJsonObject(variable.Value.Value, null, null, JsonMode.ReversibleJson);
                 Value = json;
             }
             else
@@ -543,14 +536,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             ValueRank = variable.FullAttributes.ValueRank;
             if (variable.FullAttributes.Value != null)
             {
-                var json = converter.Converter.ConvertToJson(variable.FullAttributes.Value.Value, null, null, JsonMode.ReversibleJson);
-                if (json is not null && json is not JsonObject)
-                {
-                    json = new JsonObject
-                    {
-                        ["Value"] = json
-                    };
-                }
+                var json = converter.Converter.ConvertToJsonObject(variable.FullAttributes.Value.Value, null, null, JsonMode.ReversibleJson);
                 Value = json;
             }
         }
@@ -583,14 +569,7 @@ namespace Cognite.OpcUa.Pushers.FDM
             var def = node.FullAttributes.DataTypeDefinition;
             if (def != null)
             {
-                var json = converter.Converter.ConvertToJson(def.Value, null, null, JsonMode.ReversibleJson);
-                if (json is not null && json is not JsonObject)
-                {
-                    json = new JsonObject
-                    {
-                        ["Value"] = json
-                    };
-                }
+                var json = converter.Converter.ConvertToJsonObject(def.Value, null, null, JsonMode.ReversibleJson);
                 DataTypeDefinition = json;
             }
         }

--- a/Extractor/Pushers/InfluxPusher.cs
+++ b/Extractor/Pushers/InfluxPusher.cs
@@ -559,7 +559,7 @@ namespace Cognite.OpcUa
             string? sourceNode;
             if (evt.MetaData != null && evt.MetaData.TryGetValue("SourceNode", out var rawSourceNode))
             {
-                sourceNode = Extractor.StringConverter.ConvertToString(rawSourceNode);
+                sourceNode = Extractor.TypeConverter.ConvertToString(rawSourceNode);
             }
             else
             {
@@ -571,7 +571,7 @@ namespace Cognite.OpcUa
                 foreach (var kvp in evt.MetaData)
                 {
                     if (kvp.Key == "Emitter" || kvp.Key == "Type" || kvp.Key == "SourceNode") continue;
-                    var str = Extractor.StringConverter.ConvertToString(kvp.Value);
+                    var str = Extractor.TypeConverter.ConvertToString(kvp.Value);
                     idp.Tags[kvp.Key] = string.IsNullOrEmpty(str) ? "null" : str;
                 }
             }

--- a/Extractor/Pushers/MqttPusher.cs
+++ b/Extractor/Pushers/MqttPusher.cs
@@ -625,7 +625,7 @@ namespace Cognite.OpcUa.Pushers
             if (Extractor == null) throw new InvalidOperationException("Extractor must be set");
             foreach (var node in nodes)
             {
-                var create = node.ToJson(log, Extractor.StringConverter, type);
+                var create = node.ToJson(log, Extractor.TypeConverter, type);
                 if (create == null) continue;
                 string? id = Extractor.GetUniqueId(node.Id);
                 if (id == null) continue;

--- a/Extractor/Pushers/PusherUtils.cs
+++ b/Extractor/Pushers/PusherUtils.cs
@@ -62,7 +62,7 @@ namespace Cognite.OpcUa.Pushers
 
         public static JsonElement? CreateRawUpdate(
             ILogger log,
-            StringConverter converter,
+            TypeConverter converter,
             BaseUANode node,
             RawRow<Dictionary<string, JsonElement>>? raw,
             ConverterType type)

--- a/Extractor/Pushers/Records/StreamRecordsWriter.cs
+++ b/Extractor/Pushers/Records/StreamRecordsWriter.cs
@@ -50,7 +50,7 @@ namespace Cognite.OpcUa.Pushers.Records
             await destination.CogniteClient.DataModels.UpsertSpaces(spaces.Select(s => new SpaceCreate { Space = s, Name = s }), token);
 
             await containerCache.Initialize(token);
-            converter = new DMSValueConverter(extractor.StringConverter, logSpace);
+            converter = new DMSValueConverter(extractor.TypeConverter, logSpace);
             if (logAnalyticsConfig.UseRawNodeId)
             {
                 context = new NodeIdDirectStringConverter();

--- a/Extractor/Pushers/Writers/RawWriter.cs
+++ b/Extractor/Pushers/Writers/RawWriter.cs
@@ -208,7 +208,7 @@ namespace Cognite.OpcUa.Pushers.Writers
                         return rowsToUpsert
                             .Select(
                                 kvp =>
-                                    (kvp.Key, update: PusherUtils.CreateRawUpdate(log, extractor.StringConverter, kvp.Value, null, converter))
+                                    (kvp.Key, update: PusherUtils.CreateRawUpdate(log, extractor.TypeConverter, kvp.Value, null, converter))
                             )
                             .Where(elem => elem.update != null)
                             .ToDictionary(pair => pair.Key, pair => pair.update!.Value);
@@ -229,7 +229,7 @@ namespace Cognite.OpcUa.Pushers.Writers
 
                     foreach (var (key, row, node) in toWrite)
                     {
-                        var update = PusherUtils.CreateRawUpdate(log, extractor.StringConverter, node, row, converter);
+                        var update = PusherUtils.CreateRawUpdate(log, extractor.TypeConverter, node, row, converter);
 
                         if (update != null)
                         {
@@ -275,7 +275,7 @@ namespace Cognite.OpcUa.Pushers.Writers
                 {
                     var rows = ids.Select(id => (dataMap[id], id));
                     var creates = rows
-                        .Select(pair => (pair.Item1.ToJson(log, extractor.StringConverter, converter), pair.id))
+                        .Select(pair => (pair.Item1.ToJson(log, extractor.TypeConverter, converter), pair.id))
                         .Where(pair => pair.Item1 != null)
                         .ToDictionary(pair => pair.id, pair => pair.Item1!.RootElement);
                     result.Created += creates.Count;

--- a/Extractor/Streamer.cs
+++ b/Extractor/Streamer.cs
@@ -437,10 +437,12 @@ namespace Cognite.OpcUa
                     missedArrayPoints.Inc(values.Length - dim);
                 }
                 var ret = new List<UADataPoint>();
+                var variantArray = extractor.StringConverter.ExtractVariantArray(value.WrappedValue);
                 for (int i = 0; i < dim; i++)
                 {
                     var id = variable.IsArray ? GetArrayUniqueId(uniqueId, i) : uniqueId;
-                    ret.Add(variable.DataType.ToDataPoint(extractor, values.GetValue(i), value.SourceTimestamp, id, value.StatusCode));
+                    var entry = i < variantArray.Length ? variantArray[i] : Variant.Null;
+                    ret.Add(variable.DataType.ToDataPoint(extractor, entry, value.SourceTimestamp, id, value.StatusCode));
                 }
                 return ret;
             }
@@ -568,7 +570,7 @@ namespace Cognite.OpcUa
             var finalProperties = extractedProperties.Select(kvp => kvp.Value);
             var buffEvent = new UAEvent
             {
-                Message = extractor.StringConverter.ConvertToString(extractedProperties.GetValueOrDefault("Message")?.Value),
+                Message = extractor.StringConverter.ConvertToString(extractedProperties.GetValueOrDefault("Message")?.Value ?? Variant.Null),
                 EventId = config.Extraction.IdPrefix + eventId,
                 SourceNode = sourceNode,
                 Time = time,

--- a/Extractor/Streamer.cs
+++ b/Extractor/Streamer.cs
@@ -414,30 +414,30 @@ namespace Cognite.OpcUa
         {
             string uniqueId = variable.Id;
 
-            if (value.Value is Array values)
+            if (value.Value is Array)
             {
+                var variantArray = extractor.StringConverter.ExtractVariantArray(value.WrappedValue);
                 int dim = 1;
-                if (values.Length == 0) return Enumerable.Empty<UADataPoint>();
+                if (variantArray.Length == 0) return Enumerable.Empty<UADataPoint>();
                 if (!variable.IsArray)
                 {
                     log.LogDebug("Array values returned for scalar variable {Id}", variable.Id);
-                    if (values.Length > 1)
+                    if (variantArray.Length > 1)
                     {
-                        missedArrayPoints.Inc(values.Length - 1);
+                        missedArrayPoints.Inc(variantArray.Length - 1);
                     }
                 }
-                else if (variable.ArrayDimensions[0] >= values.Length)
+                else if (variable.ArrayDimensions[0] >= variantArray.Length)
                 {
-                    dim = values.Length;
+                    dim = variantArray.Length;
                 }
                 else
                 {
                     dim = variable.ArrayDimensions[0];
-                    log.LogDebug("Missing {Count} points for variable {Id} due to too small ArrayDimensions", values.Length - dim, variable.Id);
-                    missedArrayPoints.Inc(values.Length - dim);
+                    log.LogDebug("Missing {Count} points for variable {Id} due to too small ArrayDimensions", variantArray.Length - dim, variable.Id);
+                    missedArrayPoints.Inc(variantArray.Length - dim);
                 }
                 var ret = new List<UADataPoint>();
-                var variantArray = extractor.StringConverter.ExtractVariantArray(value.WrappedValue);
                 for (int i = 0; i < dim; i++)
                 {
                     var id = variable.IsArray ? GetArrayUniqueId(uniqueId, i) : uniqueId;

--- a/Extractor/Streamer.cs
+++ b/Extractor/Streamer.cs
@@ -389,7 +389,7 @@ namespace Cognite.OpcUa
 
         private UAEvent DpAsEvent(DataValue datapoint, VariableExtractionState node)
         {
-            var value = extractor.StringConverter.ConvertToString(datapoint.WrappedValue);
+            var value = extractor.TypeConverter.ConvertToString(datapoint.WrappedValue);
             var evt = new UAEvent
             {
                 EmittingNode = node.SourceId,
@@ -398,7 +398,7 @@ namespace Cognite.OpcUa
                 SourceNode = node.SourceId,
                 Time = datapoint.SourceTimestamp,
             };
-            evt.SetMetadata(extractor.StringConverter, new[] {
+            evt.SetMetadata(extractor.TypeConverter, new[] {
                 new EventFieldValue(new RawTypeField(new QualifiedName("Status")), new Variant(datapoint.StatusCode))
             }, log);
             return evt;
@@ -416,7 +416,7 @@ namespace Cognite.OpcUa
 
             if (value.Value is Array)
             {
-                var variantArray = extractor.StringConverter.ExtractVariantArray(value.WrappedValue);
+                var variantArray = extractor.TypeConverter.ExtractVariantArray(value.WrappedValue);
                 int dim = 1;
                 if (variantArray.Length == 0) return Enumerable.Empty<UADataPoint>();
                 if (!variable.IsArray)
@@ -570,14 +570,14 @@ namespace Cognite.OpcUa
             var finalProperties = extractedProperties.Select(kvp => kvp.Value);
             var buffEvent = new UAEvent
             {
-                Message = extractor.StringConverter.ConvertToString(extractedProperties.GetValueOrDefault("Message")?.Value ?? Variant.Null),
+                Message = extractor.TypeConverter.ConvertToString(extractedProperties.GetValueOrDefault("Message")?.Value ?? Variant.Null),
                 EventId = config.Extraction.IdPrefix + eventId,
                 SourceNode = sourceNode,
                 Time = time,
                 EventType = eventType,
                 EmittingNode = emitter
             };
-            buffEvent.SetMetadata(extractor.StringConverter, finalProperties, log);
+            buffEvent.SetMetadata(extractor.TypeConverter, finalProperties, log);
             return buffEvent;
         }
     }

--- a/Extractor/Streamer.cs
+++ b/Extractor/Streamer.cs
@@ -441,7 +441,7 @@ namespace Cognite.OpcUa
                 for (int i = 0; i < dim; i++)
                 {
                     var id = variable.IsArray ? GetArrayUniqueId(uniqueId, i) : uniqueId;
-                    var entry = i < variantArray.Length ? variantArray[i] : Variant.Null;
+                    var entry = variantArray.GetValueOrDefault(i, Variant.Null);
                     ret.Add(variable.DataType.ToDataPoint(extractor, entry, value.SourceTimestamp, id, value.StatusCode));
                 }
                 return ret;

--- a/Extractor/Types/TypeConverter.cs
+++ b/Extractor/Types/TypeConverter.cs
@@ -322,6 +322,17 @@ namespace Cognite.OpcUa.Types
             return SafeEncodeToJson(value, false);
         }
 
+        public JsonObject? ConvertToJsonObject(Variant value, IDictionary<long, string>? enumValues = null, INodeIdConverter? context = null, JsonMode mode = JsonMode.Json)
+        {
+            var jsonNode = ConvertToJson(value, enumValues, context, mode);
+            if (jsonNode is JsonObject jsonObject) return jsonObject;
+            if (jsonNode is null) return null;
+
+            // If we get here, we have a JSON array or a primitive value.
+            // We wrap it in an object with a single property "value".
+            return new JsonObject { ["Value"] = jsonNode };
+        }
+
         private readonly ConcurrentDictionary<ConverterType, NodeSerializer> converters = new ConcurrentDictionary<ConverterType, NodeSerializer>();
         private readonly NodeIdConverter nodeIdConverter;
         public void AddConverters(JsonSerializerOptions options, ConverterType type)

--- a/Extractor/Types/TypeConverter.cs
+++ b/Extractor/Types/TypeConverter.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using System.Xml;
+using Cognite.Extensions.DataModels.QueryBuilder;
+using Cognite.Extractor.Common;
+using Cognite.OpcUa.Config;
+using Cognite.OpcUa.Pushers.FDM;
+using Microsoft.Extensions.Logging;
+using Opc.Ua;
+
+namespace Cognite.OpcUa.Types
+{
+    public enum JsonMode
+    {
+        Json,
+        ReversibleJson
+    }
+
+    public class TypeConverter
+    {
+        private readonly IUAClientAccess client;
+        private readonly ILogger log;
+        private readonly FullConfig config;
+        public TypeConverter(ILogger log, IUAClientAccess client, FullConfig config)
+        {
+            this.client = client;
+            this.config = config;
+            this.log = log;
+            nodeIdConverter = new NodeIdConverter(client);
+        }
+
+        public Variant[] ExtractVariantArray(Variant value)
+        {
+            if (value.Value is null) return Array.Empty<Variant>();
+            if (value.Value is Variant[] variants) return variants;
+            if (value.Value is not IEnumerable enumerable) return new Variant[] { value };
+
+            var typeInfo = new TypeInfo(value.TypeInfo.BuiltInType, ValueRanks.Scalar);
+            // If the value is enumerable, we cast it to an array of variants,
+            // reusing the outer type info.
+            return enumerable.Cast<object>().Select(v => new Variant(
+                v,
+                typeInfo
+            )).ToArray();
+        }
+
+        public string ConvertToString(
+            Variant value,
+            IDictionary<long, string>? enumValues = null,
+            INodeIdConverter? context = null)
+        {
+            // Match on all possible variant types.
+            if (value.Value is Variant nested) return ConvertToString(nested, enumValues, context);
+
+            return VariantValueToString(value.Value, value.TypeInfo, enumValues, context) ?? string.Empty;
+        }
+
+        private static bool IsNumber(object value)
+        {
+            return value is sbyte
+                || value is byte
+                || value is short
+                || value is ushort
+                || value is int
+                || value is uint
+                || value is long
+                || value is ulong
+                || value is float
+                || value is double
+                || value is decimal;
+        }
+
+        private static string? TryConvertToEnumDiscriminant(object? value, IDictionary<long, string>? enumValues)
+        {
+            if (value is null || enumValues is null) return null;
+
+            try
+            {
+                var longVal = Convert.ToInt64(value, CultureInfo.InvariantCulture);
+                if (enumValues.TryGetValue(longVal, out string enumVal))
+                {
+                    return enumVal;
+                }
+            }
+            catch { }
+
+            return null;
+        }
+
+        private JsonObject SerializeDiagnosticInfo(DiagnosticInfo diagInfo)
+        {
+            var obj = new JsonObject
+            {
+                ["LocalizedText"] = diagInfo.LocalizedText,
+                ["InnerStatusCode"] = StatusCode.LookupSymbolicId(diagInfo.InnerStatusCode.Code)
+            };
+            if (diagInfo.AdditionalInfo != null)
+            {
+                obj["AdditionalInfo"] = diagInfo.AdditionalInfo;
+            }
+            if (diagInfo.InnerDiagnosticInfo != null)
+            {
+                obj["InnerDiagnosticInfo"] = SerializeDiagnosticInfo(diagInfo.InnerDiagnosticInfo);
+            }
+
+            return obj;
+        }
+
+
+        private string? VariantValueToString(object? value, TypeInfo typeInfo, IDictionary<long, string>? enumValues = null, INodeIdConverter? context = null)
+        {
+            if (value is null) return string.Empty;
+
+            var enumDiscriminant = TryConvertToEnumDiscriminant(value, enumValues);
+            if (enumDiscriminant != null) return enumDiscriminant;
+
+            // This is based on the built-in types in OPC-UA, which are all the types a variant may take.
+            // See OPC-UA Part 6, table 1.
+            if (value is StatusCode statusCode) return StatusCode.LookupSymbolicId(statusCode.Code);
+            if (typeInfo.BuiltInType == BuiltInType.StatusCode) return StatusCode.LookupSymbolicId(value as uint? ?? 0);
+            if (IsNumber(value)) return value.ToString();
+            if (value is bool boolValue) return boolValue ? "true" : "false";
+            if (value is DateTime dateTimeValue) return dateTimeValue.ToISOString();
+            if (value is DateTimeOffset dateTimeOffsetValue) return dateTimeOffsetValue.DateTime.ToISOString();
+            if (value is Guid guidValue) return guidValue.ToString();
+            if (value is string strValue) return strValue;
+            if (value is XmlElement xmlElement) return Newtonsoft.Json.JsonConvert.SerializeXmlNode(xmlElement);
+            // byte[] is used to represent both an array of bytes, and a bytestring.
+            if (value is byte[] byteArray && typeInfo.BuiltInType == BuiltInType.ByteString) return Convert.ToBase64String(byteArray);
+            if (value is NodeId nodeId)
+            {
+                if (context != null) return context.NodeIdToString(nodeId);
+                return client.GetUniqueId(nodeId) ?? nodeId.ToString();
+            }
+            if (value is ExpandedNodeId expandedNodeId)
+            {
+                if (context != null) return context.NodeIdToString(client.Context.ToNodeId(expandedNodeId));
+                return client.GetUniqueId(expandedNodeId) ?? expandedNodeId.ToString();
+            }
+            if (value is LocalizedText localizedText) return localizedText.Text ?? string.Empty;
+            if (value is QualifiedName qualifiedName) return qualifiedName.Name ?? string.Empty;
+            if (value is DataValue dataValue) return ConvertToString(dataValue.WrappedValue, enumValues, context);
+            if (value is Uuid uuid) return uuid.GuidString;
+            if (value is DiagnosticInfo diagInfo)
+            {
+                return SerializeDiagnosticInfo(diagInfo).ToJsonString();
+            }
+            if (value.GetType().IsEnum) return Enum.GetName(value.GetType(), value);
+
+            if (value is ExtensionObject extObj)
+            {
+                return ExtensionObjectBodyToString(extObj.Body, context);
+            }
+
+            if (value is IEnumerable)
+            {
+                // Array elements are serialized as JSON...
+                return ConvertToJson(new Variant(value, typeInfo), enumValues, context)?.ToJsonString();
+            }
+            if (value is Matrix matrix)
+            {
+                return ConvertToJson(new Variant(matrix, typeInfo), enumValues, context)?.ToJsonString();
+            }
+
+            log.LogWarning("Unknown variant contents: {Value} ({Type})", value, value.GetType().Name);
+            return value.ToString();
+        }
+
+        private string ExtensionObjectBodyToString(object body, INodeIdConverter? context)
+        {
+            // For regular string conversion we special-case a few possible extension object bodies.
+            // The body can be a byte-string, which technically means we haven't been able to encode it at all.
+            // Just pass it through as a byte-string.
+            if (body is byte[] byteArray) return Convert.ToBase64String(byteArray);
+            if (body is XmlElement xmlElement) return Newtonsoft.Json.JsonConvert.SerializeXmlNode(xmlElement);
+
+            // Speical case a few types
+            if (body is Opc.Ua.KeyValuePair kvp) return $"{kvp.Key?.Name}: {ConvertToString(kvp.Value, null, context)}";
+            if (body is EUInformation euInfo) return $"{euInfo.DisplayName?.Text}: {euInfo.Description?.Text}";
+            if (body is Opc.Ua.Range range) return $"({range.Low}, {range.High})";
+            if (body is Opc.Ua.EnumValueType enumType) return $"{enumType.DisplayName?.Text}: {enumType.Value}";
+
+            // If we don't know the type, just serialize it to JSON.
+            if (body is IEncodeable encodable)
+            {
+                try
+                {
+                    using var encoder = new JsonEncoder(client.Context.MessageContext, false);
+                    encodable.Encode(encoder);
+                    var result = encoder.CloseAndReturnText();
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    log.LogError(ex, "Failed to encode extension object body: {Body}", body);
+                    return body.ToString();
+                }
+            }
+
+            log.LogWarning("Unknown extension object body type: {Body} ({Type})", body, body.GetType().Name);
+            return body.ToString();
+        }
+
+        private JsonNode? ExtensionObjectBodyToJson(object body, INodeIdConverter? context)
+        {
+            // For regular JSON conversion we special-case a few possible extension object bodies.
+            // The body can be a byte-string, which technically means we haven't been able to encode it at all.
+            // Just pass it through as a byte-string.
+            if (body is byte[] byteArray) return Convert.ToBase64String(byteArray);
+            if (body is XmlElement xmlElement) return JsonNode.Parse(Newtonsoft.Json.JsonConvert.SerializeXmlNode(xmlElement));
+
+            // Speical case a few types
+            if (body is Opc.Ua.KeyValuePair kvp) return new JsonObject { [kvp.Key?.Name ?? ""] = ConvertToJson(kvp.Value, null, context) };
+            if (body is Opc.Ua.EnumValueType enumType) return new JsonObject { [enumType.DisplayName?.Text ?? ""] = ConvertToJson(enumType.Value, null, context) };
+
+            return null;
+        }
+
+        private JsonNode? VariantValueToJson(object value, TypeInfo typeInfo, IDictionary<long, string>? enumValues, INodeIdConverter? context)
+        {
+            var enumDiscriminant = TryConvertToEnumDiscriminant(value, enumValues);
+            if (enumDiscriminant != null) return enumDiscriminant;
+
+            // This is based on the built-in types in OPC-UA, which are all the types a variant may take.
+            // See OPC-UA Part 6, table 1.
+            if (value is StatusCode statusCode) return StatusCode.LookupSymbolicId(statusCode.Code);
+            if (typeInfo.BuiltInType == BuiltInType.StatusCode) return StatusCode.LookupSymbolicId(value as uint? ?? 0);
+
+            if (value is sbyte sbyteval) return sbyteval;
+            if (value is byte byteval) return byteval;
+            if (value is short shortval) return shortval;
+            if (value is ushort ushortval) return ushortval;
+            if (value is int intval) return intval;
+            if (value is uint uintval) return uintval;
+            if (value is long longval) return longval;
+            if (value is ulong ulongval) return ulongval;
+            if (value is float floatval) return floatval;
+            if (value is double doubleval) return doubleval;
+            if (value is decimal decimalval) return decimalval;
+            if (value is bool boolValue) return boolValue;
+            if (value is DateTime dateTimeValue) return dateTimeValue.ToISOString();
+            if (value is DateTimeOffset dateTimeOffsetValue) return dateTimeOffsetValue.DateTime.ToISOString();
+            if (value is Guid guidValue) return guidValue.ToString();
+            if (value is string strValue) return strValue;
+            if (value is XmlElement xmlElement) return JsonNode.Parse(Newtonsoft.Json.JsonConvert.SerializeXmlNode(xmlElement));
+            if (value is byte[] byteArray && typeInfo.BuiltInType == BuiltInType.ByteString) return Convert.ToBase64String(byteArray);
+            if (value is NodeId nodeId)
+            {
+                if (context != null) return context.NodeIdToString(nodeId);
+                return client.GetUniqueId(nodeId) ?? nodeId.ToString();
+            }
+            if (value is ExpandedNodeId expandedNodeId)
+            {
+                if (context != null) return context.NodeIdToString(client.Context.ToNodeId(expandedNodeId));
+                return client.GetUniqueId(expandedNodeId) ?? expandedNodeId.ToString();
+            }
+            if (value.GetType().IsEnum) return Enum.GetName(value.GetType(), value);
+            if (value is ExtensionObject extensionObject)
+            {
+                return ExtensionObjectBodyToJson(extensionObject.Body, context);
+            }
+            if (value is DiagnosticInfo diagInfo)
+            {
+                return SerializeDiagnosticInfo(diagInfo);
+            }
+
+            return null;
+        }
+
+        private JsonNode? SafeEncodeToJson(Variant value, bool reversible)
+        {
+            try
+            {
+                using var encoder = new JsonEncoder(client.Context.MessageContext, reversible);
+                encoder.WriteVariant(null, value);
+                var result = encoder.CloseAndReturnText();
+
+                return JsonNode.Parse(result[1..^1]);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "Failed to encode variant contents: {Value}", value.Value);
+                return null;
+            }
+        }
+
+        public JsonNode? ConvertToJson(Variant value, IDictionary<long, string>? enumValues = null, INodeIdConverter? context = null, JsonMode mode = JsonMode.Json)
+        {
+            // Match on all possible variant types.
+            if (value.Value is Variant nested) return ConvertToJson(nested, enumValues, context, mode);
+            if (value.Value is null) return null;
+
+            if (mode == JsonMode.ReversibleJson)
+            {
+                // For reversible JSON, we just always use the JSON encoder for now.
+                return SafeEncodeToJson(value, true);
+            }
+            var specialCased = VariantValueToJson(value.Value, value.TypeInfo, enumValues, context);
+            if (specialCased != null) return specialCased;
+            if (value.Value is IEnumerable)
+            {
+                // If the value is enumerable, we cast it to an array of variants,
+                // reusing the outer type info.
+                var variants = ExtractVariantArray(value);
+                var jsonArray = new JsonArray();
+                foreach (var item in variants)
+                {
+                    var itemJson = ConvertToJson(item, enumValues, context, mode);
+                    if (itemJson != null) jsonArray.Add(itemJson);
+                }
+                return jsonArray;
+            }
+
+            return SafeEncodeToJson(value, false);
+        }
+
+        private readonly ConcurrentDictionary<ConverterType, NodeSerializer> converters = new ConcurrentDictionary<ConverterType, NodeSerializer>();
+        private readonly NodeIdConverter nodeIdConverter;
+        public void AddConverters(JsonSerializerOptions options, ConverterType type)
+        {
+            options.Converters.Add(converters.GetOrAdd(type, key => new NodeSerializer(this, config, client.Context, key, log)));
+            options.Converters.Add(nodeIdConverter);
+        }
+    }
+}

--- a/Extractor/Types/UAEvent.cs
+++ b/Extractor/Types/UAEvent.cs
@@ -227,7 +227,7 @@ namespace Cognite.OpcUa.Types
                 if (r == null) return null;
                 values.Add(r);
             }
-            evt.SetMetadata(extractor.StringConverter, values, log);
+            evt.SetMetadata(extractor.TypeConverter, values, log);
             evt.Values = values.ToDictionary(v => v.Field);
 
             return evt;
@@ -251,7 +251,7 @@ namespace Cognite.OpcUa.Types
                 : Time.ToUnixTimeMilliseconds();
             evt.ExternalId = EventId;
             evt.Type = MetaData != null && MetaData.TryGetValue("Type", out var rawType)
-                ? client.StringConverter.ConvertToString(rawType)
+                ? client.TypeConverter.ConvertToString(rawType)
                 : client.GetUniqueId(EventType?.Id);
             evt.DataSetId = dataSetId;
 
@@ -271,7 +271,7 @@ namespace Cognite.OpcUa.Types
             }
             if (MetaData.TryGetValue("SubType", out var subtype))
             {
-                evt.Subtype = client.StringConverter.ConvertToString(subtype);
+                evt.Subtype = client.TypeConverter.ConvertToString(subtype);
             }
 
             foreach (var dt in MetaData)

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -81,7 +81,7 @@ namespace Cognite.OpcUa
         private readonly ILogger<Tracing> traceLog;
         private LogLevel? traceLevel;
 
-        public StringConverter StringConverter { get; }
+        public TypeConverter StringConverter { get; }
         public Browser Browser { get; }
 
         public SourceInformation SourceInfo { get; private set; } = SourceInformation.Default();
@@ -102,7 +102,7 @@ namespace Cognite.OpcUa
             {
                 metricsManager = new NodeMetricsManager(this, config.Metrics.Nodes);
             }
-            StringConverter = new StringConverter(provider.GetRequiredService<ILogger<StringConverter>>(), this, config);
+            StringConverter = new TypeConverter(provider.GetRequiredService<ILogger<TypeConverter>>(), this, config);
             Browser = new Browser(provider.GetRequiredService<ILogger<Browser>>(), this, config);
             TypeManager = new TypeManager(config, this, provider.GetRequiredService<ILogger<TypeManager>>());
             SessionManager = new SessionManager(this, Config, provider.GetRequiredService<ILogger<SessionManager>>());

--- a/Extractor/UAClient.cs
+++ b/Extractor/UAClient.cs
@@ -81,7 +81,7 @@ namespace Cognite.OpcUa
         private readonly ILogger<Tracing> traceLog;
         private LogLevel? traceLevel;
 
-        public TypeConverter StringConverter { get; }
+        public TypeConverter TypeConverter { get; }
         public Browser Browser { get; }
 
         public SourceInformation SourceInfo { get; private set; } = SourceInformation.Default();
@@ -102,7 +102,7 @@ namespace Cognite.OpcUa
             {
                 metricsManager = new NodeMetricsManager(this, config.Metrics.Nodes);
             }
-            StringConverter = new TypeConverter(provider.GetRequiredService<ILogger<TypeConverter>>(), this, config);
+            TypeConverter = new TypeConverter(provider.GetRequiredService<ILogger<TypeConverter>>(), this, config);
             Browser = new Browser(provider.GetRequiredService<ILogger<Browser>>(), this, config);
             TypeManager = new TypeManager(config, this, provider.GetRequiredService<ILogger<TypeManager>>());
             SessionManager = new SessionManager(this, Config, provider.GetRequiredService<ILogger<SessionManager>>());

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -62,7 +62,7 @@ namespace Cognite.OpcUa
         private readonly IEnumerable<IPusher> pushers;
         private readonly ConcurrentQueue<NodeId> extraNodesToBrowse = new ConcurrentQueue<NodeId>();
         public TransformationCollection? Transformations { get; private set; }
-        public TypeConverter StringConverter => uaClient.StringConverter;
+        public TypeConverter TypeConverter => uaClient.TypeConverter;
         private PubSubManager? pubSubManager;
         public NamespaceTable? NamespaceTable => uaClient.NamespaceTable;
 
@@ -1340,7 +1340,7 @@ namespace Cognite.OpcUa
     public interface IUAClientAccess
     {
         string? GetUniqueId(ExpandedNodeId id, int index = -1);
-        TypeConverter StringConverter { get; }
+        TypeConverter TypeConverter { get; }
         string GetRelationshipId(UAReference reference);
         NamespaceTable? NamespaceTable { get; }
         public SessionContext Context { get; }

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -62,7 +62,7 @@ namespace Cognite.OpcUa
         private readonly IEnumerable<IPusher> pushers;
         private readonly ConcurrentQueue<NodeId> extraNodesToBrowse = new ConcurrentQueue<NodeId>();
         public TransformationCollection? Transformations { get; private set; }
-        public StringConverter StringConverter => uaClient.StringConverter;
+        public TypeConverter StringConverter => uaClient.StringConverter;
         private PubSubManager? pubSubManager;
         public NamespaceTable? NamespaceTable => uaClient.NamespaceTable;
 
@@ -1340,7 +1340,7 @@ namespace Cognite.OpcUa
     public interface IUAClientAccess
     {
         string? GetUniqueId(ExpandedNodeId id, int index = -1);
-        StringConverter StringConverter { get; }
+        TypeConverter StringConverter { get; }
         string GetRelationshipId(UAReference reference);
         NamespaceTable? NamespaceTable { get; }
         public SessionContext Context { get; }

--- a/Extractor/Utils/ExtractorUtils.cs
+++ b/Extractor/Utils/ExtractorUtils.cs
@@ -512,6 +512,18 @@ namespace Cognite.OpcUa.Utils
                 _ => $"{valueRank}Dimensions",
             };
         }
+
+        public static T GetValueOrDefault<T>(this T[] arr, int index, T defaultValue)
+        {
+            if (index < 0 || index >= arr.Length)
+            {
+                return defaultValue;
+            }
+            else
+            {
+                return arr[index];
+            }
+        }
     }
 
     /// <summary>

--- a/Test/CommonTestUtils.cs
+++ b/Test/CommonTestUtils.cs
@@ -272,7 +272,14 @@ namespace Test
             {
                 Assert.True(stringyMeta == null || stringyMeta.Count == 0);
                 Assert.Equal(2, mysteryMeta.Count);
-                Assert.Equal("(0, 100)", mysteryMeta["EURange"]);
+                if (raw)
+                {
+                    Assert.Equal(@"{""Low"":0,""High"":100}", mysteryMeta["EURange"]);
+                }
+                else
+                {
+                    Assert.Equal("(0, 100)", mysteryMeta["EURange"]);
+                }
             }
 
         }

--- a/Test/Integration/NodeExtractionTests.cs
+++ b/Test/Integration/NodeExtractionTests.cs
@@ -105,10 +105,10 @@ namespace Test.Integration
             Assert.Equal(2, vnode.Properties.Count());
             var prop = vnode.Properties.First(prop => prop.Name == "EngineeringUnits") as UAVariable;
             Assert.Equal(DataTypeIds.EUInformation, prop.FullAttributes.DataType.Id);
-            Assert.Equal("°C: degree Celsius", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
+            Assert.Equal("°C: degree Celsius", extractor.TypeConverter.ConvertToString(prop.Value ?? Variant.Null));
             prop = vnode.Properties.First(prop => prop.Name == "EURange") as UAVariable;
             Assert.Equal(DataTypeIds.Range, prop.FullAttributes.DataType.Id);
-            Assert.Equal("(0, 100)", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
+            Assert.Equal("(0, 100)", extractor.TypeConverter.ConvertToString(prop.Value ?? Variant.Null));
 
             Assert.All(pusher.PushedVariables.Values.Where(variable => variable.Name != "MysteryVar"
                 && variable.Name != "NumberVar"),
@@ -182,10 +182,10 @@ namespace Test.Integration
             Assert.Equal(2, arr.Properties.Count());
             var prop = arr.Properties.First(prop => prop.Name == "EngineeringUnits") as UAVariable;
             Assert.Equal(DataTypeIds.EUInformation, prop.FullAttributes.DataType.Id);
-            Assert.Equal("°C: degree Celsius", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
+            Assert.Equal("°C: degree Celsius", extractor.TypeConverter.ConvertToString(prop.Value ?? Variant.Null));
             prop = arr.Properties.First(prop => prop.Name == "EURange") as UAVariable;
             Assert.Equal(DataTypeIds.Range, prop.FullAttributes.DataType.Id);
-            Assert.Equal("(0, 100)", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
+            Assert.Equal("(0, 100)", extractor.TypeConverter.ConvertToString(prop.Value ?? Variant.Null));
             Assert.True(arr.IsArray);
             Assert.Equal(4, arr.ArrayDimensions[0]);
             Assert.Equal(4, arr.ArrayChildren.Count());
@@ -475,16 +475,16 @@ namespace Test.Integration
             var node = pusher.PushedNodes[ids.Root];
             Assert.Equal(5, node.Properties.Count());
             var prop = node.Properties.First(prop => prop.Name == "Variable StringArray") as UAVariable;
-            Assert.Equal(@"[""test1"",""test2""]", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
+            Assert.Equal(@"[""test1"",""test2""]", extractor.TypeConverter.ConvertToString(prop.Value ?? Variant.Null));
             prop = node.Properties.First(prop => prop.Name == "Variable Array") as UAVariable;
-            Assert.Equal("[0,0,0,0]", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
+            Assert.Equal("[0,0,0,0]", extractor.TypeConverter.ConvertToString(prop.Value ?? Variant.Null));
             prop = node.Properties.First(prop => prop.Name == "EnumVar1") as UAVariable;
-            Assert.Equal("Enum2", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
+            Assert.Equal("Enum2", extractor.TypeConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
             prop = node.Properties.First(prop => prop.Name == "EnumVar2") as UAVariable;
-            Assert.Equal("VEnum2", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
+            Assert.Equal("VEnum2", extractor.TypeConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
             prop = node.Properties.First(prop => prop.Name == "EnumVar3") as UAVariable;
             Assert.Equal(@"[""VEnum2"",""VEnum2"",""VEnum1"",""VEnum2""]",
-                extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
+                extractor.TypeConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
         }
         [Fact]
         public async Task TestPropertyIdFilter()
@@ -510,7 +510,7 @@ namespace Test.Integration
             var node = pusher.PushedNodes[ids.Root];
             Assert.Single(node.Properties);
             var prop = node.Properties.First(prop => prop.Name == "EnumVar2") as UAVariable;
-            Assert.Equal("VEnum2", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
+            Assert.Equal("VEnum2", extractor.TypeConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
         }
         [Fact]
         public async Task TestMultipleSourceNodes()
@@ -614,18 +614,18 @@ namespace Test.Integration
             Assert.Equal(16, pusher.PushedVariables.Count);
 
             var node = pusher.PushedNodes[ids.Root];
-            var metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
+            var metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.TypeConverter);
             Assert.Single(metadata);
             Assert.Equal("BaseObjectType", metadata["TypeDefinition"]);
 
             node = pusher.PushedNodes[ids.Array];
-            metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
+            metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.TypeConverter);
             Assert.Equal(2, metadata.Count);
             Assert.Equal("BaseDataVariableType", metadata["TypeDefinition"]);
             Assert.Equal("Double", metadata["dataType"]);
 
             node = pusher.PushedNodes[ids.EnumVar3];
-            metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
+            metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.TypeConverter);
             Assert.Equal(4, metadata.Count);
             Assert.Equal("BaseDataVariableType", metadata["TypeDefinition"]);
             Assert.Equal("CustomEnumType2", metadata["dataType"]);
@@ -633,7 +633,7 @@ namespace Test.Integration
             Assert.Equal("VEnum2", metadata["123"]);
 
             var vb = pusher.PushedVariables[(ids.EnumVar3, 1)];
-            metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
+            metadata = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.TypeConverter);
             Assert.Equal(4, metadata.Count);
             Assert.Equal("BaseDataVariableType", metadata["TypeDefinition"]);
             Assert.Equal("CustomEnumType2", metadata["dataType"]);
@@ -641,7 +641,7 @@ namespace Test.Integration
             Assert.Equal("VEnum2", metadata["123"]);
 
             vb = pusher.PushedVariables[(ids.MysteryVar, -1)];
-            metadata = vb.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
+            metadata = vb.GetExtraMetadata(tester.Config, extractor.Context, extractor.TypeConverter);
             Assert.Equal(2, metadata.Count);
             Assert.Equal("BaseDataVariableType", metadata["TypeDefinition"]);
             Assert.Equal("MysteryType", metadata["dataType"]);
@@ -1100,7 +1100,7 @@ namespace Test.Integration
             var log = tester.Provider.GetRequiredService<ILogger<NodeExtractionTests>>();
 
             // ... and that the JSON looks right
-            var metaElem = root.ToJson(log, extractor.StringConverter, ConverterType.Node);
+            var metaElem = root.ToJson(log, extractor.TypeConverter, ConverterType.Node);
             var metaString = CommonTestUtils.JsonElementToString(metaElem.RootElement.GetProperty("metadata"));
             var refJson = JsonNode.Parse(@"{""CustomRoot"":{""ChildObject"":null,""ChildObject2"":{""NumericProp"":1234,""StringProp"":""String prop value""},"
             + @"""Variable Array"":{""Value"":[0,0,0,0],""EngineeringUnits"":{""NamespaceUri"":""http://www.opcfoundation.org/UA/units/un/cefact"",""UnitId"":4408652,"
@@ -1152,7 +1152,7 @@ namespace Test.Integration
             var log = tester.Provider.GetRequiredService<ILogger<NodeExtractionTests>>();
 
             // ... and that the JSON looks right
-            var metaElem = root.ToJson(log, extractor.StringConverter, ConverterType.Node);
+            var metaElem = root.ToJson(log, extractor.TypeConverter, ConverterType.Node);
             var metaString = CommonTestUtils.JsonElementToString(metaElem.RootElement.GetProperty("metadata"));
             // This wouldn't work in clean, since there is only a single very large metadata field, but it is a much more useful input to Raw.
             var refJson = JsonNode.Parse(@"{""CustomRoot"":{""ChildObject"":null,""ChildObject2"":{""NumericProp"":1234,""StringProp"":""String prop value""},"

--- a/Test/Integration/NodeExtractionTests.cs
+++ b/Test/Integration/NodeExtractionTests.cs
@@ -105,10 +105,10 @@ namespace Test.Integration
             Assert.Equal(2, vnode.Properties.Count());
             var prop = vnode.Properties.First(prop => prop.Name == "EngineeringUnits") as UAVariable;
             Assert.Equal(DataTypeIds.EUInformation, prop.FullAttributes.DataType.Id);
-            Assert.Equal("°C: degree Celsius", extractor.StringConverter.ConvertToString(prop.Value));
+            Assert.Equal("°C: degree Celsius", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
             prop = vnode.Properties.First(prop => prop.Name == "EURange") as UAVariable;
             Assert.Equal(DataTypeIds.Range, prop.FullAttributes.DataType.Id);
-            Assert.Equal("(0, 100)", extractor.StringConverter.ConvertToString(prop.Value));
+            Assert.Equal("(0, 100)", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
 
             Assert.All(pusher.PushedVariables.Values.Where(variable => variable.Name != "MysteryVar"
                 && variable.Name != "NumberVar"),
@@ -182,10 +182,10 @@ namespace Test.Integration
             Assert.Equal(2, arr.Properties.Count());
             var prop = arr.Properties.First(prop => prop.Name == "EngineeringUnits") as UAVariable;
             Assert.Equal(DataTypeIds.EUInformation, prop.FullAttributes.DataType.Id);
-            Assert.Equal("°C: degree Celsius", extractor.StringConverter.ConvertToString(prop.Value));
+            Assert.Equal("°C: degree Celsius", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
             prop = arr.Properties.First(prop => prop.Name == "EURange") as UAVariable;
             Assert.Equal(DataTypeIds.Range, prop.FullAttributes.DataType.Id);
-            Assert.Equal("(0, 100)", extractor.StringConverter.ConvertToString(prop.Value));
+            Assert.Equal("(0, 100)", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
             Assert.True(arr.IsArray);
             Assert.Equal(4, arr.ArrayDimensions[0]);
             Assert.Equal(4, arr.ArrayChildren.Count());
@@ -475,16 +475,16 @@ namespace Test.Integration
             var node = pusher.PushedNodes[ids.Root];
             Assert.Equal(5, node.Properties.Count());
             var prop = node.Properties.First(prop => prop.Name == "Variable StringArray") as UAVariable;
-            Assert.Equal(@"[""test1"",""test2""]", extractor.StringConverter.ConvertToString(prop.Value));
+            Assert.Equal(@"[""test1"",""test2""]", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
             prop = node.Properties.First(prop => prop.Name == "Variable Array") as UAVariable;
-            Assert.Equal("[0,0,0,0]", extractor.StringConverter.ConvertToString(prop.Value));
+            Assert.Equal("[0,0,0,0]", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null));
             prop = node.Properties.First(prop => prop.Name == "EnumVar1") as UAVariable;
-            Assert.Equal("Enum2", extractor.StringConverter.ConvertToString(prop.Value, prop.FullAttributes.DataType.EnumValues));
+            Assert.Equal("Enum2", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
             prop = node.Properties.First(prop => prop.Name == "EnumVar2") as UAVariable;
-            Assert.Equal("VEnum2", extractor.StringConverter.ConvertToString(prop.Value, prop.FullAttributes.DataType.EnumValues));
+            Assert.Equal("VEnum2", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
             prop = node.Properties.First(prop => prop.Name == "EnumVar3") as UAVariable;
             Assert.Equal(@"[""VEnum2"",""VEnum2"",""VEnum1"",""VEnum2""]",
-                extractor.StringConverter.ConvertToString(prop.Value, prop.FullAttributes.DataType.EnumValues));
+                extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
         }
         [Fact]
         public async Task TestPropertyIdFilter()
@@ -510,7 +510,7 @@ namespace Test.Integration
             var node = pusher.PushedNodes[ids.Root];
             Assert.Single(node.Properties);
             var prop = node.Properties.First(prop => prop.Name == "EnumVar2") as UAVariable;
-            Assert.Equal("VEnum2", extractor.StringConverter.ConvertToString(prop.Value, prop.FullAttributes.DataType.EnumValues));
+            Assert.Equal("VEnum2", extractor.StringConverter.ConvertToString(prop.Value ?? Variant.Null, prop.FullAttributes.DataType.EnumValues));
         }
         [Fact]
         public async Task TestMultipleSourceNodes()
@@ -1103,12 +1103,15 @@ namespace Test.Integration
             var metaElem = root.ToJson(log, extractor.StringConverter, ConverterType.Node);
             var metaString = CommonTestUtils.JsonElementToString(metaElem.RootElement.GetProperty("metadata"));
             var refJson = JsonNode.Parse(@"{""CustomRoot"":{""ChildObject"":null,""ChildObject2"":{""NumericProp"":1234,""StringProp"":""String prop value""},"
-            + @"""Variable Array"":{""Value"":[0,0,0,0],""EngineeringUnits"":""°C: degree Celsius"",""EURange"":""(0, 100)""},"
+            + @"""Variable Array"":{""Value"":[0,0,0,0],""EngineeringUnits"":{""NamespaceUri"":""http://www.opcfoundation.org/UA/units/un/cefact"",""UnitId"":4408652,"
+            + @"""DisplayName"":""°C"", ""Description"":""degree Celsius""},""EURange"":{""Low"":0,""High"":100}},"
             + @"""Variable StringArray"":[""test1"",""test2""],""StringyVar"":null,""IgnoreVar"":null,"
-            + @"""MysteryVar"":{""Value"":null,""EngineeringUnits"":""°C: degree Celsius"",""EURange"":""(0, 100)""},"
+            + @"""MysteryVar"":{""Value"":null,""EngineeringUnits"":{""NamespaceUri"":""http://www.opcfoundation.org/UA/units/un/cefact"",""UnitId"":4408652,"
+            + @"""DisplayName"":""°C"", ""Description"":""degree Celsius""},""EURange"":{""Low"":0,""High"":100}},"
             + @"""NumberVar"":{""Value"":null,""DeepProp"":{""DeepProp2"":{""val1"":""value 1"",""val2"":""value 2""}}},"
             + @"""EnumVar1"":""Enum2"",""EnumVar2"":""VEnum2"",""EnumVar3"":[""VEnum2"",""VEnum2"",""VEnum1"",""VEnum2""]}}");
             var metaJson = JsonNode.Parse(metaString);
+            log.LogDebug("Metadata JSON: {MetaJson}", metaJson.ToJsonString());
             // This wouldn't work in clean, since there is only a single very large metadata field, but it is a much more useful input to Raw.
             Assert.True(JsonNode.DeepEquals(refJson, metaJson));
         }
@@ -1153,9 +1156,11 @@ namespace Test.Integration
             var metaString = CommonTestUtils.JsonElementToString(metaElem.RootElement.GetProperty("metadata"));
             // This wouldn't work in clean, since there is only a single very large metadata field, but it is a much more useful input to Raw.
             var refJson = JsonNode.Parse(@"{""CustomRoot"":{""ChildObject"":null,""ChildObject2"":{""NumericProp"":1234,""StringProp"":""String prop value""},"
-            + @"""Variable Array"":{""Value"":[0,0,0,0],""EngineeringUnits"":""°C: degree Celsius"",""EURange"":""(0, 100)""},"
+            + @"""Variable Array"":{""Value"":[0,0,0,0],""EngineeringUnits"":{""NamespaceUri"":""http://www.opcfoundation.org/UA/units/un/cefact"","
+            + @"""UnitId"":4408652,""DisplayName"":""°C"", ""Description"":""degree Celsius""},""EURange"":{""Low"":0,""High"":100}},"
             + @"""Variable StringArray"":[""test1"",""test2""],""StringyVar"":null,""IgnoreVar"":null,"
-            + @"""MysteryVar"":{""Value"":null,""EngineeringUnits"":""°C: degree Celsius"",""EURange"":""(0, 100)""},"
+            + @"""MysteryVar"":{""Value"":null,""EngineeringUnits"":{""NamespaceUri"":""http://www.opcfoundation.org/UA/units/un/cefact"",""UnitId"":4408652,"
+            + @"""DisplayName"":""°C"", ""Description"":""degree Celsius""},""EURange"":{""Low"":0,""High"":100}},"
             + @"""NumberVar"":{""Value"":null,""DeepProp"":{""DeepProp2"":{""val1"":""value 1"",""val2"":""value 2""}}},"
             + @"""EnumVar1"":1,""EnumVar2"":123,""EnumVar3"":[123,123,321,123]}}");
             var metaJson = JsonNode.Parse(metaString);

--- a/Test/Unit/CDFPusherTest.cs
+++ b/Test/Unit/CDFPusherTest.cs
@@ -992,7 +992,7 @@ namespace Test.Unit
         private void NodeToRaw(UAExtractor extractor, BaseUANode node, ConverterType type, bool ts)
         {
             var options = new JsonSerializerOptions();
-            var converter = tester.Client.StringConverter;
+            var converter = tester.Client.TypeConverter;
             converter.AddConverters(options, type);
 
             var id = node.GetUniqueId(extractor.Context);
@@ -1428,7 +1428,7 @@ namespace Test.Unit
             evt.Time = new DateTime(2024, 01, 01, 00, 00, 00, DateTimeKind.Utc);
             evt.EventType = customEventType;
             evt.EventId = "Event1";
-            evt.SetMetadata(extractor.StringConverter, new[] {
+            evt.SetMetadata(extractor.TypeConverter, new[] {
                 new EventFieldValue(fieldsByName["Message"], new LocalizedText("Some message")),
                 new EventFieldValue(fieldsByName["EventType"], customEventType.Id),
                 new EventFieldValue(fieldsByName["EventId"], new byte[] { 1, 2, 3, 4 }),
@@ -1500,7 +1500,7 @@ namespace Test.Unit
             evt.Time = new DateTime(2024, 01, 01, 00, 00, 00, DateTimeKind.Utc);
             evt.EventType = customEventType;
             evt.EventId = "Event1";
-            evt.SetMetadata(extractor.StringConverter, new[] {
+            evt.SetMetadata(extractor.TypeConverter, new[] {
                 new EventFieldValue(fieldsByName["Message"], new LocalizedText("Some message")),
                 new EventFieldValue(fieldsByName["EventType"], customEventType.Id),
                 new EventFieldValue(fieldsByName["EventId"], new byte[] { 1, 2, 3, 4 }),
@@ -1572,7 +1572,7 @@ namespace Test.Unit
             evt.Time = new DateTime(2024, 01, 01, 00, 00, 00, DateTimeKind.Utc);
             evt.EventType = customEventType;
             evt.EventId = "Event1";
-            evt.SetMetadata(extractor.StringConverter, new[] {
+            evt.SetMetadata(extractor.TypeConverter, new[] {
                 new EventFieldValue(fieldsByName["Message"], new LocalizedText("Some message")),
                 new EventFieldValue(fieldsByName["EventType"], customEventType.Id),
                 new EventFieldValue(fieldsByName["EventId"], new byte[] { 1, 2, 3, 4 }),

--- a/Test/Unit/InfluxPusherTest.cs
+++ b/Test/Unit/InfluxPusherTest.cs
@@ -286,7 +286,7 @@ namespace Test.Unit
                 Assert.Equal(rawEvt.MetaData.Count, evt.MetaData.Count);
                 foreach (var kvp in evt.MetaData)
                 {
-                    Assert.Equal(extractor.StringConverter.ConvertToString(rawEvt.MetaData[kvp.Key]), kvp.Value);
+                    Assert.Equal(extractor.TypeConverter.ConvertToString(rawEvt.MetaData[kvp.Key]), kvp.Value);
                 }
             }
 

--- a/Test/Unit/PusherUtilsTest.cs
+++ b/Test/Unit/PusherUtilsTest.cs
@@ -261,17 +261,17 @@ namespace Test.Unit
             // Test create asset
             var node = new UAObject(new NodeId("test", 0), "test", null, null, new NodeId("parent", 0), null);
             foreach (var prop in properties) node.Attributes.AddProperty(prop);
-            var result = PusherUtils.CreateRawUpdate(log, tester.Client.StringConverter, node, null, ConverterType.Node);
+            var result = PusherUtils.CreateRawUpdate(log, tester.Client.TypeConverter, node, null, ConverterType.Node);
             Assert.Equal(@"{""externalId"":""gp.base:s=test"",""name"":""test"",""description"":null,""metadata"":{""prop1"":[1,2,3,4]," +
                 @"""prop2"":{""prop3"":""value3""}},""parentExternalId"":""gp.base:s=parent""}", result.ToString());
 
             var nodeRow = ToRawRow(result.Value);
 
-            Assert.Null(PusherUtils.CreateRawUpdate(log, tester.Client.StringConverter, node, nodeRow, ConverterType.Node));
+            Assert.Null(PusherUtils.CreateRawUpdate(log, tester.Client.TypeConverter, node, nodeRow, ConverterType.Node));
 
             // Modified description
             node.Attributes.Description = "desc";
-            result = PusherUtils.CreateRawUpdate(log, tester.Client.StringConverter, node, nodeRow, ConverterType.Node);
+            result = PusherUtils.CreateRawUpdate(log, tester.Client.TypeConverter, node, nodeRow, ConverterType.Node);
             Assert.Equal(@"{""externalId"":""gp.base:s=test"",""name"":""test"",""description"":""desc"",""metadata"":{""prop1"":[1,2,3,4]," +
                 @"""prop2"":{""prop3"":""value3""}},""parentExternalId"":""gp.base:s=parent""}", result.ToString());
 
@@ -280,16 +280,16 @@ namespace Test.Unit
             variable.FullAttributes.Value = new Variant("test");
 
             foreach (var prop in properties) variable.Attributes.AddProperty(prop);
-            result = PusherUtils.CreateRawUpdate(log, tester.Client.StringConverter, variable, null, ConverterType.Variable);
+            result = PusherUtils.CreateRawUpdate(log, tester.Client.TypeConverter, variable, null, ConverterType.Variable);
             Assert.Equal(@"{""externalId"":""gp.base:s=test"",""name"":""test"",""description"":null,""metadata"":{""prop1"":[1,2,3,4]," +
                 @"""prop2"":{""prop3"":""value3""}},""assetExternalId"":""gp.base:s=parent"",""isString"":true,""isStep"":false}", result.ToString());
 
             nodeRow = ToRawRow(result.Value);
 
-            Assert.Null(PusherUtils.CreateRawUpdate(log, tester.Client.StringConverter, variable, nodeRow, ConverterType.Variable));
+            Assert.Null(PusherUtils.CreateRawUpdate(log, tester.Client.TypeConverter, variable, nodeRow, ConverterType.Variable));
 
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.Boolean);
-            result = PusherUtils.CreateRawUpdate(log, tester.Client.StringConverter, variable, nodeRow, ConverterType.Variable);
+            result = PusherUtils.CreateRawUpdate(log, tester.Client.TypeConverter, variable, nodeRow, ConverterType.Variable);
             Assert.Equal(@"{""externalId"":""gp.base:s=test"",""name"":""test"",""description"":null,""metadata"":{""prop1"":[1,2,3,4]," +
                 @"""prop2"":{""prop3"":""value3""}},""assetExternalId"":""gp.base:s=parent"",""isString"":false,""isStep"":true}", result.ToString());
         }

--- a/Test/Unit/StringConversionTest.cs
+++ b/Test/Unit/StringConversionTest.cs
@@ -1,7 +1,6 @@
 ﻿using Cognite.OpcUa.Nodes;
 using Cognite.OpcUa.NodeSources;
 using Cognite.OpcUa.Types;
-using CogniteSdk.DataModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;

--- a/Test/Unit/StringConversionTest.cs
+++ b/Test/Unit/StringConversionTest.cs
@@ -202,7 +202,7 @@ namespace Test.Unit
         public void TestNodeIdSerialization()
         {
             var options = new JsonSerializerOptions();
-            var converter = tester.Client.StringConverter;
+            var converter = tester.Client.TypeConverter;
             converter.AddConverters(options, ConverterType.Node);
 
             void TestConvert(NodeId id, string expected)
@@ -258,7 +258,7 @@ namespace Test.Unit
         public void TestWriteNodeIds()
         {
             var options = new JsonSerializerOptions();
-            var converter = tester.Client.StringConverter;
+            var converter = tester.Client.TypeConverter;
             converter.AddConverters(options, ConverterType.Node);
 
             void TestConvert(BaseUANode node, string expected)
@@ -306,7 +306,7 @@ namespace Test.Unit
         public void TestWriteInternals()
         {
             var options = new JsonSerializerOptions();
-            var converter = tester.Client.StringConverter;
+            var converter = tester.Client.TypeConverter;
             converter.AddConverters(options, ConverterType.Node);
 
             void TestConvert(BaseUANode node, string expected)
@@ -364,7 +364,7 @@ namespace Test.Unit
         {
             // Objects
             var options = new JsonSerializerOptions();
-            var converter = tester.Client.StringConverter;
+            var converter = tester.Client.TypeConverter;
             converter.AddConverters(options, ConverterType.Node);
 
             var node = new UAObject(new NodeId("test", 2), "test", null, null, new NodeId("parent", 0), null);

--- a/Test/Unit/TypesTest.cs
+++ b/Test/Unit/TypesTest.cs
@@ -365,7 +365,7 @@ namespace Test.Unit
 
         private static string MetadataToJson(ILogger log, BaseUANode node, UAExtractor extractor)
         {
-            var json = node.ToJson(log, extractor.StringConverter, ConverterType.Node);
+            var json = node.ToJson(log, extractor.TypeConverter, ConverterType.Node);
             return json.RootElement.GetProperty("metadata").ToString();
         }
 
@@ -374,7 +374,7 @@ namespace Test.Unit
         {
             using var extractor = tester.BuildExtractor();
             var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
-            var converter = tester.Client.StringConverter;
+            var converter = tester.Client.TypeConverter;
             var log = tester.Provider.GetRequiredService<ILogger<TypesTest>>();
             Assert.Equal("", MetadataToJson(log, node, extractor));
 
@@ -444,7 +444,7 @@ namespace Test.Unit
         {
             using var extractor = tester.BuildExtractor();
             var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
-            var converter = tester.Client.StringConverter;
+            var converter = tester.Client.TypeConverter;
             var log = tester.Provider.GetRequiredService<ILogger<TypesTest>>();
 
             var pdt = new UADataType(DataTypeIds.ReadValueId);
@@ -1060,7 +1060,7 @@ namespace Test.Unit
             evt.Message = "message";
             evt.Time = now;
             evt.SourceNode = new NodeId("source", 0);
-            evt.SetMetadata(extractor.StringConverter, new[]
+            evt.SetMetadata(extractor.TypeConverter, new[]
             {
                 new EventFieldValue(new RawTypeField("key1"), "value1"),
                 new EventFieldValue(new RawTypeField("key2"), 123),
@@ -1082,7 +1082,7 @@ namespace Test.Unit
                 Assert.Equal(convEvt.MetaData.Count, evt.MetaData.Count);
                 foreach (var kvp in convEvt.MetaData)
                 {
-                    Assert.Equal(kvp.Value ?? "", tester.Client.StringConverter.ConvertToString(evt.MetaData[kvp.Key]));
+                    Assert.Equal(kvp.Value ?? "", tester.Client.TypeConverter.ConvertToString(evt.MetaData[kvp.Key]));
                 }
             }
         }
@@ -1239,7 +1239,7 @@ namespace Test.Unit
                 new EventFieldValue(new RawTypeField(new QualifiedNameCollection { "deep", "deep-2" }), new [] { 1, 2, 3, 4 }),
                 new EventFieldValue(new RawTypeField(new QualifiedNameCollection { "deep", "deep-2", "Value" }), 123.321)
             };
-            evt.SetMetadata(extractor.StringConverter, rawMeta, log);
+            evt.SetMetadata(extractor.TypeConverter, rawMeta, log);
             var meta = evt.MetaData;
 
             Assert.Equal(3, meta.Count);

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -934,8 +934,8 @@ namespace Test.Unit
             Assert.Equal(new Variant(0.0), nodes[0].Value);
             Assert.Equal(new Variant(new double[] { 0, 0, 0, 0 }), nodes[1].Value);
             Assert.Equal(new Variant(new[] { "test1", "test2" }), nodes[2].Value);
-            Assert.Equal("°C: degree Celsius", tester.Client.StringConverter.ConvertToString(nodes[3].Value));
-            Assert.Equal("(0, 100)", tester.Client.StringConverter.ConvertToString(nodes[4].Value));
+            Assert.Equal("°C: degree Celsius", tester.Client.StringConverter.ConvertToString(nodes[3].Value ?? Variant.Null));
+            Assert.Equal("(0, 100)", tester.Client.StringConverter.ConvertToString(nodes[4].Value ?? Variant.Null));
         }
 
         [Fact]

--- a/Test/Unit/UAClientTest.cs
+++ b/Test/Unit/UAClientTest.cs
@@ -934,8 +934,8 @@ namespace Test.Unit
             Assert.Equal(new Variant(0.0), nodes[0].Value);
             Assert.Equal(new Variant(new double[] { 0, 0, 0, 0 }), nodes[1].Value);
             Assert.Equal(new Variant(new[] { "test1", "test2" }), nodes[2].Value);
-            Assert.Equal("°C: degree Celsius", tester.Client.StringConverter.ConvertToString(nodes[3].Value ?? Variant.Null));
-            Assert.Equal("(0, 100)", tester.Client.StringConverter.ConvertToString(nodes[4].Value ?? Variant.Null));
+            Assert.Equal("°C: degree Celsius", tester.Client.TypeConverter.ConvertToString(nodes[3].Value ?? Variant.Null));
+            Assert.Equal("(0, 100)", tester.Client.TypeConverter.ConvertToString(nodes[4].Value ?? Variant.Null));
         }
 
         [Fact]

--- a/Test/Unit/UAExtractorTest.cs
+++ b/Test/Unit/UAExtractorTest.cs
@@ -180,14 +180,14 @@ namespace Test.Unit
             tester.Config.Extraction.DataTypes.DataTypeMetadata = true;
             var variable = new UAVariable(new NodeId("test", 0), "test", null, null, NodeId.Null, null);
             variable.FullAttributes.DataType = new UADataType(DataTypeIds.Double);
-            var fields = variable.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
+            var fields = variable.GetExtraMetadata(tester.Config, extractor.Context, extractor.TypeConverter);
             Assert.Single(fields);
             Assert.Equal("Double", fields["dataType"]);
 
             tester.Config.Extraction.NodeTypes.Metadata = true;
             var node = new UAObject(new NodeId("test", 0), "test", null, null, NodeId.Null, new UAObjectType(new NodeId("type", 0)));
             node.FullAttributes.TypeDefinition.Attributes.DisplayName = "SomeType";
-            fields = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
+            fields = node.GetExtraMetadata(tester.Config, extractor.Context, extractor.TypeConverter);
             Assert.Single(fields);
             Assert.Equal("SomeType", fields["TypeDefinition"]);
 
@@ -198,7 +198,7 @@ namespace Test.Unit
             var type = new UAVariableType(new NodeId("test", 0), "test", null, null, NodeId.Null);
             type.FullAttributes.DataType = new UADataType(DataTypeIds.String);
             type.FullAttributes.Value = new Variant("value");
-            fields = type.GetExtraMetadata(tester.Config, extractor.Context, extractor.StringConverter);
+            fields = type.GetExtraMetadata(tester.Config, extractor.Context, extractor.TypeConverter);
             Assert.Single(fields);
             Assert.Equal("value", fields["Value"]);
         }


### PR DESCRIPTION
This type is the result of years of feature creep, and it is incredibly messy. This splits the ConvertToString method into ConvertToJson and ConvertToString, which hopefully will make it a lot more readable. It introduces a little code duplication, but the alternative is so horrible that I really don't think it's worth it.

I originally wrote this code years ago, and it was largely based on trial and error. I now have a much better understanding of OPC-UA encoding, and the implementation is largely based on that.

In OPC-UA, you have the `Variant` type, which is used as the general "Value" type for any place where the type is dynamic. It can be a bunch of primitive types, i.e. string, short, long, bool, float, etc. but also a few structured types like `LocalizedText`, `QualifiedName`, `DiagnosticInfo`. See https://reference.opcfoundation.org/Core/Part6/v105/docs/5.2.2.16

In addition to this fixed list of builtin types, it can also be `ExtensionObject` which is an even more dynamic wrapper around thousands of different kinds of structures. Some of these will be deserialized by the SDK already, so we can convert them specifically to JSON.

The new implementation reflects this, and explicitly handles the valid variant values, with extra handling for a few ExtensionObject types.