### PR TITLE
Bump utils, fix records

### DIFF
--- a/Extractor/Config/ExtractionConfig.cs
+++ b/Extractor/Config/ExtractionConfig.cs
@@ -462,7 +462,7 @@ namespace Cognite.OpcUa.Config
             return typeof(IFieldFilter).IsAssignableFrom(type);
         }
 
-        public object? ReadYaml(IParser parser, Type type)
+        public object? ReadYaml(IParser parser, Type type, ObjectDeserializer deserializer)
         {
             if (parser.TryConsume<Scalar>(out var scalar))
             {
@@ -497,7 +497,7 @@ namespace Cognite.OpcUa.Config
             throw new YamlException("Expected a string, object, or list of strings");
         }
 
-        public void WriteYaml(IEmitter emitter, object? value, Type type)
+        public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
         {
             if (value is RegexFieldFilter regexFilter)
             {

--- a/Extractor/Extractor.csproj
+++ b/Extractor/Extractor.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AdysTech.InfluxDB.Client.Net.Core" Version="0.25.0" />
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.34.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.36.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.375.457" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.375.457" />

--- a/Extractor/Pushers/Records/StreamRecordsWriter.cs
+++ b/Extractor/Pushers/Records/StreamRecordsWriter.cs
@@ -61,7 +61,14 @@ namespace Cognite.OpcUa.Pushers.Records
             }
             await destination.GetOrCreateStreamAsync(new StreamWrite
             {
-                ExternalId = stream
+                ExternalId = stream,
+                Settings = new StreamSettings
+                {
+                    Template = new StreamTemplateSettings
+                    {
+                        Name = StreamTemplateName.ImmutableDataStaging
+                    }
+                }
             }, token);
         }
 

--- a/MQTTCDFBridge/MQTTCDFBridge.csproj
+++ b/MQTTCDFBridge/MQTTCDFBridge.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.34.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.36.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="Google.Protobuf" Version="3.32.0" />

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -10,7 +10,7 @@
     <None Include="$(SolutionDir)config\**" CopyToOutputDirectory="Always" LinkBase="config\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.34.0" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.36.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cognite.Extractor.Testing" Version="1.34.0" />
+    <PackageReference Include="Cognite.Extractor.Testing" Version="1.36.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.37.1":
+    description: Fix creation of streams in unstable records support.
+    changelog:
+      fixed:
+        - Fix creation of streams in unstable records support. The extractor will now create streams with the ImmutableDataStaging template.
   "2.37.0":
     description: Fix issue with subscription metrics, stop creating timeseries that originate in the raw-node-buffer.
     changelog:


### PR DESCRIPTION
Update .NET extractor utils, and fix creation of streams for records support. It isn't immediately obvious what kind of stream template we want to use, but `Staging` sounds reasonable enough for now.