### PR TITLE
Build docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,4 @@ jobs:
         - name: Verify manifest
           run: |
             publish-extractor validate --manifest manifest.yml --config-files Test/config.test.yml
+            publish-extractor docs --manifest manifest.yml


### PR DESCRIPTION
We recently had a failed release of the DB extractor due to a mistake in
the schema definition that wasn't caught before we tried to build the
docs during the final steps of the release process, leading to a
half-released version that it was very annoying to clean up.

Building the docs as part of CI would have caught that error.
