### PR TITLE
Fix issue causing subscription metrics to sometimes be wrong

### DIFF
--- a/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
+++ b/Extractor/Subscriptions/BaseCreateSubscriptionTask.cs
@@ -160,6 +160,7 @@ namespace Cognite.OpcUa.Subscriptions
                 {
                     session.AddSubscription(subscription);
                     await subscription.CreateAsync(token);
+                    numSubscriptions.WithLabels(SubscriptionName.Name()).Set(subscription.MonitoredItems.Count(m => m.Created));
                     subManager.Cache.InitSubscription(SubscriptionName, subscription.Id);
                 }
                 catch (Exception ex)

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,13 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.37.0":
+    description: Fix issue with subscription metrics, stop creating timeseries that originate in the raw-node-buffer.
+    changelog:
+      fixed:
+        - Fix issue causing subscription metrics not to be incremented when a subscription is restored on the server.
+      changed:
+        - Timeseries read from raw with the raw-node-buffer feature are no longer used to produce timeseries in CDF. This speeds up startup when using the raw-node-buffer, but if the timeseries are deleted, they will not be recreated until nodes are read from the OPC-UA server.
   "2.36.1":
     description: Log errors that occur when failing to create connection parameters for connecting to the server.
     changelog:


### PR DESCRIPTION
I'm not 100% sure this actually fixes the issue, as I can't reproduce and there's some magic deep in the OPC-UA SDK, but it's something.

This cuts a release, which includes the change to the raw node buffer.