### PR TITLE
Don't "Un-initialize" pushers that fail during rebrowse

### DIFF
--- a/Extractor/Pushers/Writers/CDFWriter.cs
+++ b/Extractor/Pushers/Writers/CDFWriter.cs
@@ -69,7 +69,18 @@ namespace Cognite.OpcUa.Pushers.Writers
 
             if (idm != null)
             {
-                await idm.Init(extractor, token);
+                try
+                {
+                    await idm.Init(extractor, token);
+                }
+                catch (Exception ex)
+                {
+                    log.LogError(ex, "Failed to initialize data modeling writer.");
+                    if (idm.Assets) result.Objects = false;
+                    if (idm.Relationships) result.References = false;
+                    if (idm.Timeseries) result.Variables = false;
+                    return;
+                }
             }
 
             var assetMap = objects

--- a/Extractor/UAExtractor.cs
+++ b/Extractor/UAExtractor.cs
@@ -917,7 +917,6 @@ namespace Cognite.OpcUa
             FullPushResult result,
             IPusher pusher)
         {
-            pusher.Initialized = false;
             pusher.DataFailing = true;
             pusher.EventsFailing = true;
 

--- a/Test/Utils/BaseExtractorTestFixture.cs
+++ b/Test/Utils/BaseExtractorTestFixture.cs
@@ -68,10 +68,10 @@ namespace Test.Utils
             Server = new ServerController(Setups, Provider, Port);
             await Server.Start();
             Source = new CancellationTokenSource();
-            Callbacks = new DummyClientCallbacks(Source.Token);
 
             for (int i = 0; i < 10; i++)
             {
+                Callbacks = new DummyClientCallbacks(Source.Token);
                 Client = new UAClient(Provider, Config)
                 {
                     Callbacks = Callbacks

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,6 +67,11 @@ schema:
    - "https://raw.githubusercontent.com/"
 
 versions:
+  "2.38.1":
+    description: Fix issue causing the extractor to stop pushing datapoints if pushing nodes to CDF during rebrowse fails.
+    changelog:
+      fixed:
+        - Fix issue causing the extractor to stop pushing datapoints if pushing nodes to CDF during rebrowse fails.
   "2.38.0":
     description: Support writing metadata as a JSON structure to Core Data Model Timeseries.
     changelog:


### PR DESCRIPTION
It doesn't really make any sense to go from being initialized to _not_ being initialized, and it causes some really unfortunate issues where datapoints might get backed up.

This would have been problematic a little while ago, but we now gracefully handle nodes that are missing, so creating a subscription before we create the node isn't so terrible, and it's a corner case either way.

This could probably use a better solution in the future, but it gets _really_ complicated if we need to deal with the ingestion status of each node independently.

Also, while creating a test for this, I found that we don't catch errors during `Init`, which we should.